### PR TITLE
Fix HEIC image previews

### DIFF
--- a/wetty-chat-mobile/package-lock.json
+++ b/wetty-chat-mobile/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^1.13.6",
         "emoji-picker-react": "^4.18.0",
         "emoji-regex-xs": "^2.0.1",
+        "heic2any": "^0.0.4",
         "idb": "^8.0.3",
         "ionicons": "^8.0.13",
         "js-cookie": "^3.0.5",
@@ -6572,6 +6573,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -9470,7 +9477,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/wetty-chat-mobile/package.json
+++ b/wetty-chat-mobile/package.json
@@ -27,6 +27,7 @@
     "axios": "^1.13.6",
     "emoji-picker-react": "^4.18.0",
     "emoji-regex-xs": "^2.0.1",
+    "heic2any": "^0.0.4",
     "idb": "^8.0.3",
     "ionicons": "^8.0.13",
     "js-cookie": "^3.0.5",

--- a/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
@@ -13,6 +13,7 @@ import { useComposeAttachments } from './useComposeAttachments';
 import { useVoiceRecorder } from './useVoiceRecorder';
 import { useMentionAutocomplete } from './useMentionAutocomplete';
 import { MentionAutocomplete } from './MentionAutocomplete';
+import { isSupportedMediaFile } from '@/utils/heicMedia';
 import type { StickerSummary } from '@/api/stickers';
 import type { ComposeSendPayload, ComposeUploadInput, ComposeUploadResult, EditingMessage, ReplyTo } from './types';
 export type {
@@ -241,9 +242,7 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
 
         if (containerRef.current && containerRef.current.offsetParent === null) return;
 
-        const files = Array.from(e.dataTransfer.files).filter(
-          (file) => file.type.startsWith('image/') || file.type.startsWith('video/'),
-        );
+        const files = Array.from(e.dataTransfer.files).filter(isSupportedMediaFile);
         if (files.length > 0) {
           queueFiles(files);
         }
@@ -316,7 +315,7 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
         <div id="message-compose-bar" className={styles.bar}>
           <input
             type="file"
-            accept="image/*,video/*"
+            accept="image/*,image/heic,image/heif,.heic,.heif,video/*"
             multiple
             style={{ display: 'none' }}
             ref={fileInputRef}

--- a/wetty-chat-mobile/src/components/chat/compose/UploadPreview.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/UploadPreview.tsx
@@ -1,6 +1,8 @@
 import { IonIcon } from '@ionic/react';
 import { t } from '@lingui/core/macro';
 import { alertCircleOutline, closeCircle, documentOutline, refreshOutline } from 'ionicons/icons';
+import { DisplayableImage } from '@/components/shared/DisplayableImage';
+import { isHeicLikeMedia } from '@/utils/heicMedia';
 import styles from './UploadPreview.module.scss';
 
 export type ComposeUploadDraftStatus = 'uploading' | 'uploaded' | 'error';
@@ -44,60 +46,72 @@ export function UploadPreview({ items, onRemove, onRetry }: UploadPreviewProps) 
 
   return (
     <div className={styles.previewTray} aria-label={t`Attachment preview tray`}>
-      {items.map((item) => (
-        <article key={item.localId} className={styles.card}>
-          {item.previewUrl ? (
-            item.kind == 'image' ? (
-              <img src={item.previewUrl} alt={item.name} className={styles.previewImage} />
-            ) : (
-              <video src={item.previewUrl} autoPlay loop muted className={styles.previewImage} />
-            )
-          ) : (
-            <div className={styles.fileCard}>
-              <IonIcon icon={documentOutline} className={styles.fileCardIcon} />
-              <span className={styles.fileCardName}>{item.name}</span>
-            </div>
-          )}
-          <button
-            type="button"
-            className={styles.removeButton}
-            aria-label={t`Remove ${item.name}`}
-            onClick={() => onRemove(item.localId)}
-          >
-            <IonIcon icon={closeCircle} />
-          </button>
+      {items.map((item) => {
+        const mimeType = item.itemType === 'draft' ? item.mimeType : item.kind;
+        const isImagePreview =
+          item.kind === 'image' || item.kind.startsWith('image/') || isHeicLikeMedia({ mimeType, fileName: item.name });
 
-          {item.itemType === 'draft' && item.status !== 'uploaded' && (
-            <div className={`${styles.overlay} ${item.status === 'error' ? styles.overlayError : ''}`}>
-              {item.status === 'uploading' ? (
-                <>
-                  <div className={styles.progressRing} aria-hidden="true">
-                    <svg viewBox="0 0 36 36">
-                      <path className={styles.progressTrack} d="M18 2.5a15.5 15.5 0 1 1 0 31a15.5 15.5 0 1 1 0-31" />
-                      <path
-                        className={styles.progressValue}
-                        d="M18 2.5a15.5 15.5 0 1 1 0 31a15.5 15.5 0 1 1 0-31"
-                        style={{ strokeDasharray: `${item.progress}, 100` }}
-                      />
-                    </svg>
-                    <span className={styles.progressLabel}>{item.progress}%</span>
-                  </div>
-                  <span className={styles.statusText}>{t`Uploading`}</span>
-                </>
+        return (
+          <article key={item.localId} className={styles.card}>
+            {item.previewUrl ? (
+              isImagePreview ? (
+                <DisplayableImage
+                  src={item.previewUrl}
+                  mimeType={mimeType}
+                  fileName={item.name}
+                  alt={item.name}
+                  className={styles.previewImage}
+                />
               ) : (
-                <>
-                  <IonIcon icon={alertCircleOutline} className={styles.errorIcon} />
-                  <span className={styles.statusText}>{item.errorMessage ?? t`Upload failed`}</span>
-                  <button type="button" className={styles.retryButton} onClick={() => onRetry(item.localId)}>
-                    <IonIcon icon={refreshOutline} />
-                    {t`Retry`}
-                  </button>
-                </>
-              )}
-            </div>
-          )}
-        </article>
-      ))}
+                <video src={item.previewUrl} autoPlay loop muted className={styles.previewImage} />
+              )
+            ) : (
+              <div className={styles.fileCard}>
+                <IonIcon icon={documentOutline} className={styles.fileCardIcon} />
+                <span className={styles.fileCardName}>{item.name}</span>
+              </div>
+            )}
+            <button
+              type="button"
+              className={styles.removeButton}
+              aria-label={t`Remove ${item.name}`}
+              onClick={() => onRemove(item.localId)}
+            >
+              <IonIcon icon={closeCircle} />
+            </button>
+
+            {item.itemType === 'draft' && item.status !== 'uploaded' && (
+              <div className={`${styles.overlay} ${item.status === 'error' ? styles.overlayError : ''}`}>
+                {item.status === 'uploading' ? (
+                  <>
+                    <div className={styles.progressRing} aria-hidden="true">
+                      <svg viewBox="0 0 36 36">
+                        <path className={styles.progressTrack} d="M18 2.5a15.5 15.5 0 1 1 0 31a15.5 15.5 0 1 1 0-31" />
+                        <path
+                          className={styles.progressValue}
+                          d="M18 2.5a15.5 15.5 0 1 1 0 31a15.5 15.5 0 1 1 0-31"
+                          style={{ strokeDasharray: `${item.progress}, 100` }}
+                        />
+                      </svg>
+                      <span className={styles.progressLabel}>{item.progress}%</span>
+                    </div>
+                    <span className={styles.statusText}>{t`Uploading`}</span>
+                  </>
+                ) : (
+                  <>
+                    <IonIcon icon={alertCircleOutline} className={styles.errorIcon} />
+                    <span className={styles.statusText}>{item.errorMessage ?? t`Upload failed`}</span>
+                    <button type="button" className={styles.retryButton} onClick={() => onRetry(item.localId)}>
+                      <IonIcon icon={refreshOutline} />
+                      {t`Retry`}
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+          </article>
+        );
+      })}
     </div>
   );
 }

--- a/wetty-chat-mobile/src/components/chat/compose/useComposeAttachments.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/useComposeAttachments.ts
@@ -6,6 +6,15 @@ import type { UploadPreviewItem } from '@/components/chat/compose/UploadPreview'
 import type { ComposeUploadInput, ComposeUploadResult, DraftUploadRecord } from './types';
 
 import { MAX_ATTACHMENTS_PER_MESSAGE } from '@/constants/media';
+import {
+  convertHeicBlobToJpegBlob,
+  getImageDimensionsFromBlob,
+  getUploadMimeType,
+  isHeicLikeMedia,
+  isImageFile,
+  isSupportedMediaFile,
+  isVideoFile,
+} from '@/utils/heicMedia';
 
 const isAbortError = (error: unknown) => error instanceof DOMException && error.name === 'AbortError';
 
@@ -17,24 +26,54 @@ const createDraftId = () => {
   return `draft_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 };
 
-const getMediaDimensions = (file: File): Promise<{ width?: number; height?: number }> =>
+const getNativeImageDimensions = (file: File): Promise<{ width?: number; height?: number }> =>
   new Promise((resolve) => {
-    if (file.type.startsWith('image/')) {
-      const img = new Image();
-      const objectUrl = URL.createObjectURL(file);
-      img.onload = () => {
-        URL.revokeObjectURL(objectUrl);
-        resolve({ width: img.width, height: img.height });
-      };
-      img.onerror = () => {
-        URL.revokeObjectURL(objectUrl);
-        resolve({});
-      };
-      img.src = objectUrl;
+    if (!isImageFile(file)) {
+      resolve({});
       return;
     }
 
-    if (file.type.startsWith('video/')) {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve({ width: img.width, height: img.height });
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve({});
+    };
+    img.src = objectUrl;
+  });
+
+async function getMediaDimensions(file: File): Promise<{ width?: number; height?: number }> {
+  const mimeType = getUploadMimeType(file);
+
+  if (isImageFile(file)) {
+    const nativeDimensions = await getNativeImageDimensions(file);
+    if (nativeDimensions.width && nativeDimensions.height) {
+      return nativeDimensions;
+    }
+
+    if (isHeicLikeMedia({ mimeType, fileName: file.name })) {
+      try {
+        const jpegBlob = await convertHeicBlobToJpegBlob(file);
+        return getImageDimensionsFromBlob(jpegBlob);
+      } catch (error) {
+        console.warn('[media:heic] Failed to read HEIC dimensions', {
+          fileName: file.name,
+          mimeType,
+          error,
+        });
+        return {};
+      }
+    }
+
+    return {};
+  }
+
+  return new Promise((resolve) => {
+    if (isVideoFile(file)) {
       const video = document.createElement('video');
       const objectUrl = URL.createObjectURL(file);
       video.onloadedmetadata = () => {
@@ -51,6 +90,7 @@ const getMediaDimensions = (file: File): Promise<{ width?: number; height?: numb
 
     resolve({});
   });
+}
 
 interface UseComposeAttachmentsArgs {
   uploadAttachment: (input: ComposeUploadInput) => Promise<ComposeUploadResult>;
@@ -205,7 +245,7 @@ export function useComposeAttachments({
 
   const queueFiles = useCallback(
     (files: File[]) => {
-      const mediaFiles = files.filter((file) => file.type.startsWith('image/') || file.type.startsWith('video/'));
+      const mediaFiles = files.filter(isSupportedMediaFile);
       if (mediaFiles.length === 0) return;
 
       let allowedFiles = mediaFiles;
@@ -223,10 +263,10 @@ export function useComposeAttachments({
         file,
         draft: {
           localId: createDraftId(),
-          kind: file.type.startsWith('image/') ? 'image' : 'video',
+          kind: isImageFile(file) ? 'image' : 'video',
           name: file.name,
           previewUrl: URL.createObjectURL(file),
-          mimeType: file.type || 'application/octet-stream',
+          mimeType: getUploadMimeType(file),
           size: file.size,
           order: index,
           progress: 0,
@@ -251,11 +291,9 @@ export function useComposeAttachments({
 
       const files: File[] = [];
       for (let index = 0; index < items.length; index += 1) {
-        if (items[index].type.startsWith('image/') || items[index].type.startsWith('video/')) {
-          const file = items[index].getAsFile();
-          if (file) {
-            files.push(file);
-          }
+        const file = items[index].getAsFile();
+        if (file && isSupportedMediaFile(file)) {
+          files.push(file);
         }
       }
 
@@ -312,7 +350,15 @@ export function useComposeAttachments({
       attachmentId: attachment.id,
       kind: attachment.kind,
       name: attachment.fileName,
-      previewUrl: attachment.kind.startsWith('image/') ? attachment.url : undefined,
+      previewUrl:
+        attachment.kind.startsWith('image/') ||
+        isHeicLikeMedia({
+          mimeType: attachment.kind,
+          fileName: attachment.fileName,
+          url: attachment.url,
+        })
+          ? attachment.url
+          : undefined,
     })),
     ...drafts.map((draftRecord) => ({
       itemType: 'draft' as const,

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -28,6 +28,8 @@ import { ReactionPill } from './ReactionPill';
 import { SingleMediaAttachment } from './media/SingleMediaAttachment';
 import { JustifiedMediaGallery } from './media/JustifiedMediaGallery';
 import { VideoPreview } from './media/VideoPreview';
+import { DisplayableImage } from '@/components/shared/DisplayableImage';
+import { isHeicLikeMedia } from '@/utils/heicMedia';
 import {
   parseChatBubbleContentToRichItems,
   getMessageLayoutStats,
@@ -58,6 +60,21 @@ function parsePermalinkFromUrl(url: string): { chatId: string; messageId: string
 function formatTime(iso: string): string {
   const d = new Date(iso);
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+function isImageAttachment(attachment: Attachment) {
+  return (
+    attachment.kind.startsWith('image/') ||
+    isHeicLikeMedia({
+      mimeType: attachment.kind,
+      fileName: attachment.fileName,
+      url: attachment.url,
+    })
+  );
+}
+
+function isVideoAttachment(attachment: Attachment) {
+  return attachment.kind.startsWith('video/');
 }
 
 function renderMessageWithLinks(message: string): ReactNode[] {
@@ -258,10 +275,8 @@ export function ChatBubbleBase({
   const chatFontSizeStyle = useSelector(selectChatFontSizeStyle);
   const locale = useSelector(selectEffectiveLocale);
   const interactive = interactionMode === 'interactive';
-  const imageAttachments =
-    attachments?.filter((att) => att.kind.startsWith('image/') || att.kind.startsWith('video/')) ?? [];
-  const otherAttachments =
-    attachments?.filter((att) => !(att.kind.startsWith('image/') || att.kind.startsWith('video/'))) ?? [];
+  const imageAttachments = attachments?.filter((att) => isImageAttachment(att) || isVideoAttachment(att)) ?? [];
+  const otherAttachments = attachments?.filter((att) => !(isImageAttachment(att) || isVideoAttachment(att))) ?? [];
   const { className: bubbleClassName, style: bubbleStyle, ...bubbleRestProps } = bubbleProps ?? {};
 
   const hasTopContent = showName || replyTo;
@@ -328,8 +343,10 @@ export function ChatBubbleBase({
       );
     }
     return (
-      <img
+      <DisplayableImage
         src={att.url}
+        mimeType={att.kind}
+        fileName={att.fileName}
         alt={t`Attachment`}
         style={style}
         onLoad={(e) => logAttachmentLoad('image', att, e.currentTarget)}
@@ -338,7 +355,7 @@ export function ChatBubbleBase({
   };
 
   function renderAttachment(att: Attachment) {
-    if (att.kind.startsWith('image/')) {
+    if (isImageAttachment(att)) {
       const imageLayoutStyle = getImageLayoutStyle(att.width, att.height, maxImageHeight);
       const imageContainerStyle: CSSProperties = {
         maxHeight: maxImageHeight,
@@ -346,8 +363,10 @@ export function ChatBubbleBase({
       };
 
       const image = (
-        <img
+        <DisplayableImage
           src={att.url}
+          mimeType={att.kind}
+          fileName={att.fileName}
           alt={t`Attachment`}
           className={styles.attachmentImage}
           style={imageLayoutStyle ? undefined : { maxHeight: maxImageHeight }}

--- a/wetty-chat-mobile/src/components/chat/messages/media/ImageViewer.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/media/ImageViewer.tsx
@@ -6,6 +6,8 @@ import { chevronBack, chevronForward, close, contractOutline, download, expandOu
 import { useIsDesktop } from '@/hooks/platformHooks';
 import { appHistory } from '@/utils/navigationHistory';
 import { getOverlayPortalTarget } from '@/utils/dom';
+import { DisplayableImage } from '@/components/shared/DisplayableImage';
+import { isHeicLikeMedia } from '@/utils/heicMedia';
 import styles from './ImageViewer.module.scss';
 
 const MAX_SCALE = 5;
@@ -35,6 +37,13 @@ interface Dimensions {
 interface Point {
   x: number;
   y: number;
+}
+
+function isImageViewerImage(item: ImageViewerItem | undefined) {
+  if (!item) return false;
+  return (
+    item.kind.startsWith('image/') || isHeicLikeMedia({ mimeType: item.kind, fileName: item.fileName, url: item.src })
+  );
 }
 
 function clamp(value: number, min: number, max: number) {
@@ -627,10 +636,12 @@ export function ImageViewer({ images, initialIndex = 0, onClose }: ImageViewerPr
           )}
 
           <div className={styles.canvas} onClick={handleDismissClick}>
-            {activeImage.kind.startsWith('image/') ? (
-              <img
+            {isImageViewerImage(activeImage) ? (
+              <DisplayableImage
                 key={activeImage.id || activeImage.src}
                 src={activeImage.src}
+                mimeType={activeImage.kind}
+                fileName={activeImage.fileName}
                 className={styles.image}
                 alt={activeImage.fileName || t`Attachment large view`}
                 draggable={false}
@@ -712,12 +723,18 @@ export function ImageViewer({ images, initialIndex = 0, onClose }: ImageViewerPr
                 onClick={() => navigateTo(index)}
                 aria-label={t`View image ${index + 1}`}
               >
-                <img
-                  src={image.src}
-                  alt={image.fileName || t`Thumbnail ${index + 1}`}
-                  className={styles.thumbnail}
-                  draggable={false}
-                />
+                {isImageViewerImage(image) ? (
+                  <DisplayableImage
+                    src={image.src}
+                    mimeType={image.kind}
+                    fileName={image.fileName}
+                    alt={image.fileName || t`Thumbnail ${index + 1}`}
+                    className={styles.thumbnail}
+                    draggable={false}
+                  />
+                ) : (
+                  <video src={image.src} className={styles.thumbnail} muted playsInline />
+                )}
               </button>
             ))}
           </div>

--- a/wetty-chat-mobile/src/components/shared/DisplayableImage.tsx
+++ b/wetty-chat-mobile/src/components/shared/DisplayableImage.tsx
@@ -1,0 +1,68 @@
+import { type ImgHTMLAttributes, type SyntheticEvent, useEffect, useRef, useState } from 'react';
+import { convertHeicSourceToJpegBlob, isHeicLikeMedia } from '@/utils/heicMedia';
+
+interface DisplayableImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  src: string;
+  mimeType?: string | null;
+  fileName?: string | null;
+}
+
+export function DisplayableImage({ src, mimeType, fileName, onError, ...imgProps }: DisplayableImageProps) {
+  return (
+    <DisplayableImageInner
+      key={src}
+      src={src}
+      mimeType={mimeType}
+      fileName={fileName}
+      onError={onError}
+      {...imgProps}
+    />
+  );
+}
+
+function DisplayableImageInner({ src, mimeType, fileName, onError, ...imgProps }: DisplayableImageProps) {
+  const [displaySrc, setDisplaySrc] = useState(src);
+  const [conversionAttempted, setConversionAttempted] = useState(false);
+  const needsConversion = isHeicLikeMedia({ mimeType, fileName, url: src });
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const handleError = (event: SyntheticEvent<HTMLImageElement, Event>) => {
+    if (!needsConversion || conversionAttempted) {
+      onError?.(event);
+      return;
+    }
+
+    setConversionAttempted(true);
+    convertHeicSourceToJpegBlob(src)
+      .then((blob) => {
+        if (!mountedRef.current) return;
+        const convertedUrl = URL.createObjectURL(blob);
+        setDisplaySrc(convertedUrl);
+      })
+      .catch((error) => {
+        console.warn('[media:heic] Failed to convert HEIC preview', {
+          src,
+          mimeType,
+          fileName,
+          error,
+        });
+        onError?.(event);
+      });
+  };
+
+  useEffect(() => {
+    if (displaySrc === src) return;
+    return () => {
+      URL.revokeObjectURL(displaySrc);
+    };
+  }, [displaySrc, src]);
+
+  return <img {...imgProps} src={displaySrc} onError={handleError} />;
+}

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -102,6 +102,7 @@ import { useIsDesktop, useMouseDetected } from '@/hooks/platformHooks';
 import { useChatRole } from '@/components/chat/permissions/useChatRole';
 import { ChatMessageRow } from '@/components/chat/messages/ChatMessageRow';
 import { parseResumeHash } from '@/types/chatThreadNavigation';
+import { getUploadMimeType } from '@/utils/heicMedia';
 import { READ_REQUEST_COOLDOWN_MS } from '@/constants/chatTiming';
 import {
   markThreadAsRead as apiMarkThreadAsRead,
@@ -988,7 +989,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
   const uploadAttachment = useCallback(async ({ file, dimensions, onProgress, signal, order }: ComposeUploadInput) => {
     const res = await requestUploadUrl({
       filename: file.name,
-      contentType: file.type || 'application/octet-stream',
+      contentType: getUploadMimeType(file),
       size: file.size,
       order,
       ...dimensions,

--- a/wetty-chat-mobile/src/utils/heicMedia.ts
+++ b/wetty-chat-mobile/src/utils/heicMedia.ts
@@ -1,0 +1,95 @@
+const HEIC_MIME_TYPES = new Set(['image/heic', 'image/heif', 'image/heic-sequence', 'image/heif-sequence']);
+const HEIC_EXTENSION_PATTERN = /\.(heic|heif)(?:$|[?#])/i;
+
+function normalizeMimeType(mimeType?: string | null) {
+  return mimeType?.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+}
+
+export function isHeicMimeType(mimeType?: string | null) {
+  return HEIC_MIME_TYPES.has(normalizeMimeType(mimeType));
+}
+
+export function isHeicFileName(fileName?: string | null) {
+  return fileName != null && HEIC_EXTENSION_PATTERN.test(fileName);
+}
+
+export function isHeicLikeMedia({
+  mimeType,
+  fileName,
+  url,
+}: {
+  mimeType?: string | null;
+  fileName?: string | null;
+  url?: string | null;
+}) {
+  return isHeicMimeType(mimeType) || isHeicFileName(fileName) || isHeicFileName(url);
+}
+
+export function isImageFile(file: File) {
+  return file.type.startsWith('image/') || isHeicFileName(file.name);
+}
+
+export function isVideoFile(file: File) {
+  return file.type.startsWith('video/');
+}
+
+export function isSupportedMediaFile(file: File) {
+  return isImageFile(file) || isVideoFile(file);
+}
+
+export function getUploadMimeType(file: File) {
+  if (file.type) return file.type;
+  if (isHeicFileName(file.name)) return 'image/heic';
+  return 'application/octet-stream';
+}
+
+export async function convertHeicBlobToJpegBlob(blob: Blob) {
+  const { default: heic2any } = await import('heic2any');
+  const converted = await heic2any({
+    blob,
+    toType: 'image/jpeg',
+    quality: 0.92,
+  });
+
+  return Array.isArray(converted) ? converted[0] : converted;
+}
+
+const convertedSourceCache = new Map<string, Promise<Blob>>();
+
+export function convertHeicSourceToJpegBlob(src: string) {
+  const cached = convertedSourceCache.get(src);
+  if (cached) return cached;
+
+  const conversion = fetch(src)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to load HEIC media: ${response.status}`);
+      }
+      return response.blob();
+    })
+    .then(convertHeicBlobToJpegBlob)
+    .catch((error) => {
+      convertedSourceCache.delete(src);
+      throw error;
+    });
+
+  convertedSourceCache.set(src, conversion);
+  return conversion;
+}
+
+export function getImageDimensionsFromBlob(blob: Blob): Promise<{ width?: number; height?: number }> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(blob);
+
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve({ width: img.width, height: img.height });
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve({});
+    };
+    img.src = objectUrl;
+  });
+}


### PR DESCRIPTION
## Summary
- Add HEIC/HEIF media detection and fallback conversion for browsers that cannot render HEIC natively.
- Preserve native HEIC rendering first so Safari keeps using its built-in support.
- Allow HEIC attachments through compose, drag/drop, paste, message rendering, and the image viewer.

## Testing
- npm run verify
- npx prettier --check package.json package-lock.json src/utils/heicMedia.ts src/components/shared/DisplayableImage.tsx src/components/chat/compose/useComposeAttachments.ts src/components/chat/compose/UploadPreview.tsx src/components/chat/compose/MessageComposeBar.tsx src/components/chat/messages/ChatBubbleBase.tsx src/components/chat/messages/media/ImageViewer.tsx src/pages/chat-thread/chat-thread.tsx
- Local smoke test with DB-inserted HEIC attachment served from the Vite static directory; cleaned up test DB row and static file before commit.