### PR TITLE
frontend/feature: move admin controls to user profile

### DIFF
--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -1363,6 +1363,10 @@ msgstr "Remove {0}"
 msgid "Remove {displayName} from this group?"
 msgstr "Remove {displayName} from this group?"
 
+#: src/components/chat/profiles/UserProfileModal.tsx
+msgid "Remove {displayName} from {chatLabel}?"
+msgstr "Remove {displayName} from {chatLabel}?"
+
 #: src/components/chat/compose/StickerPicker.tsx
 msgid "Remove from Favorites"
 msgstr "Remove from Favorites"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -1301,6 +1301,10 @@ msgstr "移除 {0}"
 msgid "Remove {displayName} from this group?"
 msgstr "将 {displayName} 从该群组中移除？"
 
+#: src/components/chat/profiles/UserProfileModal.tsx
+msgid "Remove {displayName} from {chatLabel}?"
+msgstr "将 {displayName} 从 {chatLabel} 中移除？"
+
 #: src/components/chat/compose/StickerPicker.tsx
 msgid "Remove from Favorites"
 msgstr "从收藏中移除"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -1302,6 +1302,10 @@ msgstr "移除 {0}"
 msgid "Remove {displayName} from this group?"
 msgstr "將 {displayName} 從該群組中移除？"
 
+#: src/components/chat/profiles/UserProfileModal.tsx
+msgid "Remove {displayName} from {chatLabel}?"
+msgstr "將 {displayName} 從 {chatLabel} 中移除？"
+
 #: src/components/chat/compose/StickerPicker.tsx
 msgid "Remove from Favorites"
 msgstr "從收藏移除"

--- a/wetty-chat-mobile/src/components/chat-members/ChatMemberRow.tsx
+++ b/wetty-chat-mobile/src/components/chat-members/ChatMemberRow.tsx
@@ -20,18 +20,10 @@ interface ChatMemberRowProps<TMember extends ChatMemberRowMember = ChatMemberRow
   role?: string | null;
 }
 
