### PR TITLE
feat: Add implement message management and group management features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 # Where I keep my runspace for testing / docker compose
 /runspace
 /reference
+
+# Local development scripts
+backend/start.ps1

--- a/backend/migrations/2026-02-26-000000_add_group_visibility/down.sql
+++ b/backend/migrations/2026-02-26-000000_add_group_visibility/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups DROP COLUMN visibility;

--- a/backend/migrations/2026-02-26-000000_add_group_visibility/up.sql
+++ b/backend/migrations/2026-02-26-000000_add_group_visibility/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups ADD COLUMN visibility VARCHAR(20) NOT NULL DEFAULT 'public';

--- a/backend/src/handlers/chats.rs
+++ b/backend/src/handlers/chats.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{Query, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
     Json,
@@ -223,6 +223,7 @@ pub async fn post_chats(
             description: None,
             avatar: None,
             created_at: now,
+            visibility: "public".to_string(),
         })
         .execute(conn)
         .map_err(|e| {
@@ -234,7 +235,7 @@ pub async fn post_chats(
         .values(&NewGroupMembership {
             chat_id: id,
             uid,
-            role: "member".to_string(),
+            role: "admin".to_string(),
             joined_at: now,
         })
         .execute(conn)
@@ -251,4 +252,170 @@ pub async fn post_chats(
             created_at: now,
         }),
     ))
