### PR TITLE
Refactor text selection handling in message bubbles

### DIFF
--- a/wetty-chat-flutter/lib/features/conversation/message_bubble/presentation/parts/linkified_text.dart
+++ b/wetty-chat-flutter/lib/features/conversation/message_bubble/presentation/parts/linkified_text.dart
@@ -2,6 +2,7 @@ import 'package:chahua/app/theme/style_config.dart';
 import 'package:chahua/features/shared/model/message/message.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart' show SelectionArea;
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../domain/bubble_theme_v2.dart';
@@ -43,7 +44,11 @@ class LinkifiedText extends StatelessWidget {
         WidgetSpan(child: SizedBox(width: theme.timeSpacerWidth, height: 14)),
       ],
     );
-    return Text.rich(span);
+    final text = Text.rich(span);
+    if (theme.isTextSelectable) {
+      return SelectionArea(child: text);
+    }
+    return text;
   }
 
   List<InlineSpan> _buildLinkedSpans(

--- a/wetty-chat-flutter/lib/features/conversation/timeline/presentation/message_overlay/message_overlay_bubble_v2.dart
+++ b/wetty-chat-flutter/lib/features/conversation/timeline/presentation/message_overlay/message_overlay_bubble_v2.dart
@@ -3,7 +3,6 @@ import 'package:chahua/features/conversation/timeline/model/message_long_press_d
 import 'package:chahua/features/shared/model/message/message.dart'
     hide MessageItem;
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart' show SelectionArea;
 
 class MessageOverlayBubbleV2 extends StatelessWidget {
   const MessageOverlayBubbleV2({super.key, required this.details});
@@ -27,7 +26,7 @@ class MessageOverlayBubbleV2 extends StatelessWidget {
       ),
     );
     if (isTextSelectable) {
-      return SelectionArea(child: bubble);
+      return bubble;
     }
     return IgnorePointer(child: bubble);
   }

--- a/wetty-chat-flutter/test/features/conversation/message_bubble/message_overlay_bubble_v2_test.dart
+++ b/wetty-chat-flutter/test/features/conversation/message_bubble/message_overlay_bubble_v2_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  testWidgets('overlay bubble renders message text as selectable', (
+  testWidgets('overlay bubble renders main message text as selectable', (
     tester,
   ) async {
     await _pumpWithSettings(
@@ -22,7 +22,7 @@ void main() {
           message: _textMessage(),
           bubbleRect: const Rect.fromLTWH(0, 0, 240, 80),
           isMe: false,
-          sourceShowsSenderName: false,
+          sourceShowsSenderName: true,
         ),
       ),
     );


### PR DESCRIPTION
- Updated `LinkifiedText` to wrap text in a `SelectionArea` when `isTextSelectable` is true, allowing for selectable text.
- Removed unnecessary `SelectionArea` from `MessageOverlayBubbleV2` to streamline the rendering logic.
- Adjusted test case to reflect changes in message text selection behavior.