### PR TITLE
Display unread count on scroll-to-bottom button

### DIFF
--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -1450,6 +1450,43 @@ async fn mark_as_unread(
     }))
 }
 
+/// GET /chats/:chat_id/unread — Get capped unread count for a single chat.
+#[utoipa::path(
+    get,
+    path = "/unread",
+    tag = "chats",
+    params(
+        ("chat_id" = i64, Path, description = "Chat ID"),
+    ),
+    responses(
+        (status = 200, description = "Capped chat unread count", body = MarkChatReadStateResponse),
+    ),
+    security(("uid_header" = []), ("bearer_jwt" = [])),
+)]
+async fn get_chat_unread_count(
+    CurrentUid(uid): CurrentUid,
+    Path(ChatIdPath { chat_id }): Path<ChatIdPath>,
+    mut conn: DbConn,
+) -> Result<Json<MarkChatReadStateResponse>, AppError> {
+    let conn = &mut *conn;
+
+    check_membership(conn, chat_id, uid)?;
+
+    use crate::schema::group_membership::dsl as gm_dsl;
+    let last_read_message_id: Option<i64> = group_membership::table
+        .filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(uid)))
+        .select(gm_dsl::last_read_message_id)
+        .first(conn)?;
+
+    let unread_count =
+        crate::services::chat::get_chat_unread_count(conn, chat_id, last_read_message_id)?;
+
+    Ok(Json(MarkChatReadStateResponse {
+        last_read_message_id,
+        unread_count,
+    }))
+}
+
 #[derive(Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct UnreadCountResponse {
@@ -1543,6 +1580,7 @@ pub fn router() -> OpenApiRouter<crate::AppState> {
                 )
                 .routes(utoipa_axum::routes!(mark_as_read))
                 .routes(utoipa_axum::routes!(mark_as_unread))