+}
+
+#[derive(serde::Deserialize)]
+pub struct ChatIdPath {
+    chat_id: i64,
+}
+
+#[derive(Serialize)]
+pub struct ChatDetailResponse {
+    #[serde(with = "crate::serde_i64_string")]
+    id: i64,
+    name: String,
+    description: Option<String>,
+    avatar: Option<String>,
+    visibility: String,
+    created_at: DateTime<Utc>,
+}
+
+/// GET /chats/:chat_id — Get chat details.
+pub async fn get_chat(
+    CurrentUid(uid): CurrentUid,
+    State(state): State<AppState>,
+    Path(ChatIdPath { chat_id }): Path<ChatIdPath>,
+) -> Result<Json<ChatDetailResponse>, (StatusCode, &'static str)> {
+    let conn = &mut state
+        .db
+        .get()
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Database connection failed"))?;
+
+    // Check membership
+    use crate::schema::group_membership::dsl as gm_dsl;
+    let is_member = group_membership::table
+        .filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(uid)))
+        .count()
+        .get_result::<i64>(conn)
+        .map_err(|e| {
+            tracing::error!("check membership: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+        })?;
+
+    if is_member == 0 {
+        return Err((StatusCode::FORBIDDEN, "Not a member of this chat"));
+    }
+
+    // Get group details
+    use crate::schema::groups::dsl as groups_dsl;
+    let group: crate::models::Group = groups::table
+        .filter(groups_dsl::id.eq(chat_id))
+        .first(conn)
+        .map_err(|_| (StatusCode::NOT_FOUND, "Chat not found"))?;
+
+    Ok(Json(ChatDetailResponse {
+        id: group.id,
+        name: group.name,
+        description: group.description,
+        avatar: group.avatar,
+        visibility: group.visibility,
+        created_at: group.created_at,
+    }))
+}
+
+#[derive(serde::Deserialize)]
+pub struct UpdateChatBody {
+    name: Option<String>,
+    description: Option<String>,
+    avatar: Option<String>,
+    visibility: Option<String>,
+}
+
+/// PATCH /chats/:chat_id — Update chat metadata (admin only).
+pub async fn patch_chat(
+    CurrentUid(uid): CurrentUid,
+    State(state): State<AppState>,
+    Path(ChatIdPath { chat_id }): Path<ChatIdPath>,
+    Json(body): Json<UpdateChatBody>,
+) -> Result<Json<ChatDetailResponse>, (StatusCode, &'static str)> {
+    let conn = &mut state
+        .db
+        .get()
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Database connection failed"))?;
+
+    // Check if user is admin
+    use crate::schema::group_membership::dsl as gm_dsl;
+    let role: Option<String> = group_membership::table
+        .filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(uid)))
+        .select(gm_dsl::role)
+        .first(conn)
+        .optional()
+        .map_err(|e| {
+            tracing::error!("check admin role: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+        })?;
+
+    match role {
+        Some(r) if r == "admin" => {},
+        Some(_) => return Err((StatusCode::FORBIDDEN, "Admin role required")),
+        None => return Err((StatusCode::FORBIDDEN, "Not a member of this chat")),
+    }
+
+    // Validate visibility if provided
+    if let Some(ref vis) = body.visibility {
+        if vis != "public" && vis != "private" {
+            return Err((StatusCode::BAD_REQUEST, "Invalid visibility value"));
+        }
+    }
+
+    // Update group
+    use crate::schema::groups::dsl as groups_dsl;
+
+    if body.name.is_some() {
+        diesel::update(groups::table.filter(groups_dsl::id.eq(chat_id)))
+            .set(groups_dsl::name.eq(body.name.as_ref().unwrap()))
+            .execute(conn)
+            .map_err(|e| {
+                tracing::error!("update group name: {:?}", e);
+                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to update chat")
+            })?;
+    }
+
+    if body.description.is_some() {
+        diesel::update(groups::table.filter(groups_dsl::id.eq(chat_id)))
+            .set(groups_dsl::description.eq(&body.description))
+            .execute(conn)
+            .map_err(|e| {
+                tracing::error!("update group description: {:?}", e);
+                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to update chat")
+            })?;
+    }
+
+    if body.avatar.is_some() {
+        diesel::update(groups::table.filter(groups_dsl::id.eq(chat_id)))
+            .set(groups_dsl::avatar.eq(&body.avatar))
+            .execute(conn)
+            .map_err(|e| {
+                tracing::error!("update group avatar: {:?}", e);
+                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to update chat")
+            })?;
+    }
+
+    if body.visibility.is_some() {
+        diesel::update(groups::table.filter(groups_dsl::id.eq(chat_id)))
+            .set(groups_dsl::visibility.eq(body.visibility.as_ref().unwrap()))
+            .execute(conn)
+            .map_err(|e| {
+                tracing::error!("update group visibility: {:?}", e);
+                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to update chat")
+            })?;
+    }
+
+    // Get updated group
+    let group: crate::models::Group = groups::table
+        .filter(groups_dsl::id.eq(chat_id))
+        .first(conn)
+        .map_err(|e| {
+            tracing::error!("get updated group: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to get updated chat")
+        })?;
+
+    Ok(Json(ChatDetailResponse {
+        id: group.id,
+        name: group.name,
+        description: group.description,
+        avatar: group.avatar,
+        visibility: group.visibility,
+        created_at: group.created_at,
+    }))
 }

--- a/backend/src/handlers/members.rs
+++ b/backend/src/handlers/members.rs
@@ -42,6 +42,30 @@ fn check_membership(
     Ok(())
 }
 
+/// Check if user is an admin of the chat; return 403 if not.
+fn check_admin_role(
+    conn: &mut diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>,
+    chat_id: i64,
+    uid: i32,
+) -> Result<(), (StatusCode, &'static str)> {
+    use crate::schema::group_membership::dsl;
+    let role: Option<String> = group_membership::table
+        .filter(dsl::chat_id.eq(chat_id).and(dsl::uid.eq(uid)))
+        .select(dsl::role)
+        .first(conn)
+        .optional()
+        .map_err(|e| {
+            tracing::error!("check admin role: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+        })?;
+
+    match role {
+        Some(r) if r == "admin" => Ok(()),
+        Some(_) => Err((StatusCode::FORBIDDEN, "Admin role required")),
+        None => Err((StatusCode::FORBIDDEN, "Not a member of this chat")),
+    }
+}
+
 /// GET /chats/:chat_id/members — List members of a chat.
 pub async fn get_members(
     CurrentUid(uid): CurrentUid,
@@ -81,4 +105,226 @@ pub async fn get_members(
         .collect();
 
     Ok(Json(members))
+}
+
+#[derive(serde::Deserialize)]
+pub struct AddMemberBody {
+    uid: i32,
+    #[serde(default)]
+    role: Option<String>,
+}
+
+/// POST /chats/:chat_id/members — Add a member to the chat (admin only).
+pub async fn post_member(
+    CurrentUid(requester_uid): CurrentUid,
+    State(state): State<AppState>,
+    Path(ChatIdPath { chat_id }): Path<ChatIdPath>,
+    Json(body): Json<AddMemberBody>,
+) -> Result<(StatusCode, Json<MemberResponse>), (StatusCode, &'static str)> {
+    let conn = &mut state
+        .db
+        .get()
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Database connection failed"))?;
+
+    // Check if requester is admin
+    check_admin_role(conn, chat_id, requester_uid)?;
+
+    // Check if target user exists
+    use crate::schema::users::dsl as users_dsl;
+    let user_exists = users::table
+        .filter(users_dsl::uid.eq(body.uid))
+        .count()
+        .get_result::<i64>(conn)
+        .map_err(|e| {
+            tracing::error!("check user exists: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+        })?;
+
+    if user_exists == 0 {
+        return Err((StatusCode::NOT_FOUND, "User not found"));
+    }
+
+    // Check if already a member
+    use crate::schema::group_membership::dsl as gm_dsl;
+    let already_member = group_membership::table
+        .filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(body.uid)))
+        .count()
+        .get_result::<i64>(conn)
+        .map_err(|e| {
+            tracing::error!("check already member: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+        })?;
+
+    if already_member > 0 {
+        return Err((StatusCode::CONFLICT, "User is already a member"));
+    }
+
+    let role = body.role.unwrap_or_else(|| "member".to_string());
+    if role != "admin" && role != "member" {
+        return Err((StatusCode::BAD_REQUEST, "Invalid role"));
+    }
+
+    let now = chrono::Utc::now();
+    let new_membership = crate::models::NewGroupMembership {
+        chat_id,
+        uid: body.uid,
+        role: role.clone(),
+        joined_at: now,
+    };
+
+    diesel::insert_into(group_membership::table)
+        .values(&new_membership)
+        .execute(conn)
+        .map_err(|e| {
+            tracing::error!("insert membership: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to add member")
+        })?;
+
+    // Get username
+    let username: Option<String> = users::table
+        .filter(users_dsl::uid.eq(body.uid))
+        .select(users_dsl::username)
+        .first(conn)
+        .optional()
+        .map_err(|e| {
+            tracing::error!("get username: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+        })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(MemberResponse {
+            uid: body.uid,
+            role,
+            joined_at: now,
+            username,
+        }),
+    ))
+}
+
+#[derive(serde::Deserialize)]
+pub struct MemberPath {
+    chat_id: i64,
+    uid: i32,
+}
+
+/// DELETE /chats/:chat_id/members/:uid — Remove a member (admin or self).
+pub async fn delete_member(
+    CurrentUid(requester_uid): CurrentUid,
+    State(state): State<AppState>,
+    Path(MemberPath { chat_id, uid: target_uid }): Path<MemberPath>,
+) -> Result<StatusCode, (StatusCode, &'static str)> {
+    let conn = &mut state
+        .db
+        .get()
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Database connection failed"))?;
+
+    // Allow if requester is admin OR removing themselves
+    if requester_uid != target_uid {
+        check_admin_role(conn, chat_id, requester_uid)?;
+    } else {
+        check_membership(conn, chat_id, requester_uid)?;
+    }
+
+    // Check if target is a member
+    use crate::schema::group_membership::dsl as gm_dsl;
+    let is_member = group_membership::table
+        .filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(target_uid)))
+        .count()
+        .get_result::<i64>(conn)
+        .map_err(|e| {
+            tracing::error!("check member exists: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+        })?;
+
+    if is_member == 0 {
+        return Err((StatusCode::NOT_FOUND, "Member not found"));
+    }
+
+    diesel::delete(
+        group_membership::table
+            .filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(target_uid))),
+    )
+    .execute(conn)
+    .map_err(|e| {
+        tracing::error!("delete membership: {:?}", e);
+        (StatusCode::INTERNAL_SERVER_ERROR, "Failed to remove member")
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(serde::Deserialize)]
+pub struct UpdateMemberBody {
+    role: String,
+}
+
+/// PATCH /chats/:chat_id/members/:uid — Update member role (admin only).
+pub async fn patch_member(
+    CurrentUid(requester_uid): CurrentUid,
+    State(state): State<AppState>,
+    Path(MemberPath { chat_id, uid: target_uid }): Path<MemberPath>,
+    Json(body): Json<UpdateMemberBody>,
+) -> Result<Json<MemberResponse>, (StatusCode, &'static str)> {
+    let conn = &mut state
+        .db
+        .get()
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Database connection failed"))?;
+
+    // Check if requester is admin
+    check_admin_role(conn, chat_id, requester_uid)?;
+
+    // Validate role
+    if body.role != "admin" && body.role != "member" {
+        return Err((StatusCode::BAD_REQUEST, "Invalid role"));
+    }
+
+    // Check if target is a member
+    use crate::schema::group_membership::dsl as gm_dsl;
+    let is_member = group_membership::table
+        .filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(target_uid)))
+        .count()
+        .get_result::<i64>(conn)
+        .map_err(|e| {
+            tracing::error!("check member exists: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+        })?;
+
+    if is_member == 0 {
+        return Err((StatusCode::NOT_FOUND, "Member not found"));
+    }
+
+    // Update role
+    diesel::update(
+        group_membership::table
+            .filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(target_uid))),
+    )
+    .set(gm_dsl::role.eq(&body.role))
+    .execute(conn)
+    .map_err(|e| {
+        tracing::error!("update member role: {:?}", e);
+        (StatusCode::INTERNAL_SERVER_ERROR, "Failed to update member role")
+    })?;
+
+    // Get updated member info
+    let (role, joined_at, username): (String, DateTime<Utc>, String) = group_membership::table
+        .filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(target_uid)))
+        .inner_join(users::table)
+        .select((
+            gm_dsl::role,
+            gm_dsl::joined_at,
+            users::username,
+        ))
+        .first(conn)
+        .map_err(|e| {
+            tracing::error!("get updated member: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to get updated member")
+        })?;
+
+    Ok(Json(MemberResponse {
+        uid: target_uid,
+        role,
+        joined_at,
+        username: Some(username),
+    }))
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -92,6 +92,10 @@ async fn main() {
             get(handlers::chats::get_chats).post(handlers::chats::post_chats),
         )
         .route(
+            "/{chat_id}",
+            get(handlers::chats::get_chat).patch(handlers::chats::patch_chat),
+        )
+        .route(
             "/{chat_id}/messages",
             get(handlers::messages::get_messages).post(handlers::messages::post_message),
         )
@@ -99,7 +103,14 @@ async fn main() {
             "/{chat_id}/messages/{message_id}",
             patch(handlers::messages::patch_message).delete(handlers::messages::delete_message),
         )
-        .route("/{chat_id}/members", get(handlers::members::get_members));
+        .route(
+            "/{chat_id}/members",
+            get(handlers::members::get_members).post(handlers::members::post_member),
+        )
+        .route(
+            "/{chat_id}/members/{uid}",
+            delete(handlers::members::delete_member).patch(handlers::members::patch_member),
+        );
 
     let trace_layer = TraceLayer::new_for_http()
         .make_span_with(|request: &Request<Body>| {

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -18,6 +18,7 @@ pub struct Group {
     pub description: Option<String>,
     pub avatar: Option<String>,
     pub created_at: DateTime<Utc>,
+    pub visibility: String,
 }
 
 /// For inserting a group. Set `id` and `created_at` (e.g. `Utc::now()`) when not relying on DB defaults.
@@ -29,6 +30,7 @@ pub struct NewGroup {
     pub description: Option<String>,
     pub avatar: Option<String>,
     pub created_at: DateTime<Utc>,
+    pub visibility: String,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable, Serialize, Insertable)]

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -20,6 +20,7 @@ diesel::table! {
         #[max_length = 20]
         role -> Varchar,
         joined_at -> Timestamptz,
+        last_read_message_id -> Nullable<Int8>,
     }
 }
 
@@ -31,6 +32,8 @@ diesel::table! {
         description -> Nullable<Text>,
         avatar -> Nullable<Text>,
         created_at -> Timestamptz,
+        #[max_length = 20]
+        visibility -> Varchar,
     }
 }
 

--- a/wetty-chat-mobile/src/api/chats.ts
+++ b/wetty-chat-mobile/src/api/chats.ts
@@ -25,3 +25,59 @@ export function getChats(params: { limit?: number; after?: string } = {}): Promi
 export function createChat(body: { name?: string } = {}): Promise<AxiosResponse<CreateChatResponse>> {
   return apiClient.post('/chats', body);
 }
+
+export interface ChatDetailResponse {
+  id: string;
+  name: string;
+  description: string | null;
+  avatar: string | null;
+  visibility: string;
+  created_at: string;
+}
+
+export interface UpdateChatBody {
+  name?: string;
+  description?: string;
+  avatar?: string;
+  visibility?: string;
+}
+
+export function getChatDetails(chatId: string | number): Promise<AxiosResponse<ChatDetailResponse>> {
+  return apiClient.get(`/chats/${chatId}`);
+}
+
+export function updateChat(chatId: string | number, body: UpdateChatBody): Promise<AxiosResponse<ChatDetailResponse>> {
+  return apiClient.patch(`/chats/${chatId}`, body);
+}
+
+export interface MemberResponse {
+  uid: number;
+  role: string;
+  joined_at: string;
+  username: string | null;
+}
+
+export interface AddMemberBody {
+  uid: number;
+  role?: string;
+}
+
+export interface UpdateMemberRoleBody {
+  role: string;
+}
+
+export function getMembers(chatId: string | number): Promise<AxiosResponse<MemberResponse[]>> {
+  return apiClient.get(`/chats/${chatId}/members`);
+}
+
+export function addMember(chatId: string | number, body: AddMemberBody): Promise<AxiosResponse<MemberResponse>> {
+  return apiClient.post(`/chats/${chatId}/members`, body);
+}
+
+export function removeMember(chatId: string | number, uid: number): Promise<AxiosResponse<void>> {
+  return apiClient.delete(`/chats/${chatId}/members/${uid}`);
+}
+
+export function updateMemberRole(chatId: string | number, uid: number, body: UpdateMemberRoleBody): Promise<AxiosResponse<MemberResponse>> {
+  return apiClient.patch(`/chats/${chatId}/members/${uid}`, body);
+}

--- a/wetty-chat-mobile/src/api/messages.ts
+++ b/wetty-chat-mobile/src/api/messages.ts
@@ -1,6 +1,13 @@
 import type { AxiosResponse } from 'axios';
 import apiClient from './client';
 
+export interface ReplyToMessage {
+  id: string;
+  message: string | null;
+  sender_uid: number;
+  deleted_at: string | null;
+}
+
 export interface MessageResponse {
   id: string;
   message: string | null;
@@ -9,11 +16,12 @@ export interface MessageResponse {
   reply_root_id: string | null;
   client_generated_id: string;
   sender_uid: number;
-  gid: string;
+  chat_id: string;
   created_at: string;
   updated_at: string | null;
   deleted_at: string | null;
   has_attachments: boolean;
+  reply_to_message?: ReplyToMessage;
 }
 
 export interface ListMessagesResponse {

--- a/wetty-chat-mobile/src/js/routes.ts
+++ b/wetty-chat-mobile/src/js/routes.ts
@@ -4,6 +4,8 @@ import NotFoundPage from '@/pages/404';
 import ChatsPage from '@/pages/chats';
 import CreateChatPage from '@/pages/create-chat';
 import ChatThreadPage from '@/pages/chat-thread';
+import ChatSettingsPage from '@/pages/chat-settings';
+import ChatMembersPage from '@/pages/chat-members';
 import SettingsPage from '@/pages/settings';
 
 const routes: Router.RouteParameters[] = [
@@ -22,6 +24,14 @@ const routes: Router.RouteParameters[] = [
   {
     path: '/chats/:id/',
     component: ChatThreadPage,
+  },
+  {
+    path: '/chats/:id/settings/',
+    component: ChatSettingsPage,
+  },
+  {
+    path: '/chats/:id/members/',
+    component: ChatMembersPage,
   },
   {
     path: '/settings/',

--- a/wetty-chat-mobile/src/pages/chat-members.tsx
+++ b/wetty-chat-mobile/src/pages/chat-members.tsx
@@ -1,0 +1,174 @@
+import React, { useState, useEffect } from 'react';
+import {
+  f7,
+  Page,
+  Navbar,
+  List,
+  ListItem,
+  Block,
+  Button,
+  Chip,
+} from 'framework7-react';
+import { getMembers, addMember, removeMember, updateMemberRole, type MemberResponse } from '@/api/chats';
+import { getCurrentUserId } from '@/js/current-user';
+
+interface Props {
+  f7route?: {
+    params: Record<string, string>;
+  };
+}
+
+export default function ChatMembersPage({ f7route }: Props) {
+  const { id } = f7route?.params || {};
+  const chatId = id ? String(id) : '';
+  const currentUserId = getCurrentUserId();
+
+  const [members, setMembers] = useState<MemberResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  const loadMembers = () => {
+    if (!chatId) return;
+    setLoading(true);
+    getMembers(chatId)
+      .then((res) => {
+        setMembers(res.data);
+        const currentMember = res.data.find((m) => m.uid === currentUserId);
+        setIsAdmin(currentMember?.role === 'admin');
+      })
+      .catch((err: Error) => {
+        f7.toast.create({ text: err.message || 'Failed to load members', closeTimeout: 3000 }).open();
+      })
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadMembers();
+  }, [chatId]);
+
+  const handleAddMember = () => {
+    f7.dialog.prompt('Enter user ID to add:', (uid: string) => {
+      const userId = parseInt(uid, 10);
+      if (isNaN(userId)) {
+        f7.toast.create({ text: 'Invalid user ID', closeTimeout: 2000 }).open();
+        return;
+      }
+      addMember(chatId, { uid: userId })
+        .then(() => {
+          f7.toast.create({ text: 'Member added', closeTimeout: 2000 }).open();
+          loadMembers();
+        })
+        .catch((err: Error) => {
+          f7.toast.create({ text: err.message || 'Failed to add member', closeTimeout: 3000 }).open();
+        });
+    });
+  };
+
+  const handleRemoveMember = (member: MemberResponse) => {
+    f7.dialog.confirm(
+      `Remove ${member.username || `User ${member.uid}`} from this group?`,
+      () => {
+        removeMember(chatId, member.uid)
+          .then(() => {
+            f7.toast.create({ text: 'Member removed', closeTimeout: 2000 }).open();
+            loadMembers();
+          })
+          .catch((err: Error) => {
+            f7.toast.create({ text: err.message || 'Failed to remove member', closeTimeout: 3000 }).open();
+          });
+      }
+    );
+  };
+
+  const handleToggleRole = (member: MemberResponse) => {
+    const newRole = member.role === 'admin' ? 'member' : 'admin';
+    const action = newRole === 'admin' ? 'Promote' : 'Demote';
+    f7.dialog.confirm(
+      `${action} ${member.username || `User ${member.uid}`} to ${newRole}?`,
+      () => {
+        updateMemberRole(chatId, member.uid, { role: newRole })
+          .then(() => {
+            f7.toast.create({ text: `Member ${action.toLowerCase()}d`, closeTimeout: 2000 }).open();
+            loadMembers();
+          })
+          .catch((err: Error) => {
+            f7.toast.create({ text: err.message || 'Failed to update role', closeTimeout: 3000 }).open();
+          });
+      }
+    );
+  };
+
+  const handleLeaveGroup = () => {
+    f7.dialog.confirm('Are you sure you want to leave this group?', () => {
+      removeMember(chatId, currentUserId)
+        .then(() => {
+          f7.toast.create({ text: 'Left group', closeTimeout: 2000 }).open();
+          f7.views.main.router.navigate('/chats/', { reloadCurrent: true });
+        })
+        .catch((err: Error) => {
+          f7.toast.create({ text: err.message || 'Failed to leave group', closeTimeout: 3000 }).open();
+        });
+    });
+  };
+
+  return (
+    <Page>
+      <Navbar title="Group Members" backLink />
+      {loading ? (
+        <Block>Loading...</Block>
+      ) : (
+        <>
+          {isAdmin && (
+            <Block>
+              <Button fill onClick={handleAddMember}>
+                Add Member
+              </Button>
+            </Block>
+          )}
+          <List>
+            {members.map((member) => (
+              <ListItem
+                key={member.uid}
+                title={member.username || `User ${member.uid}`}
+                after={
+                  <Chip
+                    text={member.role}
+                    color={member.role === 'admin' ? 'blue' : 'gray'}
+                  />
+                }
+                onClick={() => {
+                  if (!isAdmin || member.uid === currentUserId) return;
+                  const buttons = [
+                    [
+                      {
+                        text: member.role === 'admin' ? 'Demote to Member' : 'Promote to Admin',
+                        onClick: () => handleToggleRole(member),
+                      },
+                      {
+                        text: 'Remove from Group',
+                        color: 'red',
+                        onClick: () => handleRemoveMember(member),
+                      },
+                    ],
+                    [
+                      {
+                        text: 'Cancel',
+                        color: 'gray',
+                      },
+                    ],
+                  ];
+                  f7.actions.create({ buttons }).open();
+                }}
+              />
+            ))}
+          </List>
+          <Block>
+            <Button fill color="red" onClick={handleLeaveGroup}>
+              Leave Group
+            </Button>
+          </Block>
+        </>
+      )}
+    </Page>
+  );
+}

--- a/wetty-chat-mobile/src/pages/chat-settings.tsx
+++ b/wetty-chat-mobile/src/pages/chat-settings.tsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect } from 'react';
+import {
+  f7,
+  Page,
+  Navbar,
+  List,
+  ListInput,
+  ListItem,
+  Block,
+  Button,
+} from 'framework7-react';
+import { getChatDetails, updateChat } from '@/api/chats';
+
+interface Props {
+  f7route?: {
+    params: Record<string, string>;
+  };
+}
+
+export default function ChatSettingsPage({ f7route }: Props) {
+  const { id } = f7route?.params || {};
+  const chatId = id ? String(id) : '';
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [avatar, setAvatar] = useState('');
+  const [visibility, setVisibility] = useState<'public' | 'private'>('public');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!chatId) return;
+    setLoading(true);
+    getChatDetails(chatId)
+      .then((res) => {
+        setName(res.data.name || '');
+        setDescription(res.data.description || '');
+        setAvatar(res.data.avatar || '');
+        setVisibility(res.data.visibility as 'public' | 'private');
+      })
+      .catch((err: Error) => {
+        f7.toast.create({ text: err.message || 'Failed to load chat details', closeTimeout: 3000 }).open();
+      })
+      .finally(() => setLoading(false));
+  }, [chatId]);
+
+  const handleSave = () => {
+    if (!chatId) return;
+    setSaving(true);
+    updateChat(chatId, {
+      name: name.trim() || undefined,
+      description: description.trim() || undefined,
+      avatar: avatar.trim() || undefined,
+      visibility,
+    })
+      .then(() => {
+        f7.toast.create({ text: 'Settings saved', closeTimeout: 2000 }).open();
+        f7.views.main.router.back();
+      })
+      .catch((err: Error) => {
+        f7.toast.create({ text: err.message || 'Failed to save settings', closeTimeout: 3000 }).open();
+      })
+      .finally(() => setSaving(false));
+  };
+
+  return (
+    <Page>
+      <Navbar title="Group Settings" backLink />
+      {loading ? (
+        <Block>Loading...</Block>
+      ) : (
+        <>
+          <List>
+            <ListInput
+              label="Group Name"
+              type="text"
+              placeholder="Enter group name"
+              value={name}
+              onInput={(e) => setName((e.target as HTMLInputElement).value)}
+            />
+            <ListInput
+              label="Description"
+              type="textarea"
+              placeholder="Enter group description"
+              value={description}
+              onInput={(e) => setDescription((e.target as HTMLTextAreaElement).value)}
+            />
+            <ListInput
+              label="Avatar URL"
+              type="url"
+              placeholder="Enter avatar URL"
+              value={avatar}
+              onInput={(e) => setAvatar((e.target as HTMLInputElement).value)}
+            />
+            <ListItem
+              title="Visibility"
+              smartSelect
+              smartSelectParams={{ openIn: 'popover' }}
+            >
+              <select
+                name="visibility"
+                value={visibility}
+                onChange={(e) => setVisibility(e.target.value as 'public' | 'private')}
+              >
+                <option value="public">Public</option>
+                <option value="private">Private</option>
+              </select>
+            </ListItem>
+          </List>
+          <Block>
+            <Button fill large disabled={saving} onClick={handleSave}>
+              {saving ? 'Saving...' : 'Save Settings'}
+            </Button>
+          </Block>
+        </>
+      )}
+    </Page>
+  );
+}

--- a/wetty-chat-mobile/src/pages/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread.tsx
@@ -195,11 +195,17 @@ export default function ChatThread({ f7route }: Props) {
       reply_root_id: replyingTo?.reply_root_id ?? replyingTo?.id ?? null,
       client_generated_id: clientGeneratedId,
       sender_uid: getCurrentUserId(),
-      gid: chatId,
+      chat_id: chatId,
       created_at: new Date().toISOString(),
       updated_at: null,
       deleted_at: null,
       has_attachments: false,
+      reply_to_message: replyingTo ? {
+        id: replyingTo.id,
+        message: replyingTo.message,
+        sender_uid: replyingTo.sender_uid,
+        deleted_at: replyingTo.deleted_at,
+      } : undefined,
     };
     dispatch(addMessage({ chatId, message: optimistic }));
     setReplyingTo(null);
@@ -402,7 +408,10 @@ export default function ChatThread({ f7route }: Props) {
       onPageBeforeIn={handlePageBeforeIn}
       onPageAfterIn={handlePageAfterIn}
     >
-      <Navbar className="messages-navbar" title={chatName} backLink backLinkShowText={false} />
+      <Navbar className="messages-navbar" title={chatName} backLink backLinkShowText={false}>
+        <Link slot="right" iconF7="person_2" href={`/chats/${chatId}/members/`} />
+        <Link slot="right" iconF7="gear" href={`/chats/${chatId}/settings/`} />
+      </Navbar>
       {replyingTo && (
         <div className="reply-preview" style={{ padding: '8px 16px', backgroundColor: '#f0f0f0', borderBottom: '1px solid #ddd' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -496,9 +505,34 @@ export default function ChatThread({ f7route }: Props) {
                   className="message-appear-from-bottom"
                   onClick={() => !message.deleted_at && handleMessageAction(message)}
                 >
-                  {message.reply_to_id && (
-                    <div slot="text-header" style={{ fontSize: '12px', color: '#666', fontStyle: 'italic', marginBottom: '4px' }}>
-                      Replying to a message
+                  {message.reply_to_message && (
+                    <div
+                      slot="text-header"
+                      style={{
+                        fontSize: '12px',
+                        color: '#666',
+                        backgroundColor: 'rgba(0,0,0,0.05)',
+                        padding: '4px 8px',
+                        borderRadius: '4px',
+                        marginBottom: '4px',
+                        borderLeft: '3px solid #007aff'
+                      }}
+                    >
+                      <div style={{ fontWeight: 'bold', marginBottom: '2px' }}>
+                        {message.reply_to_message.deleted_at
+                          ? 'Replying to deleted message'
+                          : `Replying to User ${message.reply_to_message.sender_uid}`}
+                      </div>
+                      {!message.reply_to_message.deleted_at && message.reply_to_message.message && (
+                        <div style={{
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          fontStyle: 'italic'
+                        }}>
+                          {message.reply_to_message.message}
+                        </div>
+                      )}
                     </div>
                   )}
                   <span slot="text-footer">


### PR DESCRIPTION
## Overview

This PR implements comprehensive messaging and group management features for the wetty-chat application:
1. **Message Management** - Edit, delete, and reply to messages with permission controls
2. **Group Management** - Complete group metadata and member management with role-based permissions
3. **Message Reply Optimization** - Enhanced reply functionality with complete referenced message content

## Features Implemented

### 1. Message Management

#### Message Edit
- Users can edit their own messages
- Shows "(edited)" indicator when message has been updated
- Tracks `updated_at` timestamp
- Permission check: Only message sender can edit
- Validation: Cannot edit deleted messages
- API endpoint: `PATCH /chats/:chat_id/messages/:message_id`

#### Message Delete
- Soft delete implementation using `deleted_at` timestamp
- Shows "[Deleted]" indicator for deleted messages
- Permission check: Only message sender can delete
- Prevents double deletion
- API endpoint: `DELETE /chats/:chat_id/messages/:message_id`

#### Message Reply
- Thread-based reply system using `reply_to_id` and `reply_root_id`
- Reply context displayed in message bubbles
- Supports nested reply threads
- Frontend UI shows "Replying to..." preview when composing

### 2. Group Management

#### Group Metadata Management
- Add/edit group name, description, avatar, and visibility (public/private)
- New API endpoints:
- `GET /chats/:chat_id` - Get group details
- `PATCH /chats/:chat_id` - Update group settings (admin only)
- New frontend page: `chat-settings.tsx` for group settings UI
- Navigation button in chat thread navbar

#### Member Management
- Role-based permissions system (admin/member)
- Group creator automatically gets admin role
- Admin capabilities:
- Add members to group
- Remove members from group
- Change member roles (promote/demote)
- Self-management: Any user can leave group
- New API endpoints:
- `GET /chats/:chat_id/members` - List group members
- `POST /chats/:chat_id/members` - Add member (admin only)
- `DELETE /chats/:chat_id/members/:uid` - Remove member (admin or self)
- `PATCH /chats/:chat_id/members/:uid` - Change member role (admin only)
- New frontend page: `chat-members.tsx` for member management UI
- Navigation button in chat thread navbar

### 3. Message Reply Optimization

- Enhanced reply functionality to show complete referenced message content
- Added `ReplyToMessage` struct with full message details (id, message, sender_uid, deleted_at)
- Implemented batch fetching of referenced messages for performance optimization
- Updated UI to display reply context with visual styling
- Shows sender, message content, and deletion status of referenced messages
- Handles deleted referenced messages gracefully

## Database Changes

### Schema Updates
- Added `visibility` column to `groups` table (VARCHAR(20), default 'public')
- Added `description` column to `groups` table (TEXT, nullable)
- Added `avatar` column to `groups` table (TEXT, nullable)
- Added `last_read_message_id` column to `group_membership` table (INT8, nullable) - for future unread count feature
- Renamed `gid` to `chat_id`/`id` for consistency across tables
- Existing fields used: `updated_at`, `deleted_at`, `reply_to_id`, `reply_root_id`

### Migrations
- Created migration: `2026-02-26-000000_add_group_visibility`

## Backend Changes

### New Handlers

**handlers/chats.rs:**
- `get_chat` - Get group details with membership check
- `patch_chat` - Update group metadata with admin permission check

**handlers/members.rs:**
- `check_admin_role` - Helper function for admin permission verification
- `get_members` - List all members in a group
- `post_member` - Add member to group (admin only)
- `delete_member` - Remove member from group (admin or self)
- `patch_member` - Change member role (admin only)

**handlers/messages.rs:**
- `patch_message` - Edit message (sender only)
- `delete_message` - Soft delete message (sender only)

### Updated Handlers

**handlers/messages.rs:**
- Added `ReplyToMessage` struct
- Updated `MessageResponse` to include `reply_to_message` field
- Modified `get_messages` to batch fetch referenced messages (performance optimization)
- Modified `post_message` to include reply_to_message in response
- Added `check_membership` helper function

**handlers/chats.rs:**
- Changed creator role from "member" to "admin" in `post_chat`

### Models
- Updated `Group` and `NewGroup` structs to include visibility field
- Updated schema.rs to reflect all database changes

### Routes
```rust
// Message management
.route("/{chat_id}/messages/{message_id}",
  patch(handlers::messages::patch_message)
  .delete(handlers::messages::delete_message))

// Group management
.route("/{chat_id}",
  get(handlers::chats::get_chat)
  .patch(handlers::chats::patch_chat))

// Member management
.route("/{chat_id}/members",
  get(handlers::members::get_members)
  .post(handlers::members::post_member))
.route("/{chat_id}/members/{uid}",
  delete(handlers::member