### PR TITLE
fronend/refactor: Use `StickerImage` to centralize sticker rendering and .webm support

### DIFF
--- a/wetty-chat-mobile/src/components/chat/StickerPreviewModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/StickerPreviewModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { IonContent, IonIcon, IonModal } from '@ionic/react';
 import { close, addCircleOutline, removeCircleOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
+import { StickerImage } from '@/components/shared/StickerImage';
 import { Trans } from '@lingui/react/macro';
 import {
   getStickerDetail,
@@ -110,12 +111,7 @@ function StickerPreviewModalContent({ stickerId, isDesktop, onDismiss }: Sticker
     return (
       <>
         <div className={styles.heroSection}>
-          {heroUrl &&
-            (heroUrl.toLowerCase().endsWith('.webm') ? (
-              <video src={heroUrl} className={styles.heroMedia} autoPlay loop muted playsInline />
-            ) : (
-              <img src={heroUrl} alt={t`Sticker preview`} className={styles.heroMedia} />
-            ))}
+          {heroUrl && <StickerImage src={heroUrl} alt={t`Sticker preview`} className={styles.heroMedia} />}
           {heroSticker && <span className={styles.heroEmoji}>{heroSticker.emoji}</span>}
         </div>
 
@@ -135,11 +131,7 @@ function StickerPreviewModalContent({ stickerId, isDesktop, onDismiss }: Sticker
               onClick={() => setSelectedStickerId(sticker.id)}
               aria-label={sticker.name || sticker.emoji}
             >
-              {sticker.media.contentType.startsWith('video/') ? (
-                <video src={sticker.media.url} className={styles.gridMedia} autoPlay loop muted playsInline />
-              ) : (
-                <img src={sticker.media.url} alt="" className={styles.gridMedia} />
-              )}
+              <StickerImage src={sticker.media.url} alt="" className={styles.gridMedia} />
             </button>
           ))}
         </div>

--- a/wetty-chat-mobile/src/components/chat/compose/StickerPicker.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/StickerPicker.tsx
@@ -4,6 +4,7 @@ import { IonIcon, useIonAlert, useIonToast } from '@ionic/react';
 import { heart, heartDislike } from 'ionicons/icons';
 import { starOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
+import { StickerImage } from '@/components/shared/StickerImage';
 import { AddStickerModal } from './AddStickerModal';
 import styles from './StickerPicker.module.scss';
 import {
@@ -290,11 +291,7 @@ export function StickerPicker({ isOpen, onStickerSelect, overlayActiveRef }: Sti
           >
             <span className={styles.packIcon} aria-hidden="true">
               {pack.previewUrl ? (
-                pack.previewUrl.toLowerCase().endsWith('.webm') ? (
-                  <video src={pack.previewUrl} className={styles.packIconImg} autoPlay loop muted playsInline />
-                ) : (
-                  <img src={pack.previewUrl} alt="" className={styles.packIconImg} />
-                )
+                <StickerImage src={pack.previewUrl} alt="" className={styles.packIconImg} />
               ) : (
                 <IonIcon icon={starOutline} />
               )}
@@ -404,11 +401,7 @@ function StickerButton({
         fireLongPress();
       }}
     >
-      {sticker.media.contentType.startsWith('video/') ? (
-        <video src={sticker.media.url} className={styles.stickerThumb} autoPlay loop muted playsInline />
-      ) : (
-        <img src={sticker.media.url} alt="" className={styles.stickerThumb} />
-      )}
+      <StickerImage src={sticker.media.url} alt="" className={styles.stickerThumb} />
     </button>
   );
 }

--- a/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties, HTMLAttributes, Ref } from 'react';
 import { IonIcon } from '@ionic/react';
 import { arrowUndo, chatbubbles, checkmarkCircle, checkmarkCircleOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
+import { StickerImage } from '@/components/shared/StickerImage';
 import { useSelector } from 'react-redux';
 import styles from './ChatBubble.module.scss';
 import { formatMessagePreview, type PreviewMessage, getNotificationPreviewLabels } from '@/utils/messagePreview';
@@ -93,26 +94,13 @@ export function StickerBubble({
         </div>
       )}
       <div className={styles.stickerContainer}>
-        {stickerUrl.toLowerCase().endsWith('.webm') ? (
-          <video
-            src={stickerUrl}
-            autoPlay
-            loop
-            muted
-            playsInline
-            className={styles.stickerImage}
-            onClick={interactive && onStickerTap ? onStickerTap : undefined}
-            style={interactive && onStickerTap ? { cursor: 'pointer' } : undefined}
-          />
-        ) : (
-          <img
-            src={stickerUrl}
-            alt={t`Sticker`}
-            className={styles.stickerImage}
-            onClick={interactive && onStickerTap ? onStickerTap : undefined}
-            style={interactive && onStickerTap ? { cursor: 'pointer' } : undefined}
-          />
-        )}
+        <StickerImage
+          src={stickerUrl}
+          alt={t`Sticker`}
+          className={styles.stickerImage}
+          onClick={interactive && onStickerTap ? onStickerTap : undefined}
+          style={interactive && onStickerTap ? { cursor: 'pointer' } : undefined}
+        />
         {timestamp && (
           <span className={styles.stickerTimestamp}>
             {formatTime(timestamp)}

--- a/wetty-chat-mobile/src/components/shared/StickerImage.tsx
+++ b/wetty-chat-mobile/src/components/shared/StickerImage.tsx
@@ -1,0 +1,18 @@
+import type { ImgHTMLAttributes } from 'react';
+
+export interface StickerImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  slot?: string;
+}
+
+export function StickerImage(props: StickerImageProps) {
+  const { src, alt, ...rest } = props;
+  if (!src) return null;
+
+  const isWebm = src.toLowerCase().endsWith('.webm');
+
+  if (isWebm) {
+    return <video src={src} autoPlay loop muted playsInline {...(rest as any)} />;
+  }
+
+  return <img src={src} alt={alt || ''} {...rest} />;
+}

--- a/wetty-chat-mobile/src/pages/settings/sticker-pack-detail.tsx
+++ b/wetty-chat-mobile/src/pages/settings/sticker-pack-detail.tsx
@@ -15,6 +15,7 @@ import {
 import { trashOutline } from 'ionicons/icons';
 import { useParams } from 'react-router-dom';
 import { t } from '@lingui/core/macro';
+import { StickerImage } from '@/components/shared/StickerImage';
 import { Trans } from '@lingui/react/macro';
 import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
@@ -251,11 +252,7 @@ export function StickerPackDetailCore({ packId, backAction }: StickerPackDetailC
               onClick={owned ? () => handleRemoveSticker(sticker) : undefined}
               style={{ cursor: owned ? 'pointer' : 'default' }}
             >
-              {sticker.media.contentType.startsWith('video/') ? (
-                <video src={sticker.media.url} className={styles.preview} autoPlay loop muted playsInline />
-              ) : (
-                <img src={sticker.media.url} alt="" className={styles.preview} />
-              )}
+              <StickerImage src={sticker.media.url} alt="" className={styles.preview} />
               {owned && (
                 <span className={styles.removeHint} aria-hidden="true">
                   ✕

--- a/wetty-chat-mobile/src/pages/settings/stickers.tsx
+++ b/wetty-chat-mobile/src/pages/settings/stickers.tsx
@@ -21,6 +21,7 @@ import { addOutline, cubeOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { BackButton } from '@/components/BackButton';
+import { StickerImage } from '@/components/shared/StickerImage';
 import {
   createStickerPack,
   getOwnedStickerPacks,
@@ -117,7 +118,7 @@ export function StickerSettingsCore({ backAction, onOpenPack }: StickerSettingsC
           {ownedPacks.map((pack) => (
             <IonItem key={pack.id} button detail onClick={() => handleOpenPack(pack.id)}>
               {pack.previewSticker ? (
-                <img
+                <StickerImage
                   slot="start"
                   src={pack.previewSticker.media.url}
                   alt=""
@@ -157,7 +158,7 @@ export function StickerSettingsCore({ backAction, onOpenPack }: StickerSettingsC
             subscribedPacks.map((pack) => (
               <IonItem key={pack.id} button detail onClick={() => handleOpenPack(pack.id)}>
                 {pack.previewSticker ? (
-                  <img
+                  <StickerImage
                     slot="start"
                     src={pack.previewSticker.media.url}
                     alt=""


### PR DESCRIPTION
This PR adds `StickerImage` and uses it everywhere stickers are rendered.

In #158, `.webm` support was added in several places individually. After finding some missed cases, I consolidated the logic into a shared component to make the code more reusable and easier to read.

This PR will also resolve #177.