### PR TITLE
Better date separator

### DIFF
--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.module.scss
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.module.scss
@@ -31,6 +31,10 @@
   transition: background-color 100ms ease-out;
 }
 
+.dateRowContentHidden {
+  visibility: hidden;
+}
+
 .spacer {
   width: 100%;
 }

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -39,6 +39,9 @@ import {
 import styles from './ChatVirtualScroll.module.scss';
 import { Trans } from '@lingui/react/macro';
 
+const TOP_DATE_FLOATING_GAP_PX = 12;
+const USER_SCROLL_ACTIVITY_GRACE_MS = 1200;
+
 function arraysEqual(a: string[], b: string[]): boolean {
   return a.length === b.length && a.every((value, index) => value === b[index]);
 }
@@ -200,10 +203,13 @@ export function ChatVirtualScroll({
   loadOlder,
   loadNewer,
   header,
+  topOverlay,
   bottomPadding = 0,
   onAtBottomChange,
   onLastFullyVisibleMessageChange,
   onFirstVisibleMessageChange,
+  onScrollActivityChange,
+  onTopDateOffsetChange,
 }: ChatVirtualScrollProps) {
   const chatFontSizeStyle = useSelector(selectChatFontSizeStyle);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -213,6 +219,8 @@ export function ChatVirtualScroll({
   const treeRef = useRef(new FenwickTree(0));
   const treeKeysRef = useRef<string[]>([]);
   const mountedRef = useRef<MountedWindow | null>(null);
+  const scrollingRef = useRef(false);
+  const topDateOffsetRef = useRef(0);
 
   const lastFontSizeRef = useRef(chatFontSizeStyle);
   if (lastFontSizeRef.current !== chatFontSizeStyle) {
@@ -266,6 +274,7 @@ export function ChatVirtualScroll({
     to: number;
     behavior?: ScrollBehavior;
   } | null>(null);
+  const userScrollIntentUntilRef = useRef(0);
   const recentScrollPositionsRef = useRef<Array<{ top: number; at: number }>>([]);
   const lastJitterLogAtRef = useRef(0);
   const topLoadArmedRef = useRef(true);
@@ -292,6 +301,7 @@ export function ChatVirtualScroll({
   const [containerHeight, setContainerHeight] = useState(0);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [highlightedRowKey, setHighlightedRowKey] = useState<string | null>(null);
+  const [hiddenDateRowKey, setHiddenDateRowKey] = useState<string | null>(null);
   const [renderTick, setRenderTick] = useState(0);
   const triggerRender = useCallback(() => setRenderTick((value) => value + 1), []);
 
@@ -467,9 +477,31 @@ export function ChatVirtualScroll({
     }
   }, [loadNewer?.hasMore, onAtBottomChange]);
 
+  const setScrollActivity = useCallback(
+    (scrolling: boolean) => {
+      if (scrollingRef.current === scrolling) return;
+      scrollingRef.current = scrolling;
+      onScrollActivityChange?.(scrolling);
+      if (!scrolling) {
+        setHiddenDateRowKey(null);
+        topDateOffsetRef.current = 0;
+        onTopDateOffsetChange?.(0);
+      }
+    },
+    [onScrollActivityChange, onTopDateOffsetChange],
+  );
+
+  const markUserScrollIntent = useCallback(() => {
+    userScrollIntentUntilRef.current = performance.now() + USER_SCROLL_ACTIVITY_GRACE_MS;
+  }, []);
+
   const updateLastFullyVisibleMessage = useCallback(() => {
     const container = containerRef.current;
     if (!container || container.clientHeight === 0 || phaseRef.current !== 'READY') {
+      if (topDateOffsetRef.current !== 0) {
+        topDateOffsetRef.current = 0;
+        onTopDateOffsetChange?.(0);
+      }
       if (lastFullyVisibleMessageIdRef.current !== null) {
         lastFullyVisibleMessageIdRef.current = null;
         onLastFullyVisibleMessageChange?.(null);
@@ -485,6 +517,7 @@ export function ChatVirtualScroll({
     const mounted = mountedRef.current;
     let nextMessageId: string | null = null;
     let firstMessageId: string | null = null;
+    let firstMessageIndex: number | null = null;
 
     if (mounted) {
       for (let index = mounted.end; index >= mounted.start; index -= 1) {
@@ -503,12 +536,49 @@ export function ChatVirtualScroll({
         if (partiallyVisible) {
           // Since we scan from bottom to top, the last one we see is the first visible from the top
           firstMessageId = row.messageId;
+          firstMessageIndex = index;
         }
 
         if (fullyVisible && nextMessageId === null) {
           nextMessageId = row.messageId;
         }
       }
+    }
+
+    let nextTopDateOffset = 0;
+    let nextHiddenDateRowKey: string | null = null;
+    if (scrollingRef.current && firstMessageIndex != null) {
+      for (let index = firstMessageIndex; index >= 0; index -= 1) {
+        const row = rows[index];
+        if (row?.type !== 'date') continue;
+        nextHiddenDateRowKey = row.key;
+        break;
+      }
+
+      for (let index = firstMessageIndex + 1; index < rows.length; index += 1) {
+        const row = rows[index];
+        if (row?.type !== 'date') continue;
+
+        const rowNode = rowRefsMap.current.get(row.key);
+        if (!rowNode) break;
+
+        const rowRect = rowNode.getBoundingClientRect();
+        if (rowRect.height <= 0) break;
+
+        const distanceFromTop = rowRect.top - containerRect.top;
+        const collisionThreshold = TOP_DATE_FLOATING_GAP_PX + rowRect.height;
+        if (distanceFromTop > 0 && distanceFromTop < collisionThreshold) {
+          nextTopDateOffset = Math.round(distanceFromTop - collisionThreshold);
+        }
+        break;
+      }
+    }
+
+    setHiddenDateRowKey((current) => (current === nextHiddenDateRowKey ? current : nextHiddenDateRowKey));
+
+    if (nextTopDateOffset !== topDateOffsetRef.current) {
+      topDateOffsetRef.current = nextTopDateOffset;
+      onTopDateOffsetChange?.(nextTopDateOffset);
     }
 
     if (nextMessageId !== lastFullyVisibleMessageIdRef.current) {
@@ -520,7 +590,7 @@ export function ChatVirtualScroll({
       firstVisibleMessageIdRef.current = firstMessageId;
       onFirstVisibleMessageChange?.(firstMessageId);
     }
-  }, [onLastFullyVisibleMessageChange, onFirstVisibleMessageChange, rows]);
+  }, [onLastFullyVisibleMessageChange, onFirstVisibleMessageChange, onTopDateOffsetChange, rows]);
 
   const scrollToBottomInternal = useCallback((behavior: ScrollBehavior = 'auto') => {
     const container = containerRef.current;
@@ -1178,6 +1248,7 @@ export function ChatVirtualScroll({
 
   const handleScrollIdle = useCallback(() => {
     maybeUpdateMountedForScroll();
+    setScrollActivity(false);
 
     const distances = scrollDistances();
     if (!distances) return;
@@ -1240,6 +1311,7 @@ export function ChatVirtualScroll({
     maybeUpdateMountedForScroll,
     pendingBatch,
     scrollDistances,
+    setScrollActivity,
     updateLastFullyVisibleMessage,
   ]);
 
@@ -1286,6 +1358,9 @@ export function ChatVirtualScroll({
       }
     }
 
+    const isUserInitiatedScroll = performance.now() <= userScrollIntentUntilRef.current;
+    setScrollActivity(isUserInitiatedScroll);
+
     if (scrollRafRef.current == null) {
       scrollRafRef.current = requestAnimationFrame(() => {
         scrollRafRef.current = null;
@@ -1313,6 +1388,7 @@ export function ChatVirtualScroll({
     maybeUpdateMountedForScroll,
     pendingBatch,
     scrollDistances,
+    setScrollActivity,
     updateAtBottom,
     updateLastFullyVisibleMessage,
   ]);
@@ -2172,12 +2248,13 @@ export function ChatVirtualScroll({
 
   useEffect(() => {
     return () => {
+      setScrollActivity(false);
       if (scrollIdleTimerRef.current) clearTimeout(scrollIdleTimerRef.current);
       if (scrollRafRef.current != null) cancelAnimationFrame(scrollRafRef.current);
       if (bottomSettleRafRef.current != null) cancelAnimationFrame(bottomSettleRafRef.current);
       if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
     };
-  }, []);
+  }, [setScrollActivity]);
 
   const adjustPrevKeysRef = useRef<string[]>([]);
   if (rowKeys !== adjustPrevKeysRef.current) {
@@ -2282,9 +2359,13 @@ export function ChatVirtualScroll({
       mountedRows.push(
         <MeasuredRow key={row.key} rowKey={row.key} onMeasure={handleMountedMeasure} registerRow={registerRow}>
           <div
-            className={
-              row.key === highlightedRowKey ? `${styles.rowContent} ${styles.rowContentHighlighted}` : styles.rowContent
-            }
+            className={[
+              styles.rowContent,
+              row.key === highlightedRowKey ? styles.rowContentHighlighted : null,
+              row.key === hiddenDateRowKey ? styles.dateRowContentHidden : null,
+            ]
+              .filter(Boolean)
+              .join(' ')}
           >
             {renderRow(row)}
           </div>
@@ -2322,7 +2403,18 @@ export function ChatVirtualScroll({
   const contentPaddingBottom = bottomPadding + (showBottomEdgeHint ? EDGE_HINT_HEIGHT : 0);
 
   return (
-    <div ref={containerRef} className={styles.container} onScroll={handleScroll}>
+    <div
+      ref={containerRef}
+      className={styles.container}
+      onScroll={handleScroll}
+      onWheel={markUserScrollIntent}
+      onTouchStart={markUserScrollIntent}
+      onTouchMove={markUserScrollIntent}
+      onPointerDown={markUserScrollIntent}
+      onPointerMove={markUserScrollIntent}
+      onKeyDown={markUserScrollIntent}
+    >
+      {topOverlay}
       <div
         className={styles.flowContent}
         style={{ paddingTop: contentPaddingTop, paddingBottom: contentPaddingBottom }}

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
@@ -84,10 +84,13 @@ export interface ChatVirtualScrollProps {
   loadOlder: LoadController;
   loadNewer?: LoadController;
   header?: ReactNode;
+  topOverlay?: ReactNode;
   bottomPadding?: number;
   onAtBottomChange?: (atBottom: boolean) => void;
   onLastFullyVisibleMessageChange?: (messageId: string | null) => void;
   onFirstVisibleMessageChange?: (messageId: string | null) => void;
+  onScrollActivityChange?: (scrolling: boolean) => void;
+  onTopDateOffsetChange?: (offset: number) => void;
 }
 
 // ── Constants ──

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.scss
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.scss
@@ -17,6 +17,28 @@
   flex-shrink: 0;
 }
 
+.chat-thread-floating-date {
+  position: sticky;
+  top: 12px;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  height: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  pointer-events: none;
+}
+
+.chat-thread-floating-date__label {
+  background-color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.08);
+  color: var(--ion-color-medium, #555);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 4px 12px;
+  border-radius: 12px;
+}
+
 /* Scroll-to-bottom FAB */
 .scroll-to-bottom-fab {
   opacity: 1;

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -120,7 +120,12 @@ import { listPins, createPin, deletePin } from '@/api/pins';
 import { setPins, selectPinsForChat, selectPinsLoaded } from '@/store/pinsSlice';
 import { PinBanner } from '@/components/chat/pins/PinBanner';
 import { PinListModal } from '@/components/chat/pins/PinListModal';
-import { selectPinnedReactions, selectRecentReactions, addRecentReaction } from '@/store/settingsSlice';
+import {
+  selectEffectiveLocale,
+  selectPinnedReactions,
+  selectRecentReactions,
+  addRecentReaction,
+} from '@/store/settingsSlice';
 import { MAX_REACTIONS_PER_USER_PER_MESSAGE } from '@/constants/emojiAndStickers';
 
 function generateClientId(): string {
@@ -214,6 +219,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
   const scrollToBottomUnreadCount = useSelector((state: RootState) =>
     threadId ? 0 : selectChatUnreadCount(state, chatId),
   );
+  const locale = useSelector(selectEffectiveLocale);
   const pinnedReactions = useSelector(selectPinnedReactions);
   const recentReactions = useSelector(selectRecentReactions);
   const QUICK_REACTION_EMOJIS = useMemo(() => {
@@ -255,26 +261,29 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
   const messages = useSelector((state: RootState) => selectMessagesForChat(state, storeChatId));
   const messageLookup = useMemo(() => new Map(messages.map((message) => [message.id, message])), [messages]);
 
-  const formatDateSeparator = useCallback((iso: string) => {
-    if (!iso) return '';
-    const date = new Date(iso);
-    const now = new Date();
+  const formatDateSeparator = useCallback(
+    (iso: string) => {
+      if (!iso) return '';
+      const date = new Date(iso);
+      const now = new Date();
 
-    const isSameDay = (d1: Date, d2: Date) =>
-      d1.getFullYear() === d2.getFullYear() && d1.getMonth() === d2.getMonth() && d1.getDate() === d2.getDate();
+      const isSameDay = (d1: Date, d2: Date) =>
+        d1.getFullYear() === d2.getFullYear() && d1.getMonth() === d2.getMonth() && d1.getDate() === d2.getDate();
 
-    if (isSameDay(date, now)) return t`Today`;
+      if (isSameDay(date, now)) return t`Today`;
 
-    const yesterday = new Date(now);
-    yesterday.setDate(now.getDate() - 1);
-    if (isSameDay(date, yesterday)) return t`Yesterday`;
+      const yesterday = new Date(now);
+      yesterday.setDate(now.getDate() - 1);
+      if (isSameDay(date, yesterday)) return t`Yesterday`;
 
-    return date.toLocaleDateString(undefined, {
-      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-      month: 'short',
-      day: 'numeric',
-    });
-  }, []);
+      return date.toLocaleDateString(locale, {
+        year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+        month: 'short',
+        day: 'numeric',
+      });
+    },
+    [locale],
+  );
 
   const scrollApiRef = useRef<VirtualScrollHandle | null>(null);
   const composeBarRef = useRef<MessageComposeBarHandle | null>(null);
@@ -286,12 +295,19 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
   const [pendingResumeMessageId, setPendingResumeMessageId] = useState<string | null>(initialResumeMessageId);
   const [lastFullyVisibleMessageId, setLastFullyVisibleMessageId] = useState<string | null>(null);
   const [firstVisibleMessageId, setFirstVisibleMessageId] = useState<string | null>(null);
+  const [messageListScrolling, setMessageListScrolling] = useState(false);
+  const [floatingDateOffset, setFloatingDateOffset] = useState(0);
 
   const topVisibleMessageDate = useMemo(() => {
     if (!firstVisibleMessageId) return null;
     const msg = messages.find((m) => m.id === firstVisibleMessageId);
     return msg?.createdAt ?? null;
   }, [firstVisibleMessageId, messages]);
+  const floatingDateLabel = useMemo(() => {
+    if (!messageListScrolling || !topVisibleMessageDate) return null;
+    return formatDateSeparator(topVisibleMessageDate);
+  }, [formatDateSeparator, messageListScrolling, topVisibleMessageDate]);
+  const floatingDateStyle = useMemo(() => ({ transform: `translateY(${floatingDateOffset}px)` }), [floatingDateOffset]);
 
   const chatRows = useChatRows(messages, formatDateSeparator);
 
@@ -1705,6 +1721,13 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
             rows={chatRows}
             renderRow={renderRow}
             initialAnchor={initialAnchor}
+            topOverlay={
+              floatingDateLabel ? (
+                <div className="chat-thread-floating-date" style={floatingDateStyle}>
+                  <span className="chat-thread-floating-date__label">{floatingDateLabel}</span>
+                </div>
+              ) : null
+            }
             loadOlder={{ hasMore: nextCursor != null, loading: loadingMore, onLoad: loadMore }}
             loadNewer={prevCursor != null ? { hasMore: true, loading: loadingNewer, onLoad: loadNewer } : undefined}
             scrollApiRef={scrollApiRef}
@@ -1712,6 +1735,8 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
             onAtBottomChange={setAtBottom}
             onLastFullyVisibleMessageChange={setLastFullyVisibleMessageId}
             onFirstVisibleMessageChange={setFirstVisibleMessageId}
+            onScrollActivityChange={setMessageListScrolling}
+            onTopDateOffsetChange={setFloatingDateOffset}
           />
           <IonFab
             vertical="bottom"


### PR DESCRIPTION
## Summary
- Show a floating date separator while the user manually scrolls through a chat thread.
- Keep the floating separator visually aligned with the existing date separator style and position.
- Hide only the original row for the currently floating date, while allowing the next date separator to remain visible and push the floating label away naturally.
- Avoid showing the floating date for programmatic scrolls such as sending or receiving new messages.

## Testing
- npm run verify
- git diff --check