### PR TITLE
frontend/fix: switch HEIC preview fallback to heic-to

### DIFF
--- a/wetty-chat-mobile/package-lock.json
+++ b/wetty-chat-mobile/package-lock.json
@@ -17,7 +17,7 @@
         "axios": "^1.13.6",
         "emoji-picker-react": "^4.18.0",
         "emoji-regex-xs": "^2.0.1",
-        "heic2any": "^0.0.4",
+        "heic-to": "^1.4.2",
         "idb": "^8.0.3",
         "ionicons": "^8.0.13",
         "js-cookie": "^3.0.5",
@@ -6573,11 +6573,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/heic2any": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
-      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
-      "license": "MIT"
+    "node_modules/heic-to": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.4.2.tgz",
+      "integrity": "sha512-y69thwxfNcEm2Vk8lbOD/cMabnvMJyOREfJYiCHcXCDqlfcPyJoBhyRc8+iDe1B95LRfpbTOpzxzY1xbRkdwBA==",
+      "license": "LGPL-3.0"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
@@ -9477,7 +9477,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/wetty-chat-mobile/package.json
+++ b/wetty-chat-mobile/package.json
@@ -27,7 +27,7 @@
     "axios": "^1.13.6",
     "emoji-picker-react": "^4.18.0",
     "emoji-regex-xs": "^2.0.1",
-    "heic2any": "^0.0.4",
+    "heic-to": "^1.4.2",
     "idb": "^8.0.3",
     "ionicons": "^8.0.13",
     "js-cookie": "^3.0.5",

--- a/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
@@ -13,9 +13,9 @@ import { useComposeAttachments } from './useComposeAttachments';
 import { useVoiceRecorder } from './useVoiceRecorder';
 import { useMentionAutocomplete } from './useMentionAutocomplete';
 import { MentionAutocomplete } from './MentionAutocomplete';
-import { isSupportedMediaFile } from '@/utils/heicMedia';
 import type { StickerSummary } from '@/api/stickers';
 import type { ComposeSendPayload, ComposeUploadInput, ComposeUploadResult, EditingMessage, ReplyTo } from './types';
+import { isSupportedMediaFile } from '@/utils/heicMedia';
 export type {
   ComposeSendAudioPayload,
   ComposeSendPayload,

--- a/wetty-chat-mobile/src/components/shared/DisplayableImage.tsx
+++ b/wetty-chat-mobile/src/components/shared/DisplayableImage.tsx
@@ -7,8 +7,7 @@ interface DisplayableImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   fileName?: string | null;
 }
 
-const TRANSPARENT_PIXEL =
-  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+const TRANSPARENT_PIXEL = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
 export function DisplayableImage({ src, mimeType, fileName, onError, ...imgProps }: DisplayableImageProps) {
   return (
@@ -76,5 +75,12 @@ function DisplayableImageInner({ src, mimeType, fileName, onError, ...imgProps }
     };
   }, [displaySrc, src]);
 
-  return <img {...imgProps} src={displaySrc} onError={handleError} style={{ opacity: isResolving ? 0 : 1, ...imgProps.style }} />;
+  return (
+    <img
+      {...imgProps}
+      src={displaySrc}
+      onError={handleError}
+      style={{ opacity: isResolving ? 0 : 1, ...imgProps.style }}
+    />
+  );
 }

--- a/wetty-chat-mobile/src/components/shared/DisplayableImage.tsx
+++ b/wetty-chat-mobile/src/components/shared/DisplayableImage.tsx
@@ -1,11 +1,14 @@
 import { type ImgHTMLAttributes, type SyntheticEvent, useEffect, useRef, useState } from 'react';
-import { convertHeicSourceToJpegBlob, isHeicLikeMedia } from '@/utils/heicMedia';
+import { convertHeicSourceToJpegBlob, isHeicLikeMedia, shouldPreferNativeHeicRendering } from '@/utils/heicMedia';
 
 interface DisplayableImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   src: string;
   mimeType?: string | null;
   fileName?: string | null;
 }