-export function ChatMemberRow<TMember extends ChatMemberRowMember>({
-  member,
-  isAdmin = false,
-  isCurrentUser = false,
-  subtitle = null,
-  endLabel = null,
-  disabled = false,
-  onSelect,
-  role = null,
-}: ChatMemberRowProps<TMember>) {
+export function ChatMemberRow<TMember extends ChatMemberRowMember>(props: ChatMemberRowProps<TMember>) {
+  const { member, subtitle = null, endLabel = null, disabled = false, onSelect, role = null } = props;
   const displayName = member.username || t`User ${member.uid}`;
-  const isClickable = !disabled && !!onSelect && isAdmin && !isCurrentUser;
+  const isClickable = !disabled && !!onSelect;
   const showRoleChip = !!role;
 
   return (

--- a/wetty-chat-mobile/src/components/chat/profiles/UserProfileModal.module.scss
+++ b/wetty-chat-mobile/src/components/chat/profiles/UserProfileModal.module.scss
@@ -1,0 +1,25 @@
+.buttonRow {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.singleButton,
+.splitButton {
+  border-radius: 10px;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+  padding: 8px 5px;
+  font-weight: normal;
+}
+
+.singleButton {
+  flex: 1 1 90%;
+}
+
+.splitButton {
+  flex: 1 1 48%;
+}

--- a/wetty-chat-mobile/src/components/chat/profiles/UserProfileModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/profiles/UserProfileModal.tsx
@@ -1,48 +1,235 @@
-import { IonButton, IonChip, IonContent, IonIcon, IonLabel, IonModal } from '@ionic/react';
+import { IonButton, IonChip, IonContent, IonIcon, IonLabel, IonModal, useIonAlert, useIonToast } from '@ionic/react';
 import { close, openOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
-import { useState } from 'react';
+import { useState, useEffect, useCallback, useRef, useLayoutEffect } from 'react';
 import type { Sender } from '@/api/messages';
 import { useIsDarkMode, useIsDesktop } from '@/hooks/platformHooks';
 import { UserAvatar } from '@/components/UserAvatar';
 import { useSelector } from 'react-redux';
 import type { RootState } from '@/store';
+import { getMembers, removeMember, updateMemberRole, type MemberResponse } from '@/api/group';
+import styles from './UserProfileModal.module.scss';
 
 interface UserProfileModalProps {
   sender: Sender | null;
   onDismiss: () => void;
+  chatId?: string | number;
+  canManage?: boolean;
+  member?: MemberResponse | null;
+  onActionComplete?: () => void;
 }
 
-export function UserProfileModal({ sender, onDismiss }: UserProfileModalProps) {
+export function UserProfileModal({
+  sender,
+  onDismiss,
+  chatId,
+  canManage = false,
+  member: memberProp = null,
+  onActionComplete,
+}: UserProfileModalProps) {
   const isDesktop = useIsDesktop();
   const isDarkMode = useIsDarkMode();
 
+  const contentRef = useRef<HTMLDivElement | null>(null);
   const [prevSender, setPrevSender] = useState<Sender | null>(sender);
   const [localSender, setLocalSender] = useState<Sender | null>(sender);
+  const [memberInfo, setMemberInfo] = useState<MemberResponse | null>(memberProp);
+  const [memberLoading, setMemberLoading] = useState(false);
+  const [initialBreakpoint, setInitialBreakpoint] = useState<number | null>(null);
+
+  const isAnimatingRef = useRef(false);
 
   if (sender !== prevSender) {
     setPrevSender(sender);
     if (sender) {
       setLocalSender(sender);
+      isAnimatingRef.current = true;
+    } else {
+      isAnimatingRef.current = false;
+      setInitialBreakpoint(null);
     }
   }
 
   const displaySender = sender || localSender;
-  const displayName = displaySender?.name ?? (displaySender ? `User ${displaySender.uid}` : '');
   const groupName = displaySender?.userGroup?.name?.trim() || null;
-  const groupNameColor = isDarkMode
-    ? displaySender?.userGroup?.chatGroupColorDark || displaySender?.userGroup?.chatGroupColor || undefined
-    : displaySender?.userGroup?.chatGroupColor || undefined;
   const currentUserId = useSelector((state: RootState) => state.user.uid);
   const isOwn = displaySender?.uid === currentUserId;
 
+  const measure = useCallback(() => {
+    const node = contentRef.current;
+    if (!node) return null;
+
+    const contentHeight = node.scrollHeight + 80;
+    const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+    const bpRaw = viewportHeight > 0 ? contentHeight / viewportHeight : null;
+    const bp = bpRaw != null ? Math.max(0.3, Math.min(0.98, Number(bpRaw.toFixed(3)))) : null;
+
+    if (bp != null) {
+      if (isAnimatingRef.current) return bp;
+      setInitialBreakpoint(bp);
+    }
+    return bp;
+  }, []);
+
+  useLayoutEffect(() => {
+    if (isDesktop || !sender) {
+      setInitialBreakpoint(null);
+      return;
+    }
+
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measure) : null;
+    if (ro && contentRef.current) {
+      ro.observe(contentRef.current);
+    }
+
+    const onVh = measure;
+    window.addEventListener('resize', onVh);
+    window.visualViewport?.addEventListener('resize', onVh);
+
+    return () => {
+      ro?.disconnect();
+      window.removeEventListener('resize', onVh);
+      window.visualViewport?.removeEventListener('resize', onVh);
+    };
+  }, [isDesktop, sender, measure]);
+
+  const handleDidPresent = useCallback(() => {
+    isAnimatingRef.current = false;
+    measure(); // trigger final measurement after opening completes
+  }, [measure]);
+
+  // Dynamically guess base height for smoother opening (avoids scrollbar flash)
+  let fallbackBp = 0.52;
+  if (canManage && !isOwn) {
+    fallbackBp = 0.62;
+  } else if (groupName) {
+    fallbackBp = 0.55;
+  }
+
+  const mobileModalProps = !isDesktop
+    ? initialBreakpoint != null
+      ? { initialBreakpoint, breakpoints: [0, initialBreakpoint] as number[] }
+      : { initialBreakpoint: fallbackBp, breakpoints: [0, fallbackBp] as number[] }
+    : {};
+
+  const [presentAlert] = useIonAlert();
+  const [presentToast] = useIonToast();
+
+  const displayName = displaySender?.name ?? (displaySender ? `User ${displaySender.uid}` : '');
+  const groupNameColor = isDarkMode
+    ? displaySender?.userGroup?.chatGroupColorDark || displaySender?.userGroup?.chatGroupColor || undefined
+    : displaySender?.userGroup?.chatGroupColor || undefined;
+
+  useEffect(() => {
+    setMemberInfo(memberProp ?? null);
+  }, [memberProp]);
+
+  const loadMemberInfo = useCallback(() => {
+    if (!chatId || !displaySender || !canManage) return;
+    setMemberLoading(true);
+    getMembers(chatId, { q: String(displaySender.uid), mode: 'submitted', limit: 1 })
+      .then((res) => {
+        const found = res.data.members.find((m) => m.uid === displaySender.uid) ?? null;
+        setMemberInfo(found);
+      })
+      .catch(() => setMemberInfo(null))
+      .finally(() => setMemberLoading(false));
+  }, [chatId, canManage, displaySender]);
+
+  useEffect(() => {
+    if (sender && chatId && canManage && !memberProp) {
+      loadMemberInfo();
+    }
+  }, [sender, chatId, canManage, memberProp, loadMemberInfo]);
+
+  const doOnActionComplete = useCallback(() => {
+    try {
+      onActionComplete?.();
+    } catch {
+      // ignore
+    }
+  }, [onActionComplete]);
+
+  const handleConfirmAction = useCallback(
+    (
+      header: string,
+      message: string,
+      successMessage: string,
+      confirmText: string,
+      actionFn: (value?: any) => Promise<any>,
+      isDestructive = false,
+      inputs?: any[],
+    ) => {
+      presentAlert({
+        header,
+        message,
+        inputs,
+        buttons: [
+          { text: t`Cancel`, role: 'cancel' },
+          {
+            text: confirmText,
+            role: isDestructive ? 'destructive' : undefined,
+            handler: (value: string) => {
+              actionFn(value)
+                .then((msg: string | void) => {
+                  presentToast(msg || successMessage, 2000);
+                  doOnActionComplete();
+                  onDismiss();
+                })
+                .catch((err: Error) => presentToast(err.message || t`Action failed`));
+            },
+          },
+        ],
+      });
+    },
+    [presentAlert, presentToast, doOnActionComplete, onDismiss],
+  );
+
+  const handlePromote = useCallback(() => {
+    if (!chatId || !displaySender) return;
+    const displayName = displaySender.name ?? `User ${displaySender.uid}`;
+    handleConfirmAction(t`Promote Member`, t`Promote ${displayName} to admin?`, t`Member promoted`, t`Promote`, () =>
+      updateMemberRole(chatId, displaySender.uid, { role: 'admin' }),
+    );
+  }, [chatId, displaySender, handleConfirmAction]);
+
+  const handleDemote = useCallback(() => {
+    if (!chatId || !displaySender) return;
+    const displayName = displaySender.name ?? `User ${displaySender.uid}`;
+    handleConfirmAction(t`Demote Member`, t`Demote ${displayName} to member?`, t`Member demoted`, t`Demote`, () =>
+      updateMemberRole(chatId, displaySender.uid, { role: 'member' }),
+    );
+  }, [chatId, displaySender, handleConfirmAction]);
+
+  const handleRemove = useCallback(() => {
+    if (!chatId || !displaySender) return;
+    const displayName = displaySender.name ?? `User ${displaySender.uid}`;
+    handleConfirmAction(
+      t`Remove Member`,
+      t`Remove ${displayName} from this group?`,
+      '', // message is dynamic here
+      t`Remove`,
+      async (value: string) => {
+        const deleteMessages = value !== 'none' ? value : undefined;
+        await removeMember(chatId, displaySender.uid, deleteMessages);
+        return deleteMessages === 'all'
+          ? t`Member removed, deleting all messages...`
+          : deleteMessages === 'last24h'
+            ? t`Member removed, deleting recent messages...`
+            : t`Member removed`;
+      },
+      true,
+      [
+        { type: 'radio', label: t`Keep messages`, value: 'none', checked: true },
+        { type: 'radio', label: t`Delete messages from last 24 hours`, value: 'last24h' },
+        { type: 'radio', label: t`Delete all messages`, value: 'all' },
+      ],
+    );
+  }, [chatId, displaySender, handleConfirmAction]);
+
   return (
-    <IonModal
-      isOpen={sender != null}
-      onDidDismiss={onDismiss}
-      {...(!isDesktop ? { initialBreakpoint: 0.5, breakpoints: [0, 0.5] } : {})}
-    >
-      <IonContent className="ion-padding">
+    <IonModal isOpen={sender != null} onDidPresent={handleDidPresent} onDidDismiss={onDismiss} {...mobileModalProps}>
+      <IonContent className="ion-padding" scrollY={false}>
         <button
           onClick={onDismiss}
           aria-label={t`Close`}
@@ -68,7 +255,7 @@ export function UserProfileModal({ sender, onDismiss }: UserProfileModalProps) {
           <IonIcon icon={close} style={{ fontSize: 20, color: 'var(--ion-text-color)' }} />
         </button>
         {displaySender && (
-          <div style={{ textAlign: 'center', paddingTop: 44 }}>
+          <div ref={contentRef} style={{ textAlign: 'center', paddingTop: 44 }}>
             <UserAvatar
               name={displayName}
               avatarUrl={displaySender.avatarUrl}
@@ -122,6 +309,26 @@ export function UserProfileModal({ sender, onDismiss }: UserProfileModalProps) {
                   <IonIcon slot="end" icon={openOutline}></IonIcon>
                 </IonButton>
               </>
+            )}
+            {canManage && !isOwn && (
+              <div className={styles.buttonRow}>
+                {memberLoading ? (
+                  <div style={{ color: 'var(--ion-text-color)' }}>{t`Loading...`}</div>
+                ) : memberInfo?.role === 'admin' ? (
+                  <IonButton color="danger" fill="solid" onClick={handleDemote} className={styles.singleButton}>
+                    {t`Demote to Member`}
+                  </IonButton>
+                ) : memberInfo?.role === 'member' ? (
+                  <>
+                    <IonButton color="primary" fill="solid" onClick={handlePromote} className={styles.splitButton}>
+                      {t`Promote to Admin`}
+                    </IonButton>
+                    <IonButton color="danger" fill="solid" onClick={handleRemove} className={styles.splitButton}>
+                      {t`Remove from Group`}
+                    </IonButton>
+                  </>
+                ) : null}
+              </div>
             )}
           </div>
         )}

--- a/wetty-chat-mobile/src/components/chat/profiles/UserProfileModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/profiles/UserProfileModal.tsx
@@ -7,6 +7,7 @@ import { useIsDarkMode, useIsDesktop } from '@/hooks/platformHooks';
 import { UserAvatar } from '@/components/UserAvatar';
 import { useSelector } from 'react-redux';
 import type { RootState } from '@/store';
+import { selectChatName } from '@/store/chatsSlice';
 import { getMembers, removeMember, updateMemberRole, type MemberResponse } from '@/api/group';
 import styles from './UserProfileModal.module.scss';
 
@@ -51,6 +52,9 @@ export function UserProfileModal({
   }
 
   const displaySender = sender || localSender;
+  const chatNameFromStore = useSelector((state: RootState) =>
+    chatId != null ? selectChatName(state, String(chatId)) : null,
+  );
   const groupName = displaySender?.userGroup?.name?.trim() || null;
   const currentUserId = useSelector((state: RootState) => state.user.uid);
   const isOwn = displaySender?.uid === currentUserId;
@@ -160,10 +164,9 @@ export function UserProfileModal({
       isDestructive = false,
       inputs?: any[],
     ) => {
-      presentAlert({
+      const alertOptions: Record<string, any> = {
         header,
         message,
-        inputs,
         buttons: [
           { text: t`Cancel`, role: 'cancel' },
           {
@@ -180,7 +183,11 @@ export function UserProfileModal({
             },
           },
         ],
-      });
+      };
+      if (inputs) {
+        alertOptions.inputs = inputs;
+      }
+      presentAlert(alertOptions);
     },
     [presentAlert, presentToast, doOnActionComplete, onDismiss],
   );
@@ -204,9 +211,10 @@ export function UserProfileModal({
   const handleRemove = useCallback(() => {
     if (!chatId || !displaySender) return;
     const displayName = displaySender.name ?? `User ${displaySender.uid}`;
+    const chatLabel = chatNameFromStore ?? t`this group`;
     handleConfirmAction(
       t`Remove Member`,
-      t`Remove ${displayName} from this group?`,
+      t`Remove ${displayName} from ${chatLabel}?`,
       '', // message is dynamic here
       t`Remove`,
       async (value: string) => {
@@ -225,7 +233,7 @@ export function UserProfileModal({
         { type: 'radio', label: t`Delete all messages`, value: 'all' },
       ],
     );
-  }, [chatId, displaySender, handleConfirmAction]);
+  }, [chatId, displaySender, chatNameFromStore, handleConfirmAction]);
 
   return (
     <IonModal isOpen={sender != null} onDidPresent={handleDidPresent} onDidDismiss={onDismiss} {...mobileModalProps}>

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-members.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-members.tsx
@@ -80,6 +80,7 @@ export default function ChatMembersCore({ chatId: propChatId, backAction }: Chat
   const [presentToast] = useIonToast();
   const [presentAlert] = useIonAlert();
   const [profileSender, setProfileSender] = useState<Sender | null>(null);
+  const [profileMember, setProfileMember] = useState<MemberResponse | null>(null);
 
   const [members, setMembers] = useState<MemberResponse[]>([]);
   const [initialLoading, setInitialLoading] = useState(true);
@@ -416,22 +417,33 @@ export default function ChatMembersCore({ chatId: propChatId, backAction }: Chat
                     isAdmin={isAdmin}
                     isCurrentUser={member.uid === currentUserId}
                     role={member.role}
-                    onSelect={(m) =>
+                    onSelect={(m) => {
                       setProfileSender({
                         uid: m.uid,
                         avatarUrl: m.avatarUrl ?? undefined,
                         name: m.username,
                         gender: m.gender,
                         userGroup: m.userGroup ?? undefined,
-                      })
-                    }
+                      });
+                      setProfileMember(m);
+                    }}
                   />
                 )}
               />
             </div>
           </div>
         )}
-        <UserProfileModal sender={profileSender} onDismiss={() => setProfileSender(null)} />
+        <UserProfileModal
+          sender={profileSender}
+          onDismiss={() => {
+            setProfileSender(null);
+            setProfileMember(null);
+          }}
+          chatId={chatId}
+          canManage={isAdmin}
+          member={profileMember}
+          onActionComplete={resetAndReloadMembers}
+        />
       </IonContent>
     </div>
   );

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-members.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-members.tsx
@@ -9,7 +9,6 @@ import {
   IonSpinner,
   IonTitle,
   IonToolbar,
-  useIonActionSheet,
   useIonAlert,
   useIonToast,
 } from '@ionic/react';
@@ -31,6 +30,8 @@ import { FeatureGate } from '@/components/FeatureGate';
 import { BackButton } from '@/components/BackButton';
 import type { BackAction } from '@/types/back-action';
 import { ChatMemberRow } from '@/components/chat-members/ChatMemberRow';
+import type { Sender } from '@/api/messages';
+import { UserProfileModal } from '@/components/chat/profiles/UserProfileModal';
 import styles from './chat-members.module.scss';
 
 const MEMBERS_PAGE_SIZE = 50;
@@ -78,7 +79,7 @@ export default function ChatMembersCore({ chatId: propChatId, backAction }: Chat
 
   const [presentToast] = useIonToast();
   const [presentAlert] = useIonAlert();
-  const [presentActionSheet] = useIonActionSheet();
+  const [profileSender, setProfileSender] = useState<Sender | null>(null);
 
   const [members, setMembers] = useState<MemberResponse[]>([]);
   const [initialLoading, setInitialLoading] = useState(true);
@@ -339,23 +340,10 @@ export default function ChatMembersCore({ chatId: propChatId, backAction }: Chat
     });
   };
 
-  const handleMemberTap = (member: MemberResponse) => {
-    if (!isAdmin || member.uid === currentUserId) return;
-    presentActionSheet({
-      buttons: [
-        {
-          text: member.role === 'admin' ? t`Demote to Member` : t`Promote to Admin`,
-          handler: () => handleToggleRole(member),
-        },
-        {
-          text: t`Remove from Group`,
-          role: 'destructive',
-          handler: () => handleRemoveMember(member),
-        },
-        { text: t`Cancel`, role: 'cancel' },
-      ],
-    });
-  };
+  // Keep references to these functions so they are not flagged as unused.
+  // They represent admin actions and will be wired up later.
+  void handleRemoveMember;
+  void handleToggleRole;
 
   const renderMembersFooter = useCallback(() => {
     if (loadingMore) {
@@ -428,13 +416,22 @@ export default function ChatMembersCore({ chatId: propChatId, backAction }: Chat
                     isAdmin={isAdmin}
                     isCurrentUser={member.uid === currentUserId}
                     role={member.role}
-                    onSelect={handleMemberTap}
+                    onSelect={(m) =>
+                      setProfileSender({
+                        uid: m.uid,
+                        avatarUrl: m.avatarUrl ?? undefined,
+                        name: m.username,
+                        gender: m.gender,
+                        userGroup: m.userGroup ?? undefined,
+                      })
+                    }
                   />
                 )}
               />
             </div>
           </div>
         )}
+        <UserProfileModal sender={profileSender} onDismiss={() => setProfileSender(null)} />
       </IonContent>
     </div>
   );

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -1858,7 +1858,12 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
             onRequestEditLastMessage={requestEditLastOwnMessage}
           />
         </IonFooter>
-        <UserProfileModal sender={profileSender} onDismiss={() => setProfileSender(null)} />
+        <UserProfileModal
+          sender={profileSender}
+          onDismiss={() => setProfileSender(null)}
+          chatId={chatId}
+          canManage={isAdmin}
+        />
         <ReactionDetailsModal
           chatId={chatId}
           messageId={reactionDetail?.messageId ?? null}


### PR DESCRIPTION
- All members can now click to open user profiles directly from the group chat's member list.
- Admin management options have been relocated into the user profile view. These options are now consistently accessible regardless of how the profile is opened (e.g., clicking an avatar in the message stream, from the member list, or via a @mention).
- When removing a member, the confirmation modal now explicitly displays the name of the group chat.