### PR TITLE
frontend/chore: rename draft-related types and variables

### DIFF
--- a/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
@@ -116,15 +116,15 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
     }, []);
 
     const {
-      drafts,
+      uploads,
       existingAttachments,
       previewItems,
-      hasUploadingDraft,
-      hasFailedDraft,
+      hasPending,
+      hasFailed,
       queueFiles,
       clearAll,
-      removeDraft,
-      retryDraft,
+      removeUpload,
+      retryUpload,
       removeExistingAttachment,
     } = useComposeAttachments({
       uploadAttachment,
@@ -139,12 +139,12 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
 
     const handleSend = useCallback(() => {
       const trimmed = toWireFormat(text.trim());
-      const uploadedDrafts = drafts.filter(
-        (draftRecord) => draftRecord.draft.status === 'uploaded' && Boolean(draftRecord.draft.attachmentId),
+      const uploadedRecords = uploads.filter(
+        (record) => record.state.status === 'uploaded' && Boolean(record.state.attachmentId),
       );
       const attachmentIds = [
         ...existingAttachments.map((attachment) => attachment.id),
-        ...uploadedDrafts.map((draftRecord) => draftRecord.draft.attachmentId!),
+        ...uploadedRecords.map((record) => record.state.attachmentId!),
       ];
 
       if (!trimmed && attachmentIds.length === 0) return;
@@ -154,13 +154,13 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
         text: trimmed,
         attachmentIds,
         existingAttachments,
-        uploadedAttachments: uploadedDrafts.map((draftRecord) => ({
-          attachmentId: draftRecord.draft.attachmentId!,
-          file: draftRecord.file,
-          mimeType: draftRecord.draft.mimeType,
-          size: draftRecord.draft.size,
-          width: draftRecord.draft.width,
-          height: draftRecord.draft.height,
+        uploadedAttachments: uploadedRecords.map((record) => ({
+          attachmentId: record.state.attachmentId!,
+          file: record.file,
+          mimeType: record.state.mimeType,
+          size: record.state.size,
+          width: record.state.width,
+          height: record.state.height,
         })),
       });
       setText('');
@@ -168,13 +168,13 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
       clearMentions();
       const ta = textareaRef.current;
       if (ta) ta.style.height = 'auto';
-    }, [clearAll, clearMentions, drafts, existingAttachments, onSend, text, toWireFormat]);
+    }, [clearAll, clearMentions, uploads, existingAttachments, onSend, text, toWireFormat]);
 
-    const uploadedDrafts = drafts.filter((draftRecord) => draftRecord.draft.status === 'uploaded');
+    const uploadedRecords = uploads.filter((record) => record.state.status === 'uploaded');
     const currentAttachmentIds = [
       ...existingAttachments.map((attachment) => attachment.id),
-      ...uploadedDrafts
-        .map((draftRecord) => draftRecord.draft.attachmentId)
+      ...uploadedRecords
+        .map((record) => record.state.attachmentId)
         .filter((attachmentId): attachmentId is string => Boolean(attachmentId)),
     ];
     const hasAttachment = currentAttachmentIds.length > 0;
@@ -186,11 +186,9 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
       trimmedText === originalEditText &&
       currentAttachmentIds.length === originalAttachmentIds.length &&
       currentAttachmentIds.every((attachmentId, index) => attachmentId === originalAttachmentIds[index]);
-    const canSend =
-      !hasUploadingDraft && !hasFailedDraft && (trimmedText.length > 0 || hasAttachment) && !isUnchangedEdit;
-    const canStartVoiceBase =
-      trimmedText.length === 0 && !hasAttachment && !editing && !hasUploadingDraft && !hasFailedDraft;
-    const canRequestRecentEdit = !editing && !replyTo && text.length === 0 && !hasAttachment && drafts.length === 0;
+    const canSend = !hasPending && !hasFailed && (trimmedText.length > 0 || hasAttachment) && !isUnchangedEdit;
+    const canStartVoiceBase = trimmedText.length === 0 && !hasAttachment && !editing && !hasPending && !hasFailed;
+    const canRequestRecentEdit = !editing && !replyTo && text.length === 0 && !hasAttachment && uploads.length === 0;
 
     const {
       voiceRecorder,
@@ -345,9 +343,9 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
                   removeExistingAttachment(localId);
                   return;
                 }
-                removeDraft(localId);
+                removeUpload(localId);
               }}