+
+const TRANSPARENT_PIXEL =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
 export function DisplayableImage({ src, mimeType, fileName, onError, ...imgProps }: DisplayableImageProps) {
   return (
@@ -21,10 +24,12 @@ export function DisplayableImage({ src, mimeType, fileName, onError, ...imgProps
 }
 
 function DisplayableImageInner({ src, mimeType, fileName, onError, ...imgProps }: DisplayableImageProps) {
-  const [displaySrc, setDisplaySrc] = useState(src);
-  const [conversionAttempted, setConversionAttempted] = useState(false);
-  const needsConversion = isHeicLikeMedia({ mimeType, fileName, url: src });
+  const rawHeicLike = isHeicLikeMedia({ mimeType, fileName, url: src });
+  const needsConversion = rawHeicLike && !shouldPreferNativeHeicRendering();
+  const [displaySrc, setDisplaySrc] = useState(() => (needsConversion ? TRANSPARENT_PIXEL : src));
+  const [isResolving, setIsResolving] = useState(needsConversion);
   const mountedRef = useRef(true);
+  const conversionStartedRef = useRef(false);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -33,36 +38,43 @@ function DisplayableImageInner({ src, mimeType, fileName, onError, ...imgProps }
     };
   }, []);
 
-  const handleError = (event: SyntheticEvent<HTMLImageElement, Event>) => {
-    if (!needsConversion || conversionAttempted) {
-      onError?.(event);
+  useEffect(() => {
+    if (!needsConversion || conversionStartedRef.current) {
       return;
     }
 
-    setConversionAttempted(true);
+    conversionStartedRef.current = true;
     convertHeicSourceToJpegBlob(src)
       .then((blob) => {
         if (!mountedRef.current) return;
         const convertedUrl = URL.createObjectURL(blob);
         setDisplaySrc(convertedUrl);
+        setIsResolving(false);
       })
       .catch((error) => {
+        if (!mountedRef.current) return;
+        setDisplaySrc(src);
+        setIsResolving(false);
         console.warn('[media:heic] Failed to convert HEIC preview', {
           src,
           mimeType,
           fileName,
           error,
         });
-        onError?.(event);
       });
+  }, [fileName, mimeType, needsConversion, src]);
+
+  const handleError = (event: SyntheticEvent<HTMLImageElement, Event>) => {
+    setIsResolving(false);
+    onError?.(event);
   };
 
   useEffect(() => {
-    if (displaySrc === src) return;
+    if (displaySrc === src || displaySrc === TRANSPARENT_PIXEL) return;
     return () => {
       URL.revokeObjectURL(displaySrc);
     };
   }, [displaySrc, src]);
 
-  return <img {...imgProps} src={displaySrc} onError={handleError} />;
+  return <img {...imgProps} src={displaySrc} onError={handleError} style={{ opacity: isResolving ? 0 : 1, ...imgProps.style }} />;
 }

--- a/wetty-chat-mobile/src/utils/heicMedia.ts
+++ b/wetty-chat-mobile/src/utils/heicMedia.ts
@@ -1,3 +1,5 @@
+import { heicTo } from 'heic-to/csp';
+
 const HEIC_MIME_TYPES = new Set(['image/heic', 'image/heif', 'image/heic-sequence', 'image/heif-sequence']);
 const HEIC_EXTENSION_PATTERN = /\.(heic|heif)(?:$|[?#])/i;
 
@@ -37,6 +39,38 @@ export function isSupportedMediaFile(file: File) {
   return isImageFile(file) || isVideoFile(file);
 }
 
+function isLikelySafariUserAgent(userAgent: string) {
+  return /Safari\//.test(userAgent) && !/(Chrome|Chromium|CriOS|Edg|EdgiOS|OPR|FxiOS|Firefox|SamsungBrowser)\//.test(userAgent);
+}
+
+function parseSafariMajorVersion(userAgent: string) {
+  const versionMatch = userAgent.match(/Version\/(\d+)(?:\.\d+)?/);
+  if (versionMatch) {
+    return Number.parseInt(versionMatch[1], 10);
+  }
+
+  const iosMatch = userAgent.match(/OS (\d+)_\d+(?:_\d+)? like Mac OS X/);
+  if (iosMatch) {
+    return Number.parseInt(iosMatch[1], 10);
+  }
+
+  return null;
+}
+
+export function shouldPreferNativeHeicRendering() {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const userAgent = navigator.userAgent;
+  if (!isLikelySafariUserAgent(userAgent)) {
+    return false;
+  }
+
+  const safariMajorVersion = parseSafariMajorVersion(userAgent);
+  return safariMajorVersion != null && safariMajorVersion >= 17;
+}
+
 export function getUploadMimeType(file: File) {
   if (file.type) return file.type;
   if (isHeicFileName(file.name)) return 'image/heic';
@@ -44,14 +78,11 @@ export function getUploadMimeType(file: File) {
 }
 
 export async function convertHeicBlobToJpegBlob(blob: Blob) {
-  const { default: heic2any } = await import('heic2any');
-  const converted = await heic2any({
+  return heicTo({
     blob,
-    toType: 'image/jpeg',
+    type: 'image/jpeg',
     quality: 0.92,
   });
-
-  return Array.isArray(converted) ? converted[0] : converted;
 }
 
 const convertedSourceCache = new Map<string, Promise<Blob>>();
@@ -65,7 +96,14 @@ export function convertHeicSourceToJpegBlob(src: string) {
       if (!response.ok) {
         throw new Error(`Failed to load HEIC media: ${response.status}`);
       }
-      return response.blob();
+
+      return response.blob().then((blob) => {
+        if (blob.size === 0) {
+          throw new Error('Failed to load HEIC media: empty blob');
+        }
+
+        return blob;
+      });
     })
     .then(convertHeicBlobToJpegBlob)
     .catch((error) => {

--- a/wetty-chat-mobile/src/utils/heicMedia.ts
+++ b/wetty-chat-mobile/src/utils/heicMedia.ts
@@ -40,7 +40,10 @@ export function isSupportedMediaFile(file: File) {
 }
 
 function isLikelySafariUserAgent(userAgent: string) {
-  return /Safari\//.test(userAgent) && !/(Chrome|Chromium|CriOS|Edg|EdgiOS|OPR|FxiOS|Firefox|SamsungBrowser)\//.test(userAgent);
+  return (
+    /Safari\//.test(userAgent) &&
+    !/(Chrome|Chromium|CriOS|Edg|EdgiOS|OPR|FxiOS|Firefox|SamsungBrowser)\//.test(userAgent)
+  );
 }
 
 function parseSafariMajorVersion(userAgent: string) {


### PR DESCRIPTION
## Summary
- replace the HEIC preview fallback library from \\heic2any\\ to \\heic-to/csp\\
- keep normal image preview behavior unchanged and continue converting only HEIC-like sources
- prefer native HEIC rendering on Safari 17+ / iOS 17+ and use the heic-to fallback elsewhere

## Verification
- npm run verify
- npm run build-prod

Follow-up to #319.