### PR TITLE
frontend/feature: local saving for chat drafts

### DIFF
--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -288,6 +288,9 @@ msgstr "Download"
 msgid "Download image"
 msgstr "Download image"
 
+msgid "Draft: "
+msgstr "Draft: "
+
 msgid "Drop images or videos"
 msgstr "Drop images or videos"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -288,6 +288,9 @@ msgstr "下载"
 msgid "Download image"
 msgstr "下载图片"
 
+msgid "Draft: "
+msgstr "草稿："
+
 msgid "Drop images or videos"
 msgstr "拖放图片或视频"
 

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -288,6 +288,9 @@ msgstr "下載"
 msgid "Download image"
 msgstr "下載圖片"
 
+msgid "Draft: "
+msgstr "草稿："
+
 msgid "Drop images or videos"
 msgstr "拖放圖片或影片"
 

--- a/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
@@ -16,6 +16,7 @@ import { MentionAutocomplete } from './MentionAutocomplete';
 import type { StickerSummary } from '@/api/stickers';
 import type { ComposeSendPayload, ComposeUploadInput, ComposeUploadResult, EditingMessage, ReplyTo } from './types';
 import { isSupportedMediaFile } from '@/utils/heicMedia';
+import { useChatDraft, loadDraft } from '@/hooks/useChatDraft';
 export type {
   ComposeSendAudioPayload,
   ComposeSendPayload,
@@ -29,6 +30,8 @@ export type {
 
 interface MessageComposeBarProps {
   chatId?: string | number;
+  draftKey?: string;
+  onRestoreReply?: (replyToMessageId: string) => void;
   onSend: (payload: ComposeSendPayload) => void;
   uploadAttachment: (input: ComposeUploadInput) => Promise<ComposeUploadResult>;
   replyTo?: ReplyTo;
@@ -58,6 +61,8 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
   function MessageComposeBarInner(
     {
       chatId,
+      draftKey: draftKeyProp,
+      onRestoreReply,
       onSend,
       uploadAttachment,
       replyTo,
@@ -70,14 +75,51 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
     }: MessageComposeBarProps,
     ref,
   ) {
+    const draftKeyValue = draftKeyProp ?? String(chatId ?? '');
+    const isEditing = editing != null;
+    const { saveDebounced, clear: clearDraft } = useChatDraft(isEditing ? undefined : draftKeyValue);
+
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const [text, setText] = useState(() => editing?.text ?? '');
+    const [draftLoaded, setDraftLoaded] = useState(false);
     const [stickerPickerOpen, setStickerPickerOpen] = useState(false);
     const stickerOverlayActiveRef = useRef(false);
     const [isDragOver, setIsDragOver] = useState(false);
     const dragCounterRef = useRef(0);
+
+    useEffect(() => {
+      if (!draftKeyValue || isEditing) {
+        setDraftLoaded(true);
+        return;
+      }
+
+      let canceled = false;
+      void loadDraft(draftKeyValue).then((draft) => {
+        if (canceled) return;
+        if (draft) {
+          setText(draft.text);
+          if (draft.replyToMessageId) {
+            onRestoreReply?.(draft.replyToMessageId);
+          }
+        }
+        setDraftLoaded(true);
+      });
+
+      return () => {
+        canceled = true;
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [draftKeyValue]);
+
+    useEffect(() => {
+      if (!draftLoaded || isEditing) return;
+      saveDebounced({
+        text,
+        replyToMessageId: replyTo?.messageId,
+      });
+    }, [text, replyTo?.messageId, draftLoaded, isEditing, saveDebounced]);
 
     const {
       mentionState,
@@ -166,9 +208,10 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
       setText('');
       clearAll();
       clearMentions();
+      clearDraft();
       const ta = textareaRef.current;
       if (ta) ta.style.height = 'auto';
-    }, [clearAll, clearMentions, uploads, existingAttachments, onSend, text, toWireFormat]);
+    }, [clearAll, clearDraft, clearMentions, uploads, existingAttachments, onSend, text, toWireFormat]);
 
     const uploadedRecords = uploads.filter((record) => record.state.status === 'uploaded');
     const currentAttachmentIds = [

--- a/wetty-chat-mobile/src/components/chat/lists/ChatList.module.scss
+++ b/wetty-chat-mobile/src/components/chat/lists/ChatList.module.scss
@@ -94,6 +94,11 @@
   text-transform: none;
 }
 
+.chatsListDraftLabel {
+  color: var(--ion-color-danger, #eb445a);
+  font-weight: 500;
+}
+
 .chatListItem {
   color: inherit;
 }
@@ -112,6 +117,10 @@
 
   .chatsListPreviewSender {
     color: var(--ion-color-primary-contrast);
+  }
+
+  .chatsListDraftLabel {
+    color: inherit;
   }
 
   .chatsListPreview {

--- a/wetty-chat-mobile/src/components/chat/lists/ChatList.tsx
+++ b/wetty-chat-mobile/src/components/chat/lists/ChatList.tsx
@@ -51,7 +51,10 @@ import { markChatAsUnread, markMessagesAsRead, type MessagePreview, type Message
 import { syncAppBadgeCount } from '@/utils/badges';
 import { getChatDisplayName } from '@/utils/chatDisplay';
 import { UserAvatar } from '@/components/UserAvatar';
-import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
+import { formatMessagePreview, getNotificationPreviewLabels, truncatePreview } from '@/utils/messagePreview';
+import { getAllDrafts } from '@/utils/draftSync';
+import { onDraftChange } from '@/utils/draftEvents';
+import { loadDraft } from '@/hooks/useChatDraft';
 import { buildResumeHash } from '@/types/chatThreadNavigation';
 import { CHAT_LIST_REFRESH_MIN_DURATION_MS } from '@/constants/chatTiming';
 import { type ChatListTab, ChatListSegment } from '@/components/chat/lists/ChatListSegment';
@@ -168,6 +171,7 @@ export function ChatList({
   const messageChats = useSelector((state: RootState) => state.messages.chats);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [activeTab, setActiveTab] = useState<ChatListTab>(initialTab ?? (showAllTab ? 'all' : 'groups'));
   const effectiveTab = activeTab === 'all' && !showAllTab ? 'groups' : activeTab;
   const chats = archivedMode ? archivedChats : activeChats;
@@ -207,17 +211,39 @@ export function ChatList({
 
   useEffect(() => {
     loadLists()
-      .then(() => {
-        setError(null);
-      })
+      .then(() => setError(null))
       .catch((err: Error) => setError(err.message || t`Failed to load chats`))
       .finally(() => setLoading(false));
     void updateAppBadge();
+
+    getAllDrafts()
+      .then((draftsMap) => setDrafts(draftsMap))
+      .catch(() => {});
   }, [loadLists, updateAppBadge]);
 
   useEffect(() => {
     void updateAppBadge();
   }, [unreadChats, unreadThreads, updateAppBadge]);
+
+  useEffect(() => {
+    const unsubscribe = onDraftChange((draftKey) => {
+      loadDraft(draftKey)
+        .then((draft) => {
+          setDrafts((prev) => {
+            if (draft) {
+              return { ...prev, [draftKey]: draft.text };
+            }
+            // Draft was cleared — remove from map
+            const next = { ...prev };
+            delete next[draftKey];
+            return next;
+          });
+        })
+        .catch(() => {});
+    });
+
+    return unsubscribe;
+  }, []);
 
   const handleToggleRead = async (chat: ChatListEntry, slidingItem: HTMLIonItemSlidingElement | null) => {
     slidingItem?.close();
@@ -297,9 +323,7 @@ export function ChatList({
     const startTime = Date.now();
 
     loadLists()
-      .then(() => {
-        setError(null);
-      })
+      .then(() => setError(null))
       .catch((err: Error) => {
         setError(err.message || t`Failed to refresh chats`);
       })
@@ -310,6 +334,11 @@ export function ChatList({
           event.detail.complete();
         }, delay);
       });
+
+    // Refresh drafts independently
+    getAllDrafts()
+      .then((draftsMap) => setDrafts(draftsMap))
+      .catch(() => {});
 
     void updateAppBadge();
   };
@@ -448,7 +477,16 @@ export function ChatList({
               <IonIcon aria-hidden="true" icon={notificationsOffOutline} className={styles.chatsListMutedIcon} />
             ) : null}
           </h3>
-          <p className={styles.chatsListPreview}>{getMessagePreview(chat.lastMessage, locale)}</p>
+          <p className={styles.chatsListPreview}>
+            {chat.id in drafts ? (
+              <>
+                <span className={styles.chatsListDraftLabel}>{t`Draft: `}</span>
+                {truncatePreview(drafts[chat.id])}
+              </>
+            ) : (
+              getMessagePreview(chat.lastMessage, locale)
+            )}
+          </p>
         </IonLabel>
         <div slot="end" className={styles.chatsListEndSlot}>
           <div className={styles.chatsListTime}>{formatLastActivity(chat.lastMessageAt, locale)}</div>
@@ -464,23 +502,27 @@ export function ChatList({
     </IonItemSliding>
   );
 
-  const renderThreadItem = (thread: StoredThreadListItem) => (
-    <ThreadListRow
-      key={`thread-${thread.threadRootMessage.id}`}
-      thread={thread}
-      locale={locale}
-      isActive={activeThreadId === thread.threadRootMessage.id}
-      onSelect={handleThreadSelect}
-      endAction={{
-        color: archivedMode ? 'success' : 'medium',
-        icon: archivedMode ? arrowUndoOutline : archiveOutline,
-        label: archivedMode ? t`Unarchive` : t`Archive`,
-        onAction: () => {
-          void handleArchiveThread(thread, archivedMode);
-        },
-      }}
-    />
-  );
+  const renderThreadItem = (thread: StoredThreadListItem) => {
+    const threadDraftKey = `${thread.chatId}_thread_${thread.threadRootMessage.id}`;
+    return (
+      <ThreadListRow
+        key={`thread-${thread.threadRootMessage.id}`}
+        thread={thread}
+        locale={locale}
+        isActive={activeThreadId === thread.threadRootMessage.id}
+        onSelect={handleThreadSelect}
+        draftText={drafts[threadDraftKey]}
+        endAction={{
+          color: archivedMode ? 'success' : 'medium',
+          icon: archivedMode ? arrowUndoOutline : archiveOutline,
+          label: archivedMode ? t`Unarchive` : t`Archive`,
+          onAction: () => {
+            void handleArchiveThread(thread, archivedMode);
+          },
+        }}
+      />
+    );
+  };
 
   const renderContent = () => {
     if (error) {

--- a/wetty-chat-mobile/src/components/chat/lists/ThreadListRow.module.scss
+++ b/wetty-chat-mobile/src/components/chat/lists/ThreadListRow.module.scss
@@ -23,6 +23,10 @@
     color: var(--ion-color-primary-contrast);
   }
 
+  .draftLabel {
+    color: inherit;
+  }
+
   .headerTime {
     color: rgba(var(--ion-color-primary-contrast-rgb), 0.8);
   }
@@ -127,6 +131,11 @@
 .latestReplySender {
   font-weight: 500;
   color: var(--ion-color-dark);
+}
+
+.draftLabel {
+  color: var(--ion-color-danger, #eb445a);
+  font-weight: 500;
 }
 
 .chatsListEndSlot {

--- a/wetty-chat-mobile/src/components/chat/lists/ThreadListRow.tsx
+++ b/wetty-chat-mobile/src/components/chat/lists/ThreadListRow.tsx
@@ -1,12 +1,13 @@
 import { type ReactNode, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { IonBadge, IonIcon, IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel } from '@ionic/react';
+import { t } from '@lingui/core/macro';
 import { toMessagePreview, type MessagePreview } from '@/api/messages';
 import type { StoredThreadListItem } from '@/api/threads';
 import { OverlayAvatar } from '@/components/OverlayAvatar';
 import type { RootState } from '@/store/index';
 import { selectLatestThreadReplyMessage } from '@/store/messagesSlice';
-import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
+import { formatMessagePreview, getNotificationPreviewLabels, truncatePreview } from '@/utils/messagePreview';
 import styles from './ThreadListRow.module.scss';
 
 function formatRelativeTime(isoString: string, locale: string): string {
@@ -41,6 +42,7 @@ interface ThreadListRowProps {
   thread: StoredThreadListItem;
   locale: string;
   isActive?: boolean;
+  draftText?: string;
   onSelect: (chatId: string, threadRootId: string) => void;
   endAction?: {
     color: string;
@@ -50,7 +52,7 @@ interface ThreadListRowProps {
   };
 }
 
-export function ThreadListRow({ thread, locale, isActive, onSelect, endAction }: ThreadListRowProps) {
+export function ThreadListRow({ thread, locale, isActive, draftText, onSelect, endAction }: ThreadListRowProps) {
   const rootMsg = thread.threadRootMessage;
   const rootPreview = formatMessagePreview(rootMsg, getNotificationPreviewLabels(locale));
 
@@ -87,11 +89,19 @@ export function ThreadListRow({ thread, locale, isActive, onSelect, endAction }:
       <IonLabel className={styles.bodyContent}>
         {/* Row 2: replied to */}
         <div className={styles.repliedTo}>{rootPreview || rootMsg.sender.name}</div>
-        {/* Row 3: latest reply */}
-        {lastReply && lastReplyPreview && (
+        {/* Row 3: latest reply or draft */}
+        {draftText !== undefined ? (
           <p className={styles.latestReply}>
-            <span className={styles.latestReplySender}>{lastReply.sender.name ?? 'User'}:</span> {lastReplyPreview}
+            <span className={styles.draftLabel}>{t`Draft: `}</span>
+            {truncatePreview(draftText)}
           </p>
+        ) : (
+          lastReply &&
+          lastReplyPreview && (
+            <p className={styles.latestReply}>
+              <span className={styles.latestReplySender}>{lastReply.sender.name ?? 'User'}:</span> {lastReplyPreview}
+            </p>
+          )
         )}
       </IonLabel>
       <div slot="end" className={styles.chatsListEndSlot}>

--- a/wetty-chat-mobile/src/hooks/useChatDraft.ts
+++ b/wetty-chat-mobile/src/hooks/useChatDraft.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { kvGet, kvSet, kvDelete } from '@/utils/db';
+import { notifyDraftChange } from '@/utils/draftEvents';
+import { DRAFT_KEY_PREFIX } from '@/utils/draftSync';
+
+export interface ChatDraft {
+  text: string;
+  replyToMessageId?: string;
+}
+
+const SAVE_DEBOUNCE_MS = 500;
+
+function draftKey(key: string): string {
+  return `${DRAFT_KEY_PREFIX}${key}`;
+}
+
+export async function loadDraft(key: string): Promise<ChatDraft | undefined> {
+  return kvGet<ChatDraft>(draftKey(key));
+}
+
+export async function saveDraft(key: string, draft: ChatDraft): Promise<void> {
+  if (!draft.text && !draft.replyToMessageId) {
+    // If both text and replyTo are empty, clear the draft instead of saving an empty one
+    await clearDraft(key);
+    return;
+  }
+  await kvSet(draftKey(key), draft);
+  notifyDraftChange(key);
+}
+
+export async function clearDraft(key: string): Promise<void> {
+  await kvDelete(draftKey(key));
+  notifyDraftChange(key);
+}
+
+/**
+ * Hook to manage chat compose drafts in IndexedDB.
+ * Returns a ref-backed save function so the latest draft can be saved
+ * without causing re-renders on every debounce cycle.
+ */
+export function useChatDraft(draftKeyValue: string | undefined) {
+  const draftKeyRef = useRef(draftKeyValue);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef<ChatDraft | null>(null);
+
+  useEffect(() => {
+    draftKeyRef.current = draftKeyValue;
+  }, [draftKeyValue]);
+
+  const saveDebounced = useCallback((draft: ChatDraft) => {
+    const key = draftKeyRef.current;
+    if (!key) return;
+
+    pendingRef.current = draft;
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = setTimeout(() => {
+      void saveDraft(key, draft);
+      pendingRef.current = null;
+      timerRef.current = null;
+    }, SAVE_DEBOUNCE_MS);
+  }, []);
+
+  const clear = useCallback(() => {
+    const key = draftKeyRef.current;
+    if (!key) return;
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    pendingRef.current = null;
+    void clearDraft(key);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+        const key = draftKeyRef.current;
+        const pending = pendingRef.current;
+        if (key && pending) {
+          void saveDraft(key, pending);
+        }
+      }
+    };
+  }, [draftKeyValue]);
+
+  return { saveDebounced, clear };
+}

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -1891,6 +1891,13 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
           <MessageComposeBar
             ref={composeBarRef}
             chatId={chatId}
+            draftKey={storeChatId}
+            onRestoreReply={(replyToMessageId) => {
+              const message = messageLookup.get(replyToMessageId);
+              if (message) {
+                setReplyingTo(message);
+              }
+            }}
             onSend={handleSend}
             uploadAttachment={uploadAttachment}
             onError={(message) => showToast(message, 3000)}

--- a/wetty-chat-mobile/src/utils/draftEvents.ts
+++ b/wetty-chat-mobile/src/utils/draftEvents.ts
@@ -1,0 +1,16 @@
+type DraftChangeListener = (draftKey: string) => void;
+
+const listeners = new Set<DraftChangeListener>();
+
+export function onDraftChange(fn: DraftChangeListener): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+export function notifyDraftChange(draftKey: string): void {
+  for (const fn of listeners) {
+    fn(draftKey);
+  }
+}

--- a/wetty-chat-mobile/src/utils/draftSync.ts
+++ b/wetty-chat-mobile/src/utils/draftSync.ts
@@ -1,0 +1,23 @@
+import { getDb } from '@/utils/db';
+import type { ChatDraft } from '@/hooks/useChatDraft';
+
+export const DRAFT_KEY_PREFIX = 'draft:';
+
+export async function getAllDrafts(): Promise<Record<string, string>> {
+  const db = await getDb();
+  const keys = await db.getAllKeys('kv');
+  const values = await db.getAll('kv');
+
+  const drafts: Record<string, string> = {};
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = values[i] as ChatDraft | undefined;
+    if (typeof key !== 'string' || !key.startsWith(DRAFT_KEY_PREFIX)) continue;
+    if (!value || typeof value !== 'object') continue;
+
+    const rawKey = key.slice(DRAFT_KEY_PREFIX.length);
+    drafts[rawKey] = value.text;
+  }
+
+  return drafts;
+}


### PR DESCRIPTION
This PR adds local draft saving for chats to prevent unsent text from being lost when switching between chats or closing the window.

Notes: This does not implement the cross-device draft sync requested in #56. 
Since #56 is the ultimate goal and this is likely just a transitional solution, I opted to simply store the local drafts in the existing IndexedDB KV store rather than creating a dedicated store for them.