+                .routes(utoipa_axum::routes!(get_chat_unread_count))
                 .routes(utoipa_axum::routes!(self::messages::post_thread_message))
                 .nest(
                     "/threads/{thread_root_id}",

--- a/wetty-chat-mobile/src/api/chats.ts
+++ b/wetty-chat-mobile/src/api/chats.ts
@@ -24,6 +24,11 @@ interface CreateChatResponse {
   createdAt: string;
 }
 
+export interface ChatUnreadCountResponse {
+  lastReadMessageId: string | null;
+  unreadCount: number;
+}
+
 export function getChats(params: { limit?: number; after?: string } = {}): Promise<AxiosResponse<ListChatsResponse>> {
   return apiClient.get('/chats', { params });
 }
@@ -34,4 +39,8 @@ export function createChat(body: { name?: string } = {}): Promise<AxiosResponse<
 
 export function getUnreadCount(): Promise<AxiosResponse<{ unreadCount: number }>> {
   return apiClient.get('/chats/unread');
+}
+
+export function getChatUnreadCount(chatId: string | number): Promise<AxiosResponse<ChatUnreadCountResponse>> {
+  return apiClient.get(`/chats/${chatId}/unread`);
 }

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.scss
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.scss
@@ -20,13 +20,56 @@
 /* Scroll-to-bottom FAB */
 .scroll-to-bottom-fab {
   opacity: 1;
+  overflow: visible;
   transition: opacity 0.2s ease;
   margin-right: 16px;
+
+  ion-fab-button {
+    width: 48px;
+    height: 48px;
+    --background: #fff;
+    --background-activated: var(--ion-color-light-shade, #d7d8da);
+    --background-hover: var(--ion-color-light, #f4f5f8);
+    --box-shadow: 0 3px 10px rgba(0, 0, 0, 0.18);
+    --color: var(--ion-color-medium, #92949c);
+    transition: transform 120ms ease;
+
+    &::part(native) {
+      transition: transform 120ms ease;
+    }
+
+    &:active::part(native) {
+      transform: scale(0.94);
+    }
+  }
 
   &--hidden {
     opacity: 0;
     pointer-events: none;
   }
+}
+
+.scroll-to-bottom-fab__badge {
+  position: absolute;
+  top: -5px;
+  left: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform: translateX(-50%);
+  z-index: 2;
+  min-width: 24px;
+  height: 22px;
+  padding: 0 7px;
+  border-radius: 999px;
+  background: var(--ion-color-primary, #3880ff);
+  color: var(--ion-color-primary-contrast, #fff);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.24);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  pointer-events: none;
+  text-align: center;
 }
 
 .messages-scroll-container {

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -46,10 +46,12 @@ import {
   sendThreadMessage,
   updateMessage,
 } from '@/api/messages';
+import { getChatUnreadCount } from '@/api/chats';
 import {
   selectChatLastReadMessageId,
   selectChatMeta,
   selectChatName,
+  selectChatUnreadCount,
   selectIsChatMuted,
   setChatLastReadMessageId,
   setChatMeta,
@@ -209,6 +211,9 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
   const storedName = useSelector((state: RootState) => selectChatName(state, chatId));
   const isMuted = useSelector((state: RootState) => selectIsChatMuted(state, chatId));
   const lastReadMessageId = useSelector((state: RootState) => selectChatLastReadMessageId(state, chatId));
+  const scrollToBottomUnreadCount = useSelector((state: RootState) =>
+    threadId ? 0 : selectChatUnreadCount(state, chatId),
+  );
   const pinnedReactions = useSelector(selectPinnedReactions);
   const recentReactions = useSelector(selectRecentReactions);
   const QUICK_REACTION_EMOJIS = useMemo(() => {
@@ -218,6 +223,23 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
     );
   }, [pinnedReactions, recentReactions]);
   const chatName = threadId ? t`Thread` : (storedName ?? t`Loading...`);
+
+  useEffect(() => {
+    if (threadId || !chatId) return;
+
+    let canceled = false;
+    getChatUnreadCount(chatId)
+      .then((res) => {
+        if (canceled) return;
+        dispatch(setChatLastReadMessageId({ chatId, lastReadMessageId: res.data.lastReadMessageId }));
+        dispatch(setChatUnreadCount({ chatId, unreadCount: res.data.unreadCount }));
+      })
+      .catch(() => {});
+
+    return () => {
+      canceled = true;
+    };
+  }, [chatId, dispatch, threadId]);
 
   useEffect(() => {
     if (!chatId || hasLoadedThreadChatMeta(cachedMeta)) return;
@@ -531,6 +553,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
 
   useEffect(() => {
     if (threadId || !chatId) return;
+    if (initialResumeMessageId == null && lastReadMessageId == null && atBottom) return;
 
     if (readRequestTimerRef.current) {
       clearTimeout(readRequestTimerRef.current);
@@ -566,7 +589,15 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
         readRequestTimerRef.current = null;
       }
     };
-  }, [chatId, flushPendingReadTarget, lastFullyVisibleMessageId, lastReadMessageId, threadId]);
+  }, [
+    atBottom,
+    chatId,
+    flushPendingReadTarget,
+    initialResumeMessageId,
+    lastFullyVisibleMessageId,
+    lastReadMessageId,
+    threadId,
+  ]);
 
   // Thread-specific mark-as-read: fires when viewing a thread and messages become visible.
   // Unlike chat read tracking (which is purely scroll-based), this also fires on mount
@@ -1687,6 +1718,11 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
             horizontal="end"
             className={`scroll-to-bottom-fab ${atBottom ? 'scroll-to-bottom-fab--hidden' : ''}`}
           >
+            {scrollToBottomUnreadCount > 0 && (
+              <span className="scroll-to-bottom-fab__badge">
+                {scrollToBottomUnreadCount > 99 ? '99+' : scrollToBottomUnreadCount}
+              </span>
+            )}
             <IonFabButton
               size="small"
               onClick={() => {

--- a/wetty-chat-mobile/src/store/chatsSlice.ts
+++ b/wetty-chat-mobile/src/store/chatsSlice.ts
@@ -85,10 +85,14 @@ function getEffectiveListMeta(entry?: ChatStateEntry): ChatListMeta {
   };
 }
 
-function reconcileAuthoritativeListFields(entry: ChatStateEntry): void {
+function reconcileAuthoritativeListFields(entry: ChatStateEntry, snapshotUnreadCount: number): void {
   if (!entry.liveProjection) return;
 
-  delete entry.liveProjection.unreadCount;
+  const liveUnreadCount = entry.liveProjection.unreadCount;
+  // Chat list counts are capped at 100 for badge queries; keep exact per-chat counts while they are fresher.
+  if (liveUnreadCount == null || snapshotUnreadCount < 100 || liveUnreadCount <= snapshotUnreadCount) {
+    delete entry.liveProjection.unreadCount;
+  }
   delete entry.liveProjection.lastReadMessageId;
 }
 
@@ -122,7 +126,7 @@ const chatsSlice = createSlice({
           inList: true,
           mutedUntil: chat.mutedUntil,
         };
-        reconcileAuthoritativeListFields(entry);
+        reconcileAuthoritativeListFields(entry, chat.unreadCount);
       }
     },
     setChatMutedUntil(state, action: PayloadAction<{ chatId: string; mutedUntil: string | null }>) {


### PR DESCRIPTION
## Summary
- Add a per-chat unread count endpoint backed by the existing capped unread-count query.
- Fetch and refresh unread counts while the chat thread is open.
- Display the unread message count badge on the scroll-to-bottom button, using 99+ for large counts, and keep chat list unread state in sync.

Closes #171

## Tests
- cargo check
- npm run verify