### PR TITLE
fix: prevent keyboard jump when sending messages on iOS and Android

### DIFF
--- a/wetty-chat-mobile/src/components/app.tsx
+++ b/wetty-chat-mobile/src/components/app.tsx
@@ -44,6 +44,13 @@ const MyApp = () => {
       theme: 'auto', // Automatic theme detection
       // App routes
       routes: routes,
+      // Keyboard handling - minimal intervention
+      input: {
+        scrollIntoViewCentered: false,
+      },
+      touch: {
+        fastClicks: false, // Disable fast clicks for better touch handling
+      },
   };
   const alertLoginData = () => {
     f7.dialog.alert('Username: ' + username + '<br>Password: ' + password, () => {

--- a/wetty-chat-mobile/src/pages/chat-thread.scss
+++ b/wetty-chat-mobile/src/pages/chat-thread.scss
@@ -15,6 +15,23 @@
   }
 }
 
+/* iOS keyboard stability fixes */
+@supports (-webkit-touch-callout: none) {
+  .page.messages-content {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+
+  .messagebar textarea {
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+    will-change: transform;
+  }
+}
+
 .messages-page.chat-thread-page {
   &.page-current .message-appear-from-bottom {
     animation-duration: 0ms; // optional: disable animation when not current
@@ -88,5 +105,40 @@
   .link-disabled {
     pointer-events: none;
     opacity: 0.6;
+  }
+}
+
+/* Prevent iOS keyboard jump when sending messages */
+.ios .messages-page.chat-thread-page .page-content {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Lock input focus to prevent keyboard dismissal */
+.android .messagebar textarea,
+.ios .messagebar textarea {
+  /* Prevent keyboard from dismissing */
+  user-select: none;
+  -webkit-user-select: none;
+  /* Improve tap response */
+  -webkit-tap-highlight-color: transparent;
+  tap-highlight-color: transparent;
+}
+
+/* Prevent form submission that could blur input */
+.messagebar form,
+.messagebar .messagebar-area {
+  pointer-events: none;
+}
+
+.messagebar .messagebar-area textarea,
+.messagebar .messagebar-area .messagebar-send-link {
+  pointer-events: auto;
+}
+
+/* Messagebar container stability */
+.messages-page.chat-thread-page {
+  .toolbar-inner {
+    align-items: center;
   }
 }

--- a/wetty-chat-mobile/src/pages/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread.tsx
@@ -177,11 +177,16 @@ export default function ChatThread({ f7route }: Props) {
       .finally(() => setLoadingMore(false));
   };
 
-  const handleSend = () => {
+  const handleSend = (e?: React.BaseSyntheticEvent) => {
+    e?.preventDefault();
+    e?.stopPropagation();
+
     const text = messageText.trim();
     if (!text || !chatId) return;
+
     const clientGeneratedId = generateClientId();
     setMessageText('');
+
     const optimistic: MessageResponse = {
       id: '0',
       message: text,
@@ -231,10 +236,6 @@ export default function ChatThread({ f7route }: Props) {
         dispatch(setMessagesForChat({ chatId, messages: current }));
         setMessageText(text);
       });
-    setTimeout(() => {
-      const mb = messagebarRef.current?.f7Messagebar?.();
-      if (typeof mb?.focus === 'function') mb.focus();
-    }, 0);
   };
 
   const moveFocusToThisPage = () => {
@@ -311,15 +312,17 @@ export default function ChatThread({ f7route }: Props) {
         placeholder="Message"
         value={messageText}
         onInput={(e) => setMessageText((e.target as HTMLInputElement)?.value ?? '')}
-        onSubmit={handleSend}
       >
         <button
           type="button"
           slot="send-link"
           className={`messagebar-send-link ${messageText.trim().length === 0 ? 'messagebar-send-link--disabled' : ''}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            handleSend();
+          onClick={handleSend}
+          onTouchEnd={(e) => {
+            if (messageText.trim()) {
+              e.preventDefault();
+              handleSend(e);
+            }
           }}
           aria-label="Send message"
         >


### PR DESCRIPTION
## Problem
When clicking the send button in the chat thread, the input method keyboard would briefly jump down and then bounce back up. This occurred on both iOS and Android devices.

## Solution
- Remove all focus/blur operations that triggered keyboard animations
- Add preventDefault on touch events to stop form submission
- Use CSS pointer-events locking to maintain input focus state
- Remove Framework7's scrollIntoViewOnFocus to prevent side effects
- Disable fastClicks for better touch handling

## Testing
- iOS:  **None** ， because I don't have any Apple devices
- Tested on Android: keyboard remains stable, no jump observed
- Focus is maintained after sending, allowing continuous typing
