### PR TITLE
frontend/feature: add video preview component

### DIFF
--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -201,6 +201,40 @@
   }
 }
 
+.mediaRemaining {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  background: rgba(0, 0, 0, 0.45);
+  border-radius: 10px;
+  padding: 2px 6px;
+  color: #fff;
+  font-size: 11px;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  pointer-events: none;
+}
+
+.videoPlayButton {
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.92);
+  background: rgba(0, 0, 0, 0.18);
+  font-size: 34px;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.remainingMuteIcon {
+  font-size: 12px;
+  opacity: 0.95;
+}
+
 .attachmentImageButton {
   display: block;
   width: fit-content;

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -25,6 +25,7 @@ import { InviteLinkInline } from './InviteLinkInline';
 import { PermalinkInline } from './PermalinkInline';
 import { SingleMediaAttachment } from './media/SingleMediaAttachment';
 import { JustifiedMediaGallery } from './media/JustifiedMediaGallery';
+import { VideoPreview } from './media/VideoPreview';
 import {
   parseChatBubbleContentToRichItems,
   getMessageLayoutStats,
@@ -310,17 +311,17 @@ export function ChatBubbleBase({
     });
   }
 
+  const isOnlyAttachment = attachments?.length === 1;
+
   const renderMediaItem = (att: Attachment, style?: CSSProperties) => {
     if (att.kind.startsWith('video/')) {
       return (
-        <video
-          autoPlay
-          loop
-          muted
-          playsInline
+        <VideoPreview
           src={att.url}
           style={style}
-          onLoadedMetadata={(e) => logAttachmentLoad('video', att, e.currentTarget)}
+          autoPlay={isOnlyAttachment}
+          showPlayButton={!isOnlyAttachment}
+          onLoaded={(el) => logAttachmentLoad('video', att, el)}
         />
       );
     }
@@ -386,17 +387,13 @@ export function ChatBubbleBase({
       };
 
       const video = (
-        <video
-          autoPlay
-          loop
-          muted
-          playsInline
+        <VideoPreview
           src={att.url}
           className={styles.attachmentImage}
           style={imageLayoutStyle ? undefined : { maxHeight: maxImageHeight }}
-          onLoadedMetadata={(event) => {
-            logAttachmentLoad('video', att, event.currentTarget);
-          }}
+          autoPlay={isOnlyAttachment}
+          showPlayButton={!isOnlyAttachment}
+          onLoaded={(el) => logAttachmentLoad('video', att, el)}
         />
       );
 

--- a/wetty-chat-mobile/src/components/chat/messages/media/VideoPreview.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/media/VideoPreview.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react';
+import { IonIcon } from '@ionic/react';
+import { play, volumeMute } from 'ionicons/icons';
+import styles from '../ChatBubble.module.scss';
+import type { CSSProperties } from 'react';
+
+interface VideoPreviewProps {
+  src: string;
+  className?: string;
+  style?: CSSProperties;
+  onLoaded?: (el: HTMLVideoElement) => void;
+  autoPlay?: boolean;
+  showPlayButton?: boolean;
+}
+
+export function VideoPreview({
+  src,
+  className,
+  style,
+  onLoaded,
+  autoPlay = true,
+  showPlayButton = false,
+}: VideoPreviewProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [remaining, setRemaining] = useState<number | null>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const updateRemaining = () => {
+      const dur = video.duration;
+      const currentTime = video.currentTime;
+      if (!isFinite(dur) || dur <= 0 || !Number.isFinite(currentTime) || currentTime < 0) {
+        setRemaining(null);
+        return;
+      }
+      const rem = Math.max(0, Math.ceil(dur - currentTime));
+      setRemaining(rem);
+    };
+
+    const onLoadedMeta = () => {
+      onLoaded?.(video);
+      updateRemaining();
+    };
+
+    video.addEventListener('loadedmetadata', onLoadedMeta);
+    video.addEventListener('timeupdate', updateRemaining);
+
+    updateRemaining();
+
+    return () => {
+      video.removeEventListener('loadedmetadata', onLoadedMeta);
+      video.removeEventListener('timeupdate', updateRemaining);
+    };
+  }, [src, onLoaded]);
+
+  function formatRemaining(rem: number | null) {
+    if (rem == null || Number.isNaN(rem)) return '';
+    const minutes = Math.floor(rem / 60);
+    const seconds = rem % 60;
+    return `${minutes}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  const showRemaining = autoPlay && remaining != null;
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%', ...style }}>
+      <video
+        ref={videoRef}
+        autoPlay={autoPlay}
+        loop={autoPlay}
+        muted
+        playsInline
+        src={src}
+        className={className}
+        style={{ width: '100%', height: '100%' }}
+      />
+      {showPlayButton && (
+        <span className={styles.videoPlayButton} aria-hidden>
+          <IonIcon icon={play} />
+        </span>
+      )}
+      {showRemaining && (
+        <span className={styles.mediaRemaining} aria-hidden>
+          <span>{formatRemaining(remaining)}</span>
+          <IonIcon icon={volumeMute} className={styles.remainingMuteIcon} />
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Single video attachments: Autoplay on mute by default. A mute icon and the remaining playback time are now displayed in the top-left corner.
- Multiple attachments: Videos sent alongside other attachments do not autoplay. A play icon is now centered on the video thumbnail to indicate playability.

