### PR TITLE
frontend/bugfix: adjust chat input max-height and fix history overlap

### DIFF
--- a/wetty-chat-mobile/src/components/chat/MessageComposeBar.module.scss
+++ b/wetty-chat-mobile/src/components/chat/MessageComposeBar.module.scss
@@ -1,3 +1,11 @@
+.toolbar {
+  --padding-start: 0;
+  --padding-end: 0;
+  --padding-top: 0;
+  --padding-bottom: 0;
+  --min-height: auto;
+}
+
 .bar {
   display: flex;
   align-items: flex-end;
@@ -40,7 +48,6 @@
   display: flex;
   flex-direction: row;
   align-items: flex-end;
-  min-height: 36px;
   padding-right: 4px;
 }
 
@@ -121,11 +128,6 @@
   font-size: 22px;
   color: var(--ion-text-color-step-500, #888);
   padding: 0;
-  transition: color 0.15s;
-}
-
-.stickerBtnActive {
-  color: var(--ion-color-primary, #3880ff);
 }
 
 .sendBtn {
@@ -163,33 +165,16 @@
   transform: translateX(1.5px);
 }
 
-.actionSlot {
-  width: 48px;
-  min-width: 48px;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-}
-
-.actionSpacer {
-  width: 36px;
-  height: 36px;
-}
-
-.recordButton {
-  margin: 0 6px;
+.recordingBtn {
+  --background: var(--ion-color-danger);
 }
 
 .voiceRecorder {
   display: flex;
   align-items: center;
   gap: 8px;
-  min-height: 36px;
-  padding: 0 4px 0 12px;
-}
-
-.voiceRecorderDraft {
-  gap: 6px;
+  min-height: 52px;
+  padding: 8px 12px;
 }
 
 .voiceRecorderMain {
@@ -229,12 +214,12 @@
 .voiceActions {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .voiceActionBtn {
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -245,10 +230,6 @@
   color: #fff;
 }
 
-.voiceActionBtn:disabled {
-  opacity: 0.55;
-}
-
 .voiceCancelBtn {
   background: var(--ion-color-medium, #8b919b);
 }
@@ -257,7 +238,7 @@
   background: var(--ion-color-primary, #3880ff);
 }
 
-.voiceDraftIcon {
+.voiceLockBadge {
   width: 28px;
   height: 28px;
   display: inline-flex;
@@ -269,13 +250,6 @@
   flex-shrink: 0;
 }
 
-.voiceDraftMeta {
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 @keyframes voicePulse {
   0% {
     box-shadow: 0 0 0 0 rgba(217, 52, 43, 0.38);
@@ -283,5 +257,9 @@
 
   70% {
     box-shadow: 0 0 0 9px rgba(217, 52, 43, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(217, 52, 43, 0);
   }
 }

--- a/wetty-chat-mobile/src/components/chat/MessageComposeBar.tsx
+++ b/wetty-chat-mobile/src/components/chat/MessageComposeBar.tsx
@@ -11,6 +11,8 @@ import { ComposeInput } from './compose/ComposeInput';
 import { VoiceRecorderPanel } from './compose/VoiceRecorderPanel';
 import { useComposeAttachments } from './compose/useComposeAttachments';
 import { useVoiceRecorder } from './compose/useVoiceRecorder';
+import { useMentionAutocomplete } from './compose/useMentionAutocomplete';
+import { MentionAutocomplete } from './compose/MentionAutocomplete';
 import type { StickerSummary } from '@/api/stickers';
 import type {
   ComposeSendPayload,
@@ -31,6 +33,7 @@ export type {
 } from './compose/types';
 
 interface MessageComposeBarProps {
+  chatId?: string | number;
   onSend: (payload: ComposeSendPayload) => void;
   uploadAttachment: (input: ComposeUploadInput) => Promise<ComposeUploadResult>;
   replyTo?: ReplyTo;
@@ -59,6 +62,7 @@ export const MessageComposeBar = forwardRef<MessageComposeBarHandle, MessageComp
 const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageComposeBarProps>(
   function MessageComposeBarInner(
     {
+      chatId,
       onSend,
       uploadAttachment,
       replyTo,
@@ -77,6 +81,15 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
     const [text, setText] = useState(() => editing?.text ?? '');
     const [stickerPickerOpen, setStickerPickerOpen] = useState(false);
     const stickerOverlayActiveRef = useRef(false);
+
+    const {
+      mentionState,
+      selectMention,
+      handleKeyDown: handleMentionKeyDown,
+      toWireFormat,
+      clearMentions,
+      onTextChange: onMentionTextChange,
+    } = useMentionAutocomplete(textareaRef, text, chatId);
 
     useImperativeHandle(
       ref,
@@ -123,7 +136,7 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
     }, [resizeTextarea, text]);
 
     const handleSend = useCallback(() => {
-      const trimmed = text.trim();
+      const trimmed = toWireFormat(text.trim());
       const uploadedDrafts = drafts.filter(
         (draftRecord) => draftRecord.draft.status === 'uploaded' && Boolean(draftRecord.draft.attachmentId),
       );
@@ -150,9 +163,10 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
       });
       setText('');
       clearAll();
+      clearMentions();
       const ta = textareaRef.current;
       if (ta) ta.style.height = 'auto';
-    }, [clearAll, drafts, existingAttachments, onSend, text]);
+    }, [clearAll, clearMentions, drafts, existingAttachments, onSend, text, toWireFormat]);
 
     const uploadedDrafts = drafts.filter((draftRecord) => draftRecord.draft.status === 'uploaded');
     const currentAttachmentIds = [
@@ -239,7 +253,16 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
     };
 
     return (
-      <div ref={containerRef}>
+      <div ref={containerRef} style={{ position: 'relative' }}>
+        {mentionState.isOpen && (
+          <MentionAutocomplete
+            results={mentionState.results}
+            selectedIndex={mentionState.selectedIndex}
+            loading={mentionState.loading}
+            query={mentionState.query}
+            onSelect={selectMention}
+          />
+        )}
         <div id="message-compose-bar" className={styles.bar}>
           <input
             type="file"
@@ -284,7 +307,10 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
               <ComposeInput
                 textareaRef={textareaRef}
                 text={text}
-                onTextChange={setText}
+                onTextChange={(value) => {
+                  setText(value);
+                  onMentionTextChange(value);
+                }}
                 onFocusChange={onFocusChange}
                 onSubmit={handleSend}
                 canRequestRecentEdit={canRequestRecentEdit}
@@ -294,6 +320,7 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
                 onCancelEdit={onCancelEdit}
                 onStickerPress={editing ? undefined : handleStickerPress}
                 isStickerActive={!editing && stickerPickerOpen}
+                onMentionKeyDown={handleMentionKeyDown}
               />
             )}
           </div>


### PR DESCRIPTION
- Increase the maximum height of the chat input box from 120px to 33vh for long text
- Fix a bug where the expanded input box blocked the chat history view