### PR TITLE
frontend/feature: pin/unpin confirmation dialog

### DIFF
--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -129,14 +129,14 @@ msgid "Are you sure you want to leave this group?"
 msgstr "Are you sure you want to leave this group?"
 
 #: src/pages/chat-thread/chat-thread.tsx
-msgid "Are you sure you want to pin this message?"
-msgstr "Are you sure you want to pin this message?"
+msgid "Pin this message in the group?"
+msgstr "Pin this message in the group?"
 
 #: src/components/chat/PinBanner.tsx
 #: src/components/chat/PinListModal.tsx
 #: src/pages/chat-thread/chat-thread.tsx
-msgid "Are you sure you want to unpin this message?"
-msgstr "Are you sure you want to unpin this message?"
+msgid "Would you like to unpin this message?"
+msgstr "Would you like to unpin this message?"
 
 #: src/pages/settings.tsx
 msgid "Ask first"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -105,14 +105,14 @@ msgid "Are you sure you want to leave this group?"
 msgstr "确定要退出这个群组吗？"
 
 #: src/pages/chat-thread/chat-thread.tsx
-msgid "Are you sure you want to pin this message?"
-msgstr "确定要置顶这条消息吗？"
+msgid "Pin this message in the group?"
+msgstr "确定要置顶此消息吗？"
 
 #: src/components/chat/PinBanner.tsx
 #: src/components/chat/PinListModal.tsx
 #: src/pages/chat-thread/chat-thread.tsx
-msgid "Are you sure you want to unpin this message?"
-msgstr "确定要取消置顶这条消息吗？"
+msgid "Would you like to unpin this message?"
+msgstr "确定要取消置顶此消息吗？"
 
 #: src/pages/settings.tsx
 msgid "Ask first"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -105,14 +105,14 @@ msgid "Are you sure you want to leave this group?"
 msgstr "確定要退出這個群組嗎？"
 
 #: src/pages/chat-thread/chat-thread.tsx
-msgid "Are you sure you want to pin this message?"
-msgstr "確定要釘選這則訊息嗎？"
+msgid "Pin this message in the group?"
+msgstr "確定要釘選此訊息嗎？"
 
 #: src/components/chat/PinBanner.tsx
 #: src/components/chat/PinListModal.tsx
 #: src/pages/chat-thread/chat-thread.tsx
-msgid "Are you sure you want to unpin this message?"
-msgstr "確定要取消釘選這則訊息嗎？"
+msgid "Would you like to unpin this message?"
+msgstr "確定要取消釘選此訊息嗎？"
 
 #: src/pages/settings.tsx
 msgid "Ask first"

--- a/wetty-chat-mobile/src/components/chat/PinBanner.tsx
+++ b/wetty-chat-mobile/src/components/chat/PinBanner.tsx
@@ -30,7 +30,7 @@ export function PinBanner({ chatId, onClickPin, onClickThread, onClickCounter }:
       if (!latestPin) return;
       presentAlert({
         header: t`Unpin Message`,
-        message: t`Are you sure you want to unpin this message?`,
+        message: t`Would you like to unpin this message?`,
         buttons: [
           { text: t`Cancel`, role: 'cancel' },
           {

--- a/wetty-chat-mobile/src/components/chat/PinListModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/PinListModal.tsx
@@ -38,7 +38,7 @@ export function PinListModal({ chatId, isOpen, onDismiss, onSelectPin, onSelectT
       e.stopPropagation();
       presentAlert({
         header: t`Unpin Message`,
-        message: t`Are you sure you want to unpin this message?`,
+        message: t`Would you like to unpin this message?`,
         buttons: [
           { text: t`Cancel`, role: 'cancel' },
           {

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -1393,7 +1393,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
         handler: () => {
           presentAlert({
             header: existingPin ? t`Unpin Message` : t`Pin Message`,
-            message: existingPin ? t`Are you sure you want to unpin this message?` : t`Are you sure you want to pin this message?`,
+            message: existingPin ? t`Would you like to unpin this message?` : t`Pin this message in the group?`,
             buttons: [
               { text: t`Cancel`, role: 'cancel' },
               {


### PR DESCRIPTION
introduces a confirmation dialog before executing pin or unpin actions to prevent accidental clicks.

This confirmation behavior applies consistently, whether the action is triggered from the top banner or directly within the pinned messages list.