### PR TITLE
frontend/feature: Telegram like pin message banner

### DIFF
--- a/wetty-chat-mobile/src/components/chat/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/ChatVirtualScroll.tsx
@@ -180,6 +180,7 @@ export function ChatVirtualScroll({
   bottomPadding = 0,
   onAtBottomChange,
   onLastFullyVisibleMessageChange,
+  onFirstVisibleMessageChange,
 }: ChatVirtualScrollProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -192,6 +193,7 @@ export function ChatVirtualScroll({
   const layoutIntentRef = useRef<LayoutIntent | null>(null);
   const isAtBottomRef = useRef(true);
   const lastFullyVisibleMessageIdRef = useRef<string | null>(null);
+  const firstVisibleMessageIdRef = useRef<string | null>(null);
   const initialAnchorRef = useRef(initialAnchor);
   initialAnchorRef.current = initialAnchor;
 
@@ -440,12 +442,17 @@ export function ChatVirtualScroll({
         lastFullyVisibleMessageIdRef.current = null;
         onLastFullyVisibleMessageChange?.(null);
       }
+      if (firstVisibleMessageIdRef.current !== null) {
+        firstVisibleMessageIdRef.current = null;
+        onFirstVisibleMessageChange?.(null);
+      }
       return;
     }
 
     const containerRect = container.getBoundingClientRect();
     const mounted = mountedRef.current;
     let nextMessageId: string | null = null;
+    let firstMessageId: string | null = null;
 
     if (mounted) {
       for (let index = mounted.end; index >= mounted.start; index -= 1) {
@@ -459,17 +466,29 @@ export function ChatVirtualScroll({
         if (rowRect.height <= 0) continue;
 
         const fullyVisible = rowRect.top >= containerRect.top - 0.5 && rowRect.bottom <= containerRect.bottom + 0.5;
-        if (!fullyVisible) continue;
+        const partiallyVisible = rowRect.bottom > containerRect.top && rowRect.top < containerRect.bottom;
 
-        nextMessageId = row.messageId;
-        break;
+        if (partiallyVisible) {
+          // Since we scan from bottom to top, the last one we see is the first visible from the top
+          firstMessageId = row.messageId;
+        }
+
+        if (fullyVisible && nextMessageId === null) {
+          nextMessageId = row.messageId;
+        }
       }
     }
 
-    if (nextMessageId === lastFullyVisibleMessageIdRef.current) return;
-    lastFullyVisibleMessageIdRef.current = nextMessageId;
-    onLastFullyVisibleMessageChange?.(nextMessageId);
-  }, [onLastFullyVisibleMessageChange, rows]);
+    if (nextMessageId !== lastFullyVisibleMessageIdRef.current) {
+      lastFullyVisibleMessageIdRef.current = nextMessageId;
+      onLastFullyVisibleMessageChange?.(nextMessageId);
+    }
+
+    if (firstMessageId !== firstVisibleMessageIdRef.current) {
+      firstVisibleMessageIdRef.current = firstMessageId;
+      onFirstVisibleMessageChange?.(firstMessageId);
+    }
+  }, [onLastFullyVisibleMessageChange, onFirstVisibleMessageChange, rows]);
 
   const scrollToBottomInternal = useCallback((behavior: ScrollBehavior = 'auto') => {
     const container = containerRef.current;

--- a/wetty-chat-mobile/src/components/chat/PinBanner.tsx
+++ b/wetty-chat-mobile/src/components/chat/PinBanner.tsx
@@ -1,10 +1,10 @@
 import { IonIcon, useIonAlert } from '@ionic/react';
 import { chatbubbles, close, listOutline, pin } from 'ionicons/icons';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { t } from '@lingui/core/macro';
 import type { RootState } from '@/store/index';
-import { selectLatestPin, selectPinsForChat } from '@/store/pinsSlice';
+import { selectPinsForChat } from '@/store/pinsSlice';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { deletePin } from '@/api/pins';
 import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
@@ -12,22 +12,44 @@ import styles from './PinBanner.module.scss';
 
 interface PinBannerProps {
   chatId: string;
+  topVisibleMessageDate?: string | null;
   onClickPin: (messageId: string) => void;
   onClickThread: (messageId: string) => void;
   onClickCounter: () => void;
 }
 
-export function PinBanner({ chatId, onClickPin, onClickThread, onClickCounter }: PinBannerProps) {
+export function PinBanner({
+  chatId,
+  topVisibleMessageDate,
+  onClickPin,
+  onClickThread,
+  onClickCounter,
+}: PinBannerProps) {
   const [presentAlert] = useIonAlert();
-  const latestPin = useSelector((state: RootState) => selectLatestPin(state, chatId));
   const pins = useSelector((state: RootState) => selectPinsForChat(state, chatId));
   const locale = useSelector(selectEffectiveLocale);
+
+  const activePin = useMemo(() => {
+    if (pins.length === 0) return null;
+    if (!topVisibleMessageDate) return pins[0];
+
+    const visibleTime = new Date(topVisibleMessageDate).getTime();
+    // Assuming pins are already sorted descending by message.createdAt in Redux (newest at index 0)
+    for (const p of pins) {
+      // Find the most recent pin that is older than or equal to the current top visible message
+      if (new Date(p.message.createdAt).getTime() <= visibleTime) {
+        return p;
+      }
+    }
+    // If all pins are newer than our current viewport, maybe just show the oldest one
+    return pins[pins.length - 1];
+  }, [pins, topVisibleMessageDate]);
 
   const handleUnpin = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      if (!latestPin) return;
+      if (!activePin) return;
       presentAlert({
         header: t`Unpin Message`,
         message: t`Would you like to unpin this message?`,
@@ -37,23 +59,23 @@ export function PinBanner({ chatId, onClickPin, onClickThread, onClickCounter }:
             text: t`Unpin`,
             role: 'destructive',
             handler: () => {
-              deletePin(chatId, latestPin.id).catch(() => {});
+              deletePin(chatId, activePin.id).catch(() => {});
             },
           },
         ],
       });
     },
-    [chatId, latestPin, presentAlert],
+    [chatId, activePin, presentAlert],
   );
 
   const handleThreadClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (latestPin) {
-        onClickThread(latestPin.message.id);
+      if (activePin) {
+        onClickThread(activePin.message.id);
       }
     },
-    [latestPin, onClickThread],
+    [activePin, onClickThread],
   );
 
   const handleCounterClick = useCallback(
@@ -64,9 +86,9 @@ export function PinBanner({ chatId, onClickPin, onClickThread, onClickCounter }:
     [onClickCounter],
   );
 
-  if (!latestPin) return null;
+  if (!activePin) return null;
 
-  const msg = latestPin.message;
+  const msg = activePin.message;
   const previewText = formatMessagePreview(msg, getNotificationPreviewLabels(locale)) || t`Message`;
 
   return (

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
@@ -87,6 +87,7 @@ export interface ChatVirtualScrollProps {
   bottomPadding?: number;
   onAtBottomChange?: (atBottom: boolean) => void;
   onLastFullyVisibleMessageChange?: (messageId: string | null) => void;
+  onFirstVisibleMessageChange?: (messageId: string | null) => void;
 }
 
 // ── Constants ──

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -242,6 +242,13 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
     initialResumeRequest,
   );
   const [lastFullyVisibleMessageId, setLastFullyVisibleMessageId] = useState<string | null>(null);
+  const [firstVisibleMessageId, setFirstVisibleMessageId] = useState<string | null>(null);
+
+  const topVisibleMessageDate = useMemo(() => {
+    if (!firstVisibleMessageId) return null;
+    const msg = messages.find((m) => m.id === firstVisibleMessageId);
+    return msg?.createdAt ?? null;
+  }, [firstVisibleMessageId, messages]);
 
   const chatRows = useChatRows(messages, formatDateSeparator);
 
@@ -1509,6 +1516,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
         {!threadId && (
           <PinBanner
             chatId={chatId}
+            topVisibleMessageDate={topVisibleMessageDate}
             onClickPin={jumpToMessage}
             onClickThread={(messageId) => history.push(`/chats/chat/${chatId}/thread/${messageId}`)}
             onClickCounter={() => setPinListOpen(true)}
@@ -1526,6 +1534,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
             bottomPadding={16}
             onAtBottomChange={setAtBottom}
             onLastFullyVisibleMessageChange={setLastFullyVisibleMessageId}
+            onFirstVisibleMessageChange={setFirstVisibleMessageId}
           />
           <IonFab
             vertical="bottom"

--- a/wetty-chat-mobile/src/store/pinsSlice.ts
+++ b/wetty-chat-mobile/src/store/pinsSlice.ts
@@ -24,8 +24,11 @@ const pinsSlice = createSlice({
   initialState,
   reducers: {
     setPins(state, action: PayloadAction<{ chatId: string; pins: PinResponse[] }>) {
+      const sortedPins = [...action.payload.pins].sort(
+        (a, b) => new Date(b.message.createdAt).getTime() - new Date(a.message.createdAt).getTime(),
+      );
       state.byChatId[action.payload.chatId] = {
-        pins: action.payload.pins,
+        pins: sortedPins,
         loaded: true,
       };
     },
@@ -35,7 +38,8 @@ const pinsSlice = createSlice({
       if (entry) {
         // Avoid duplicates
         if (!entry.pins.some((p) => p.id === action.payload.id)) {
-          entry.pins.unshift(action.payload);
+          entry.pins.push(action.payload);
+          entry.pins.sort((a, b) => new Date(b.message.createdAt).getTime() - new Date(a.message.createdAt).getTime());
         }
       } else {
         state.byChatId[chatId] = { pins: [action.payload], loaded: true };


### PR DESCRIPTION
Both the pin banner and the pin list are now sorted by the message's original send time, rather than the time they were pinned.

When scrolling up past a pinned message in the chat view, the banner automatically swaps to display an older pinned message if one exists.