### PR TITLE
frontend/feature: enhance floating date indicator behavior

### DIFF
--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -38,9 +38,10 @@ import {
 } from './types';
 import styles from './ChatVirtualScroll.module.scss';
 import { Trans } from '@lingui/react/macro';
+import { useNativeScrollActivity } from '@/hooks/useNativeScrollActivity';
+import { USER_SCROLL_ACTIVITY_GRACE_MS } from '@/constants/ui';
 
 const TOP_DATE_FLOATING_GAP_PX = 12;
-const USER_SCROLL_ACTIVITY_GRACE_MS = 1200;
 
 function arraysEqual(a: string[], b: string[]): boolean {
   return a.length === b.length && a.every((value, index) => value === b[index]);
@@ -274,7 +275,6 @@ export function ChatVirtualScroll({
     to: number;
     behavior?: ScrollBehavior;
   } | null>(null);
-  const userScrollIntentUntilRef = useRef(0);
   const recentScrollPositionsRef = useRef<Array<{ top: number; at: number }>>([]);
   const lastJitterLogAtRef = useRef(0);
   const topLoadArmedRef = useRef(true);
@@ -490,10 +490,15 @@ export function ChatVirtualScroll({
     },
     [onScrollActivityChange, onTopDateOffsetChange],
   );
+  const { active: nativeScrollActive, markIntent } = useNativeScrollActivity(
+    containerRef,
+    USER_SCROLL_ACTIVITY_GRACE_MS,
+    SCROLL_IDLE_MS,
+  );
 
-  const markUserScrollIntent = useCallback(() => {
-    userScrollIntentUntilRef.current = performance.now() + USER_SCROLL_ACTIVITY_GRACE_MS;
-  }, []);
+  useEffect(() => {
+    setScrollActivity(nativeScrollActive);
+  }, [nativeScrollActive, setScrollActivity]);
 
   const updateLastFullyVisibleMessage = useCallback(() => {
     const container = containerRef.current;
@@ -1317,8 +1322,8 @@ export function ChatVirtualScroll({
 
   const handleScroll = useCallback(() => {
     const container = containerRef.current;
+    const now = performance.now();
     if (container) {
-      const now = performance.now();
       const recent = recentScrollPositionsRef.current;
       recent.push({ top: roundScrollValue(container.scrollTop), at: now });
       while (recent.length > 8) recent.shift();
@@ -1358,8 +1363,7 @@ export function ChatVirtualScroll({
       }
     }
 
-    const isUserInitiatedScroll = performance.now() <= userScrollIntentUntilRef.current;
-    setScrollActivity(isUserInitiatedScroll);
+    // scroll activity (user vs programmatic) is handled by useNativeScrollActivity
 
     if (scrollRafRef.current == null) {
       scrollRafRef.current = requestAnimationFrame(() => {
@@ -1388,7 +1392,6 @@ export function ChatVirtualScroll({
     maybeUpdateMountedForScroll,
     pendingBatch,
     scrollDistances,
-    setScrollActivity,
     updateAtBottom,
     updateLastFullyVisibleMessage,
   ]);
@@ -2407,12 +2410,10 @@ export function ChatVirtualScroll({
       ref={containerRef}
       className={styles.container}
       onScroll={handleScroll}
-      onWheel={markUserScrollIntent}
-      onTouchStart={markUserScrollIntent}
-      onTouchMove={markUserScrollIntent}
-      onPointerDown={markUserScrollIntent}
-      onPointerMove={markUserScrollIntent}
-      onKeyDown={markUserScrollIntent}
+      onWheel={markIntent}
+      onTouchStart={markIntent}
+      onTouchMove={markIntent}
+      onPointerDown={markIntent}
     >
       {topOverlay}
       <div

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -39,9 +39,11 @@ import {
 import styles from './ChatVirtualScroll.module.scss';
 import { Trans } from '@lingui/react/macro';
 import { useNativeScrollActivity } from '@/hooks/useNativeScrollActivity';
-import { USER_SCROLL_ACTIVITY_GRACE_MS } from '@/constants/ui';
-
-const TOP_DATE_FLOATING_GAP_PX = 12;
+import {
+  USER_SCROLL_ACTIVITY_GRACE_MS,
+  TOP_DATE_FLOATING_GAP_PX,
+  TOP_DATE_OVERLAY_FALLBACK_HEIGHT,
+} from '@/constants/ui';
 
 function arraysEqual(a: string[], b: string[]): boolean {
   return a.length === b.length && a.every((value, index) => value === b[index]);
@@ -210,7 +212,7 @@ export function ChatVirtualScroll({
   onLastFullyVisibleMessageChange,
   onFirstVisibleMessageChange,
   onScrollActivityChange,
-  onTopDateOffsetChange,
+  onTopDateCollidingChange,
 }: ChatVirtualScrollProps) {
   const chatFontSizeStyle = useSelector(selectChatFontSizeStyle);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -220,15 +222,48 @@ export function ChatVirtualScroll({
   const treeRef = useRef(new FenwickTree(0));
   const treeKeysRef = useRef<string[]>([]);
   const mountedRef = useRef<MountedWindow | null>(null);
-  const scrollingRef = useRef(false);
-  const topDateOffsetRef = useRef(0);
-
   const lastFontSizeRef = useRef(chatFontSizeStyle);
+  const overlayMeasureElRef = useRef<HTMLElement | null>(null);
+  const overlayHeightRef = useRef<number | null>(null);
+
+  const topDateCollidingRef = useRef(false);
+  const scrollingRef = useRef(false);
   if (lastFontSizeRef.current !== chatFontSizeStyle) {
     lastFontSizeRef.current = chatFontSizeStyle;
     heightCacheRef.current.clear();
     treeKeysRef.current = [];
   }
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Create a hidden measurement element inside the container so CSS context
+    // matches the real floating label. We prefer keeping a persistent node
+    // to avoid reflows on every measurement.
+    let el = overlayMeasureElRef.current;
+    if (!el) {
+      el = document.createElement('div');
+      el.className = 'chat-thread-floating-date__label';
+      el.style.visibility = 'hidden';
+      el.style.position = 'absolute';
+      el.style.pointerEvents = 'none';
+      el.style.transform = 'translateY(-99999px)';
+      container.appendChild(el);
+      overlayMeasureElRef.current = el;
+    }
+
+    // Measure height for collision calculations
+    overlayHeightRef.current = el.getBoundingClientRect().height || null;
+
+    return () => {
+      if (overlayMeasureElRef.current && overlayMeasureElRef.current.parentElement) {
+        overlayMeasureElRef.current.parentElement.removeChild(overlayMeasureElRef.current);
+      }
+      overlayMeasureElRef.current = null;
+      overlayHeightRef.current = null;
+    };
+  }, [chatFontSizeStyle]);
 
   const layoutIntentRef = useRef<LayoutIntent | null>(null);
   const isAtBottomRef = useRef(true);
@@ -484,11 +519,9 @@ export function ChatVirtualScroll({
       onScrollActivityChange?.(scrolling);
       if (!scrolling) {
         setHiddenDateRowKey(null);
-        topDateOffsetRef.current = 0;
-        onTopDateOffsetChange?.(0);
       }
     },
-    [onScrollActivityChange, onTopDateOffsetChange],
+    [onScrollActivityChange],
   );
   const { active: nativeScrollActive, markIntent } = useNativeScrollActivity(
     containerRef,
@@ -503,10 +536,6 @@ export function ChatVirtualScroll({
   const updateLastFullyVisibleMessage = useCallback(() => {
     const container = containerRef.current;
     if (!container || container.clientHeight === 0 || phaseRef.current !== 'READY') {
-      if (topDateOffsetRef.current !== 0) {
-        topDateOffsetRef.current = 0;
-        onTopDateOffsetChange?.(0);
-      }
       if (lastFullyVisibleMessageIdRef.current !== null) {
         lastFullyVisibleMessageIdRef.current = null;
         onLastFullyVisibleMessageChange?.(null);
@@ -523,11 +552,17 @@ export function ChatVirtualScroll({
     let nextMessageId: string | null = null;
     let firstMessageId: string | null = null;
     let firstMessageIndex: number | null = null;
+    let nextTopDateColliding = false;
+    let nextHiddenDateRowKey: string | null = null;
 
     if (mounted) {
+      const overlayHeight = overlayHeightRef.current || TOP_DATE_OVERLAY_FALLBACK_HEIGHT;
+      const floatingTop = TOP_DATE_FLOATING_GAP_PX;
+      const floatingBottom = floatingTop + overlayHeight;
+
       for (let index = mounted.end; index >= mounted.start; index -= 1) {
         const row = rows[index];
-        if (!row || row.type !== 'message') continue;
+        if (!row) continue;
 
         const rowNode = rowRefsMap.current.get(row.key);
         if (!rowNode) continue;
@@ -535,55 +570,49 @@ export function ChatVirtualScroll({
         const rowRect = rowNode.getBoundingClientRect();
         if (rowRect.height <= 0) continue;
 
-        const fullyVisible = rowRect.top >= containerRect.top - 0.5 && rowRect.bottom <= containerRect.bottom + 0.5;
-        const partiallyVisible = rowRect.bottom > containerRect.top && rowRect.top < containerRect.bottom;
+        if (row.type === 'message') {
+          const fullyVisible = rowRect.top >= containerRect.top - 0.5 && rowRect.bottom <= containerRect.bottom + 0.5;
+          const partiallyVisible = rowRect.bottom > containerRect.top && rowRect.top < containerRect.bottom;
 
-        if (partiallyVisible) {
-          // Since we scan from bottom to top, the last one we see is the first visible from the top
-          firstMessageId = row.messageId;
-          firstMessageIndex = index;
-        }
+          if (partiallyVisible) {
+            firstMessageId = row.messageId;
+            firstMessageIndex = index;
+          }
 
-        if (fullyVisible && nextMessageId === null) {
-          nextMessageId = row.messageId;
+          if (fullyVisible && nextMessageId === null) {
+            nextMessageId = row.messageId;
+          }
+        } else if (row.type === 'date' && !nextTopDateColliding) {
+          const distanceFromTop = rowRect.top - containerRect.top;
+          const distanceBottom = distanceFromTop + rowRect.height;
+          const MARGIN = 1;
+          if (distanceBottom + MARGIN >= floatingTop && distanceFromTop - MARGIN <= floatingBottom) {
+            nextTopDateColliding = true;
+          }
         }
       }
     }
 
-    let nextTopDateOffset = 0;
-    let nextHiddenDateRowKey: string | null = null;
-    if (scrollingRef.current && firstMessageIndex != null) {
+    if (scrollingRef.current && firstMessageIndex != null && mounted) {
+      let activeDateRowKey: string | null = null;
       for (let index = firstMessageIndex; index >= 0; index -= 1) {
         const row = rows[index];
-        if (row?.type !== 'date') continue;
-        nextHiddenDateRowKey = row.key;
-        break;
+        if (row?.type === 'date') {
+          activeDateRowKey = row.key;
+          break;
+        }
       }
 
-      for (let index = firstMessageIndex + 1; index < rows.length; index += 1) {
-        const row = rows[index];
-        if (row?.type !== 'date') continue;
-
-        const rowNode = rowRefsMap.current.get(row.key);
-        if (!rowNode) break;
-
-        const rowRect = rowNode.getBoundingClientRect();
-        if (rowRect.height <= 0) break;
-
-        const distanceFromTop = rowRect.top - containerRect.top;
-        const collisionThreshold = TOP_DATE_FLOATING_GAP_PX + rowRect.height;
-        if (distanceFromTop > 0 && distanceFromTop < collisionThreshold) {
-          nextTopDateOffset = Math.round(distanceFromTop - collisionThreshold);
-        }
-        break;
+      if (!nextTopDateColliding) {
+        nextHiddenDateRowKey = activeDateRowKey;
       }
     }
 
     setHiddenDateRowKey((current) => (current === nextHiddenDateRowKey ? current : nextHiddenDateRowKey));
 
-    if (nextTopDateOffset !== topDateOffsetRef.current) {
-      topDateOffsetRef.current = nextTopDateOffset;
-      onTopDateOffsetChange?.(nextTopDateOffset);
+    if (topDateCollidingRef.current !== nextTopDateColliding) {
+      topDateCollidingRef.current = nextTopDateColliding;
+      onTopDateCollidingChange?.(nextTopDateColliding);
     }
 
     if (nextMessageId !== lastFullyVisibleMessageIdRef.current) {
@@ -595,7 +624,7 @@ export function ChatVirtualScroll({
       firstVisibleMessageIdRef.current = firstMessageId;
       onFirstVisibleMessageChange?.(firstMessageId);
     }
-  }, [onLastFullyVisibleMessageChange, onFirstVisibleMessageChange, onTopDateOffsetChange, rows]);
+  }, [onLastFullyVisibleMessageChange, onFirstVisibleMessageChange, onTopDateCollidingChange, rows]);
 
   const scrollToBottomInternal = useCallback((behavior: ScrollBehavior = 'auto') => {
     const container = containerRef.current;
@@ -1321,6 +1350,11 @@ export function ChatVirtualScroll({
   ]);
 
   const handleScroll = useCallback(() => {
+    // Immediately mark activity so updateLastFullyVisibleMessage runs with
+    // scrollingRef set. This prevents a race where the scroll handler runs
+    // before the native scroll activity effect updates `scrollingRef`, which
+    // caused the floating date to appear and overlap a visible fixed date.
+    setScrollActivity(true);
     const container = containerRef.current;
     const now = performance.now();
     if (container) {
@@ -1394,6 +1428,7 @@ export function ChatVirtualScroll({
     scrollDistances,
     updateAtBottom,
     updateLastFullyVisibleMessage,
+    setScrollActivity,
   ]);
 
   useLayoutEffect(() => {

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
@@ -90,7 +90,7 @@ export interface ChatVirtualScrollProps {
   onLastFullyVisibleMessageChange?: (messageId: string | null) => void;
   onFirstVisibleMessageChange?: (messageId: string | null) => void;
   onScrollActivityChange?: (scrolling: boolean) => void;
-  onTopDateOffsetChange?: (offset: number) => void;
+  onTopDateCollidingChange?: (colliding: boolean) => void;
 }
 
 // ── Constants ──

--- a/wetty-chat-mobile/src/constants/ui.ts
+++ b/wetty-chat-mobile/src/constants/ui.ts
@@ -2,3 +2,7 @@
 export const FLOATING_DATE_HIDE_DELAY_MS = 1000;
 export const FLOATING_DATE_FADE_MS = 200;
 export const USER_SCROLL_ACTIVITY_GRACE_MS = 1000;
+
+// UI-related layout constants
+export const TOP_DATE_FLOATING_GAP_PX = 12;
+export const TOP_DATE_OVERLAY_FALLBACK_HEIGHT = 28;

--- a/wetty-chat-mobile/src/constants/ui.ts
+++ b/wetty-chat-mobile/src/constants/ui.ts
@@ -1,0 +1,4 @@
+// UI-related timing constants
+export const FLOATING_DATE_HIDE_DELAY_MS = 1000;
+export const FLOATING_DATE_FADE_MS = 200;
+export const USER_SCROLL_ACTIVITY_GRACE_MS = 1000;

--- a/wetty-chat-mobile/src/hooks/useFloatingDate.ts
+++ b/wetty-chat-mobile/src/hooks/useFloatingDate.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+import { FLOATING_DATE_HIDE_DELAY_MS, FLOATING_DATE_FADE_MS } from '@/constants/ui';
+
+export function useFloatingDateVisibility(
+  hasDate: boolean,
+  isScrolling: boolean,
+  hideDelay = FLOATING_DATE_HIDE_DELAY_MS,
+  fadeMs = FLOATING_DATE_FADE_MS,
+) {
+  const [visible, setVisible] = useState(false);
+  const [fading, setFading] = useState(false);
+  const hideTimerRef = useRef<number | null>(null);
+  const fadeTimerRef = useRef<number | null>(null);
+  const immediateTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (isScrolling) {
+      if (hideTimerRef.current) {
+        window.clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+      if (fadeTimerRef.current) {
+        window.clearTimeout(fadeTimerRef.current);
+        fadeTimerRef.current = null;
+      }
+      if (immediateTimerRef.current) {
+        window.clearTimeout(immediateTimerRef.current);
+        immediateTimerRef.current = null;
+      }
+      immediateTimerRef.current = window.setTimeout(() => {
+        setFading(false);
+        setVisible(!!hasDate);
+        immediateTimerRef.current = null;
+      }, 0);
+      return;
+    }
+
+    if (!hasDate) {
+      if (immediateTimerRef.current) {
+        window.clearTimeout(immediateTimerRef.current);
+        immediateTimerRef.current = null;
+      }
+      immediateTimerRef.current = window.setTimeout(() => {
+        setVisible(false);
+        setFading(false);
+        immediateTimerRef.current = null;
+      }, 0);
+      return;
+    }
+
+    if (hideTimerRef.current) {
+      window.clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+
+    hideTimerRef.current = window.setTimeout(() => {
+      setFading(true);
+      fadeTimerRef.current = window.setTimeout(() => {
+        setFading(false);
+        setVisible(false);
+        fadeTimerRef.current = null;
+      }, fadeMs);
+      hideTimerRef.current = null;
+    }, hideDelay);
+
+    return () => {
+      if (hideTimerRef.current) {
+        window.clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+      if (fadeTimerRef.current) {
+        window.clearTimeout(fadeTimerRef.current);
+        fadeTimerRef.current = null;
+      }
+      if (immediateTimerRef.current) {
+        window.clearTimeout(immediateTimerRef.current);
+        immediateTimerRef.current = null;
+      }
+    };
+  }, [hasDate, isScrolling, hideDelay, fadeMs]);
+
+  return { visible, fading };
+}

--- a/wetty-chat-mobile/src/hooks/useNativeScrollActivity.ts
+++ b/wetty-chat-mobile/src/hooks/useNativeScrollActivity.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function useNativeScrollActivity(
+  containerRef: React.RefObject<HTMLElement | null>,
+  graceMs = 1200,
+  idleMs = 200,
+) {
+  const [active, setActive] = useState(false);
+  const userUntilRef = useRef(0);
+  const idleTimerRef = useRef<number | null>(null);
+
+  const markIntent = useCallback(() => {
+    userUntilRef.current = performance.now() + graceMs;
+    setActive(true);
+    if (idleTimerRef.current) {
+      window.clearTimeout(idleTimerRef.current);
+    }
+    idleTimerRef.current = window.setTimeout(() => {
+      setActive(false);
+      idleTimerRef.current = null;
+    }, idleMs);
+  }, [graceMs, idleMs]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const onScroll = (e: Event) => {
+      const now = performance.now();
+      const isUser = (e as any).isTrusted || now <= userUntilRef.current;
+      setActive(isUser);
+      if (idleTimerRef.current) {
+        window.clearTimeout(idleTimerRef.current);
+      }
+      idleTimerRef.current = window.setTimeout(() => {
+        setActive(false);
+        idleTimerRef.current = null;
+      }, idleMs);
+    };
+
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      if (idleTimerRef.current) {
+        window.clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+    };
+  }, [containerRef, idleMs]);
+
+  useEffect(() => {
+    return () => {
+      if (idleTimerRef.current) {
+        window.clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  return { active, markIntent };
+}

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.scss
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.scss
@@ -37,6 +37,15 @@
   font-weight: 500;
   padding: 4px 12px;
   border-radius: 12px;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+  opacity: 1;
+}
+
+.chat-thread-floating-date--fading .chat-thread-floating-date__label {
+  opacity: 0;
+  transform: translateY(-6px);
 }
 
 /* Scroll-to-bottom FAB */

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.scss
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.scss
@@ -40,6 +40,7 @@
   transition:
     opacity 0.2s ease,
     transform 0.2s ease;
+  will-change: opacity, transform;
   opacity: 1;
 }
 
@@ -63,11 +64,6 @@
     --background-hover: var(--ion-color-light, #f4f5f8);
     --box-shadow: 0 3px 10px rgba(0, 0, 0, 0.18);
     --color: var(--ion-color-medium, #92949c);
-    transition: transform 120ms ease;
-
-    &::part(native) {
-      transition: transform 120ms ease;
-    }
 
     &:active::part(native) {
       transform: scale(0.94);

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -297,7 +297,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
   const [lastFullyVisibleMessageId, setLastFullyVisibleMessageId] = useState<string | null>(null);
   const [firstVisibleMessageId, setFirstVisibleMessageId] = useState<string | null>(null);
   const [messageListScrolling, setMessageListScrolling] = useState(false);
-  const [floatingDateOffset, setFloatingDateOffset] = useState(0);
+  const [floatingDateColliding, setFloatingDateColliding] = useState(false);
 
   const topVisibleMessageDate = useMemo(() => {
     if (!firstVisibleMessageId) return null;
@@ -310,12 +310,18 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
   );
 
   const floatingDateLabel = useMemo(() => {
-    if (!topVisibleMessageDate) return null;
+    if (!topVisibleMessageDate || floatingDateColliding) return null;
     if (messageListScrolling || floatingDateVisible || floatingDateFading)
       return formatDateSeparator(topVisibleMessageDate);
     return null;
-  }, [formatDateSeparator, messageListScrolling, topVisibleMessageDate, floatingDateVisible, floatingDateFading]);
-  const floatingDateStyle = useMemo(() => ({ transform: `translateY(${floatingDateOffset}px)` }), [floatingDateOffset]);
+  }, [
+    formatDateSeparator,
+    messageListScrolling,
+    topVisibleMessageDate,
+    floatingDateVisible,
+    floatingDateFading,
+    floatingDateColliding,
+  ]);
 
   const chatRows = useChatRows(messages, formatDateSeparator);
 
@@ -1733,7 +1739,6 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
               floatingDateLabel ? (
                 <div
                   className={`chat-thread-floating-date ${floatingDateFading ? 'chat-thread-floating-date--fading' : ''}`}
-                  style={floatingDateStyle}
                 >
                   <span className="chat-thread-floating-date__label">{floatingDateLabel}</span>
                 </div>
@@ -1747,7 +1752,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
             onLastFullyVisibleMessageChange={setLastFullyVisibleMessageId}
             onFirstVisibleMessageChange={setFirstVisibleMessageId}
             onScrollActivityChange={setMessageListScrolling}
-            onTopDateOffsetChange={setFloatingDateOffset}
+            onTopDateCollidingChange={setFloatingDateColliding}
           />
           <IonFab
             vertical="bottom"

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -1,5 +1,6 @@
 import { MAX_PINNED_REACTIONS } from '@/constants/emojiAndStickers';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useFloatingDateVisibility } from '@/hooks/useFloatingDate';
 import {
   IonButton,
   IonButtons,
@@ -303,10 +304,17 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
     const msg = messages.find((m) => m.id === firstVisibleMessageId);
     return msg?.createdAt ?? null;
   }, [firstVisibleMessageId, messages]);
+  const { visible: floatingDateVisible, fading: floatingDateFading } = useFloatingDateVisibility(
+    !!topVisibleMessageDate,
+    messageListScrolling,
+  );
+
   const floatingDateLabel = useMemo(() => {
-    if (!messageListScrolling || !topVisibleMessageDate) return null;
-    return formatDateSeparator(topVisibleMessageDate);
-  }, [formatDateSeparator, messageListScrolling, topVisibleMessageDate]);
+    if (!topVisibleMessageDate) return null;
+    if (messageListScrolling || floatingDateVisible || floatingDateFading)
+      return formatDateSeparator(topVisibleMessageDate);
+    return null;
+  }, [formatDateSeparator, messageListScrolling, topVisibleMessageDate, floatingDateVisible, floatingDateFading]);
   const floatingDateStyle = useMemo(() => ({ transform: `translateY(${floatingDateOffset}px)` }), [floatingDateOffset]);
 
   const chatRows = useChatRows(messages, formatDateSeparator);
@@ -1723,7 +1731,10 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
             initialAnchor={initialAnchor}
             topOverlay={
               floatingDateLabel ? (
-                <div className="chat-thread-floating-date" style={floatingDateStyle}>
+                <div
+                  className={`chat-thread-floating-date ${floatingDateFading ? 'chat-thread-floating-date--fading' : ''}`}
+                  style={floatingDateStyle}
+                >
                   <span className="chat-thread-floating-date__label">{floatingDateLabel}</span>
                 </div>
               ) : null


### PR DESCRIPTION
- The floating date indicator is now correctly triggered when the user manually drags the scrollbar.
- Extended the display duration of the floating date; it now remains visible for 2 seconds after scrolling stops before fading out.
- Fixed an edge case where the floating date indicator would overlap with the fixed in-line date separators.
- Reorganized the file structure within the relevant directories.