-              onRetry={retryDraft}
+              onRetry={retryUpload}
             />
 
             {voiceRecorder ? (

--- a/wetty-chat-mobile/src/components/chat/compose/UploadPreview.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/UploadPreview.tsx
@@ -5,9 +5,9 @@ import { DisplayableImage } from '@/components/shared/DisplayableImage';
 import { isHeicLikeMedia } from '@/utils/heicMedia';
 import styles from './UploadPreview.module.scss';
 
-export type ComposeUploadDraftStatus = 'uploading' | 'uploaded' | 'error';
+export type UploadStatus = 'uploading' | 'uploaded' | 'error';
 
-export interface ImageUploadDraft {
+export interface UploadFileState {
   localId: string;
   kind: 'image' | 'video';
   name: string;
@@ -18,7 +18,7 @@ export interface ImageUploadDraft {
   height?: number;
   order?: number;
   progress: number;
-  status: ComposeUploadDraftStatus;
+  status: UploadStatus;
   attachmentId?: string;
   errorMessage?: string;
 }
@@ -32,7 +32,7 @@ export interface ExistingAttachmentPreview {
 }
 
 export type UploadPreviewItem =
-  | ({ itemType: 'draft' } & ImageUploadDraft)
+  | ({ itemType: 'pending' } & UploadFileState)
   | ({ itemType: 'existing' } & ExistingAttachmentPreview);
 
 interface UploadPreviewProps {
@@ -47,7 +47,7 @@ export function UploadPreview({ items, onRemove, onRetry }: UploadPreviewProps) 
   return (
     <div className={styles.previewTray} aria-label={t`Attachment preview tray`}>
       {items.map((item) => {
-        const mimeType = item.itemType === 'draft' ? item.mimeType : item.kind;
+        const mimeType = item.itemType === 'pending' ? item.mimeType : item.kind;
         const isImagePreview =
           item.kind === 'image' || item.kind.startsWith('image/') || isHeicLikeMedia({ mimeType, fileName: item.name });
 
@@ -80,7 +80,7 @@ export function UploadPreview({ items, onRemove, onRetry }: UploadPreviewProps) 
               <IonIcon icon={closeCircle} />
             </button>
 
-            {item.itemType === 'draft' && item.status !== 'uploaded' && (
+            {item.itemType === 'pending' && item.status !== 'uploaded' && (
               <div className={`${styles.overlay} ${item.status === 'error' ? styles.overlayError : ''}`}>
                 {item.status === 'uploading' ? (
                   <>
@@ -117,5 +117,5 @@ export function UploadPreview({ items, onRemove, onRetry }: UploadPreviewProps) 
 }
 
 // When file/video/audio previews are added, keep this tray-level API unchanged and
-// branch on draft.kind into dedicated card renderers. The compose bar should continue
-// to own draft lifecycle, while this component stays focused on presentation/actions.
+// branch on file.kind into dedicated card renderers. The compose bar should continue
+// to own upload lifecycle, while this component stays focused on presentation/actions.

--- a/wetty-chat-mobile/src/components/chat/compose/types.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/types.ts
@@ -1,6 +1,6 @@
 import type { Attachment, MentionInfo } from '@/api/messages';
 import type { StickerSummary } from '@/api/stickers';
-import type { ImageUploadDraft } from '@/components/chat/compose/UploadPreview';
+import type { UploadFileState } from '@/components/chat/compose/UploadPreview';
 
 export interface ReplyTo {
   messageId: string;
@@ -66,13 +66,13 @@ export interface ComposeSendStickerPayload {
 
 export type ComposeSendPayload = ComposeSendTextPayload | ComposeSendAudioPayload | ComposeSendStickerPayload;
 
-export interface DraftUploadRecord {
-  draft: ImageUploadDraft;
+export interface UploadRecord {
+  state: UploadFileState;
   file: File;
   abortController?: AbortController;
 }
 
-export interface RecordedVoiceDraft {
+export interface RecordedVoiceData {
   file: File;
   mimeType: string;
   size: number;
@@ -88,4 +88,4 @@ export type VoiceRecorderState =
   | ({
       phase: 'recorded' | 'uploading';
       uploadProgress: number;
-    } & RecordedVoiceDraft);
+    } & RecordedVoiceData);

--- a/wetty-chat-mobile/src/components/chat/compose/useComposeAttachments.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/useComposeAttachments.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { t } from '@lingui/core/macro';
 import type { Attachment } from '@/api/messages';
 import type { UploadPreviewItem } from '@/components/chat/compose/UploadPreview';
-import type { ComposeUploadInput, ComposeUploadResult, DraftUploadRecord } from './types';
+import type { ComposeUploadInput, ComposeUploadResult, UploadRecord } from './types';
 
 import { MAX_ATTACHMENTS_PER_MESSAGE } from '@/constants/media';
 import {
@@ -18,12 +18,12 @@ import {
 
 const isAbortError = (error: unknown) => error instanceof DOMException && error.name === 'AbortError';
 
-const createDraftId = () => {
+const createUploadId = () => {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
 
-  return `draft_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+  return `upload_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 };
 
 const getNativeImageDimensions = (file: File): Promise<{ width?: number; height?: number }> =>
@@ -107,112 +107,112 @@ export function useComposeAttachments({
   onError,
   maxAttachments = MAX_ATTACHMENTS_PER_MESSAGE,
 }: UseComposeAttachmentsArgs) {
-  const [drafts, setDrafts] = useState<DraftUploadRecord[]>([]);
+  const [uploads, setUploads] = useState<UploadRecord[]>([]);
   const [existingAttachments, setExistingAttachments] = useState<Attachment[]>(initialExistingAttachments);
-  const draftsRef = useRef<DraftUploadRecord[]>([]);
+  const uploadsRef = useRef<UploadRecord[]>([]);
 
-  const cleanupDraft = useCallback((draftRecord: DraftUploadRecord) => {
-    draftRecord.abortController?.abort();
-    URL.revokeObjectURL(draftRecord.draft.previewUrl);
+  const cleanupRecord = useCallback((record: UploadRecord) => {
+    record.abortController?.abort();
+    URL.revokeObjectURL(record.state.previewUrl);
   }, []);
 
-  const clearDrafts = useCallback(
-    (currentDrafts: DraftUploadRecord[]) => {
-      currentDrafts.forEach(cleanupDraft);
-      setDrafts([]);
+  const clearUploads = useCallback(
+    (currentUploads: UploadRecord[]) => {
+      currentUploads.forEach(cleanupRecord);
+      setUploads([]);
     },
-    [cleanupDraft],
+    [cleanupRecord],
   );
 
   useEffect(() => {
-    draftsRef.current = drafts;
-  }, [drafts]);
+    uploadsRef.current = uploads;
+  }, [uploads]);
 
   useEffect(
     () => () => {
-      draftsRef.current.forEach(cleanupDraft);
+      uploadsRef.current.forEach(cleanupRecord);
     },
-    [cleanupDraft],
+    [cleanupRecord],
   );
 
   const startUpload = useCallback(
     async (localId: string, file: File) => {
       const abortController = new AbortController();
 
-      setDrafts((prev) =>
-        prev.map((draftRecord) =>
-          draftRecord.draft.localId === localId
+      setUploads((prev) =>
+        prev.map((record) =>
+          record.state.localId === localId
             ? {
-                ...draftRecord,
+                ...record,
                 abortController,
-                draft: {
-                  ...draftRecord.draft,
+                state: {
+                  ...record.state,
                   status: 'uploading',
                   progress: 0,
                   errorMessage: undefined,
                   attachmentId: undefined,
                 },
               }
-            : draftRecord,
+            : record,
         ),
       );
 
       try {
         const dimensions = await getMediaDimensions(file);
-        const currentDraft = draftsRef.current.find((r) => r.draft.localId === localId)?.draft;
+        const currentState = uploadsRef.current.find((r) => r.state.localId === localId)?.state;
 
-        setDrafts((prev) =>
-          prev.map((draftRecord) =>
-            draftRecord.draft.localId === localId
+        setUploads((prev) =>
+          prev.map((record) =>
+            record.state.localId === localId
               ? {
-                  ...draftRecord,
-                  draft: {
-                    ...draftRecord.draft,
+                  ...record,
+                  state: {
+                    ...record.state,
                     width: dimensions.width,
                     height: dimensions.height,
                   },
                 }
-              : draftRecord,
+              : record,
           ),
         );
 
         const result = await uploadAttachment({
           file,
           dimensions,
-          order: currentDraft?.order,
+          order: currentState?.order,
           signal: abortController.signal,
           onProgress: (progress) => {
-            setDrafts((prev) =>
-              prev.map((draftRecord) =>
-                draftRecord.draft.localId === localId
+            setUploads((prev) =>
+              prev.map((record) =>
+                record.state.localId === localId
                   ? {
-                      ...draftRecord,
-                      draft: {
-                        ...draftRecord.draft,
+                      ...record,
+                      state: {
+                        ...record.state,
                         progress,
                       },
                     }
-                  : draftRecord,
+                  : record,
               ),
             );
           },
         });
 
-        setDrafts((prev) =>
-          prev.map((draftRecord) =>
-            draftRecord.draft.localId === localId
+        setUploads((prev) =>
+          prev.map((record) =>
+            record.state.localId === localId
               ? {
-                  ...draftRecord,
+                  ...record,
                   abortController: undefined,
-                  draft: {
-                    ...draftRecord.draft,
+                  state: {
+                    ...record.state,
                     status: 'uploaded',
                     progress: 100,
                     attachmentId: result.attachmentId,
                     errorMessage: undefined,
                   },
                 }
-              : draftRecord,
+              : record,
           ),
         );
       } catch (error) {
@@ -221,21 +221,21 @@ export function useComposeAttachments({
         }
 
         console.error('Failed to upload attachment:', error);
-        setDrafts((prev) =>
-          prev.map((draftRecord) =>
-            draftRecord.draft.localId === localId
+        setUploads((prev) =>
+          prev.map((record) =>
+            record.state.localId === localId
               ? {
-                  ...draftRecord,
+                  ...record,
                   abortController: undefined,
-                  draft: {
-                    ...draftRecord.draft,
+                  state: {
+                    ...record.state,
                     status: 'error',
                     progress: 0,
                     attachmentId: undefined,
                     errorMessage: t`Upload failed`,
                   },
                 }
-              : draftRecord,
+              : record,
           ),
         );
       }
@@ -249,7 +249,7 @@ export function useComposeAttachments({
       if (mediaFiles.length === 0) return;
 
       let allowedFiles = mediaFiles;
-      const currentCount = existingAttachments.length + draftsRef.current.length;
+      const currentCount = existingAttachments.length + uploadsRef.current.length;
       if (currentCount + mediaFiles.length > maxAttachments) {
         const available = Math.max(0, maxAttachments - currentCount);
         if (onError) {
@@ -259,10 +259,10 @@ export function useComposeAttachments({
         allowedFiles = mediaFiles.slice(0, available);
       }
 
-      const queuedDrafts: DraftUploadRecord[] = allowedFiles.map((file, index) => ({
+      const queuedRecords: UploadRecord[] = allowedFiles.map((file, index) => ({
         file,
-        draft: {
-          localId: createDraftId(),
+        state: {
+          localId: createUploadId(),
           kind: isImageFile(file) ? 'image' : 'video',
           name: file.name,
           previewUrl: URL.createObjectURL(file),
@@ -274,9 +274,9 @@ export function useComposeAttachments({
         },
       }));
 
-      setDrafts((prev) => [...prev, ...queuedDrafts]);
-      queuedDrafts.forEach(({ draft, file }) => {
-        void startUpload(draft.localId, file);
+      setUploads((prev) => [...prev, ...queuedRecords]);
+      queuedRecords.forEach(({ state, file }) => {
+        void startUpload(state.localId, file);
       });
     },
     [startUpload, existingAttachments, maxAttachments, onError],
@@ -307,23 +307,23 @@ export function useComposeAttachments({
     return () => document.removeEventListener('paste', handleGlobalPaste);
   }, [containerRef, queueFiles]);
 
-  const removeDraft = useCallback(
+  const removeUpload = useCallback(
     (localId: string) => {
-      setDrafts((prev) => {
-        const draftToRemove = prev.find((draftRecord) => draftRecord.draft.localId === localId);
-        if (draftToRemove) {
-          cleanupDraft(draftToRemove);
+      setUploads((prev) => {
+        const toRemove = prev.find((record) => record.state.localId === localId);
+        if (toRemove) {
+          cleanupRecord(toRemove);
         }
 
-        return prev.filter((draftRecord) => draftRecord.draft.localId !== localId);
+        return prev.filter((record) => record.state.localId !== localId);
       });
     },
-    [cleanupDraft],
+    [cleanupRecord],
   );
 
-  const retryDraft = useCallback(
+  const retryUpload = useCallback(
     (localId: string) => {
-      const file = draftsRef.current.find((draftRecord) => draftRecord.draft.localId === localId)?.file;
+      const file = uploadsRef.current.find((record) => record.state.localId === localId)?.file;
       if (!file) return;
       void startUpload(localId, file);
     },
@@ -337,11 +337,11 @@ export function useComposeAttachments({
 
   const clearAll = useCallback(() => {
     setExistingAttachments([]);
-    clearDrafts(draftsRef.current);
-  }, [clearDrafts]);
+    clearUploads(uploadsRef.current);
+  }, [clearUploads]);
 
-  const hasUploadingDraft = drafts.some((draftRecord) => draftRecord.draft.status === 'uploading');
-  const hasFailedDraft = drafts.some((draftRecord) => draftRecord.draft.status === 'error');
+  const hasPending = uploads.some((record) => record.state.status === 'uploading');
+  const hasFailed = uploads.some((record) => record.state.status === 'error');
 
   const previewItems: UploadPreviewItem[] = [
     ...existingAttachments.map((attachment) => ({
@@ -360,22 +360,22 @@ export function useComposeAttachments({
           ? attachment.url
           : undefined,
     })),
-    ...drafts.map((draftRecord) => ({
-      itemType: 'draft' as const,
-      ...draftRecord.draft,
+    ...uploads.map((record) => ({
+      itemType: 'pending' as const,
+      ...record.state,
     })),
   ];
 
   return {
-    drafts,
+    uploads,
     existingAttachments,
     previewItems,
-    hasUploadingDraft,
-    hasFailedDraft,
+    hasPending,
+    hasFailed,
     queueFiles,
     clearAll,
-    removeDraft,
-    retryDraft,
+    removeUpload,
+    retryUpload,
     removeExistingAttachment,
   };
 }

--- a/wetty-chat-mobile/src/components/chat/compose/useVoiceRecorder.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/useVoiceRecorder.ts
@@ -4,7 +4,7 @@ import type {
   ComposeSendAudioPayload,
   ComposeUploadInput,
   ComposeUploadResult,
-  RecordedVoiceDraft,
+  RecordedVoiceData,
   VoiceRecorderState,
 } from './types';
 
@@ -135,19 +135,19 @@ export function useVoiceRecorder({
     setVoiceRecorderState(null);
   }, [setVoiceRecorderState, stopVoiceStream]);
 
-  const uploadAndSendDraft = useCallback(
-    async (draft: RecordedVoiceDraft) => {
+  const uploadAndSendVoice = useCallback(
+    async (voiceData: RecordedVoiceData) => {
       const uploadAbortController = new AbortController();
       voiceUploadAbortControllerRef.current = uploadAbortController;
       setVoiceRecorderState({
         phase: 'uploading',
-        ...draft,
+        ...voiceData,
         uploadProgress: 0,
       });
 
       try {
         const result = await uploadAttachment({
-          file: draft.file,
+          file: voiceData.file,
           signal: uploadAbortController.signal,
           onProgress: (progress) => {
             setVoiceRecorder((currentVoice) =>
@@ -163,13 +163,13 @@ export function useVoiceRecorder({
 
         onSend({
           kind: 'audio',
-          durationMs: draft.durationMs,
+          durationMs: voiceData.durationMs,
           attachmentId: result.attachmentId,
           uploadedAttachment: {
             attachmentId: result.attachmentId,
-            file: draft.file,
-            mimeType: draft.mimeType,
-            size: draft.size,
+            file: voiceData.file,
+            mimeType: voiceData.mimeType,
+            size: voiceData.size,
           },
         });
         setVoiceRecorder(null);
@@ -179,7 +179,7 @@ export function useVoiceRecorder({
           reportVoiceError(t`Failed to send voice message.`);
           setVoiceRecorderState({
             phase: 'recorded',
-            ...draft,
+            ...voiceData,
             uploadProgress: 0,
           });
         } else {
@@ -207,7 +207,7 @@ export function useVoiceRecorder({
 
       if (current.phase !== 'recording') {
         if (action === 'send' && current.phase === 'recorded') {
-          void uploadAndSendDraft(current);
+          void uploadAndSendVoice(current);
         } else if (action === 'cancel' && current.phase === 'recorded') {
           resetVoiceRecorder();
         }
@@ -231,7 +231,7 @@ export function useVoiceRecorder({
 
       recorder.stop();
     },
-    [resetVoiceRecorder, setVoiceRecorderState, uploadAndSendDraft],
+    [resetVoiceRecorder, setVoiceRecorderState, uploadAndSendVoice],
   );
 
   const startVoiceRecording = useCallback(async () => {
@@ -335,7 +335,7 @@ export function useVoiceRecorder({
             lastModified: Date.now(),
           },
         );
-        const draft: RecordedVoiceDraft = {
+        const voiceData: RecordedVoiceData = {
           file,
           mimeType: blobType,
           size: file.size,
@@ -343,13 +343,13 @@ export function useVoiceRecorder({
         };
 
         if (finalAction === 'send') {
-          await uploadAndSendDraft(draft);
+          await uploadAndSendVoice(voiceData);
           return;
         }
 
         setVoiceRecorderState({
           phase: 'recorded',
-          ...draft,
+          ...voiceData,
           uploadProgress: 0,
         });
       };
@@ -378,7 +378,7 @@ export function useVoiceRecorder({
     reportVoiceError,
     setVoiceRecorderState,
     stopVoiceStream,
-    uploadAndSendDraft,
+    uploadAndSendVoice,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This PR renames most of the variables that previously included the word `draft` (which were primarily related to handling attachment uploads).

I'm planning to introduce a text draft saving feature. Making these renames ahead of time prevents naming conflicts or confusion down the line.

