### PR TITLE
feat: add dismiss delivered notifications when msgs are read

### DIFF
--- a/wetty-chat-flutter/ios/Runner/PushNotificationPlugin.swift
+++ b/wetty-chat-flutter/ios/Runner/PushNotificationPlugin.swift
@@ -61,6 +61,23 @@ class PushNotificationPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterD
         case "clearBadge":
             setBadge(0)
             result(nil)
+        case "dismissDeliveredNotificationsForConversation":
+            guard let args = call.arguments as? [String: Any],
+                  let chatId = args["chatId"] as? String
+            else {
+                result(FlutterError(
+                    code: "INVALID_ARGUMENTS",
+                    message: "chatId is required",
+                    details: nil
+                ))
+                return
+            }
+            let threadRootId = args["threadRootId"] as? String
+            dismissDeliveredNotificationsForConversation(
+                chatId: chatId,
+                threadRootId: threadRootId,
+                result: result
+            )
         case "getLaunchNotification":
             if let payload = launchNotificationPayload {
                 launchNotificationPayload = nil
@@ -162,6 +179,67 @@ class PushNotificationPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterD
                 UNUserNotificationCenter.current().setBadgeCount(count)
             }
             UIApplication.shared.applicationIconBadgeNumber = count
+        }
+    }
+
+    private func dismissDeliveredNotificationsForConversation(
+        chatId: String,
+        threadRootId: String?,
+        result: @escaping FlutterResult
+    ) {
+        let center = UNUserNotificationCenter.current()
+        center.getDeliveredNotifications { notifications in
+            let identifiers = notifications
+                .filter { self.matchesConversation($0, chatId: chatId, threadRootId: threadRootId) }
+                .map { $0.request.identifier }
+
+            if !identifiers.isEmpty {
+                center.removeDeliveredNotifications(withIdentifiers: identifiers)
+            }
+
+            DispatchQueue.main.async {
+                result(nil)
+            }
+        }
+    }
+
+    private func matchesConversation(
+        _ notification: UNNotification,
+        chatId: String,
+        threadRootId: String?
+    ) -> Bool {
+        let expectedThreadIdentifier: String
+        if let threadRootId = threadRootId, !threadRootId.isEmpty {
+            expectedThreadIdentifier = "chat_\(chatId)_thread_\(threadRootId)"
+        } else {
+            expectedThreadIdentifier = "chat_\(chatId)"
+        }
+
+        if notification.request.content.threadIdentifier == expectedThreadIdentifier {
+            return true
+        }
+
+        guard let wettyChatData = notification.request.content.userInfo["wettyChat"] as? [String: Any],
+              Self.stringValue(wettyChatData["chatId"]) == chatId
+        else {
+            return false
+        }
+
+        let notificationThreadRootId = Self.stringValue(wettyChatData["threadRootId"])
+        if let threadRootId = threadRootId, !threadRootId.isEmpty {
+            return notificationThreadRootId == threadRootId
+        }
+        return notificationThreadRootId == nil || notificationThreadRootId?.isEmpty == true
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        switch value {
+        case let string as String:
+            return string
+        case let number as NSNumber:
+            return number.stringValue
+        default:
+            return nil
         }
     }
 

--- a/wetty-chat-flutter/lib/core/notifications/apns_channel.dart
+++ b/wetty-chat-flutter/lib/core/notifications/apns_channel.dart
@@ -68,6 +68,20 @@ class ApnsChannel {
   /// Clears the app icon badge count.
   Future<void> clearBadge() => _channel.invokeMethod<void>('clearBadge');
 
+  /// Dismisses delivered notifications for a chat or one of its threads.
+  Future<void> dismissDeliveredNotificationsForConversation({
+    required int chatId,
+    int? threadRootId,
+  }) {
+    return _channel.invokeMethod<void>(
+      'dismissDeliveredNotificationsForConversation',
+      <String, dynamic>{
+        'chatId': chatId.toString(),
+        'threadRootId': ?threadRootId?.toString(),
+      },
+    );
+  }
+
   /// Returns the notification payload that launched the app (cold start),
   /// or `null` if the app was not launched from a notification.
   Future<Map<String, dynamic>?> getLaunchNotification() async {

--- a/wetty-chat-flutter/lib/core/notifications/push_platform_client.dart
+++ b/wetty-chat-flutter/lib/core/notifications/push_platform_client.dart
@@ -63,6 +63,10 @@ abstract class PushPlatformClient {
   Future<void> registerForRemoteNotifications();
   Future<void> unregisterForRemoteNotifications();
   Future<Map<String, dynamic>?> getLaunchNotification();
+  Future<void> dismissDeliveredNotificationsForConversation({
+    required int chatId,
+    int? threadRootId,
+  });
   Future<PushSubscriptionDescriptor?> subscriptionDescriptorForToken(
     String token,
   );
@@ -116,6 +120,17 @@ class ApnsPushPlatformClient implements PushPlatformClient {
   @override
   Future<Map<String, dynamic>?> getLaunchNotification() {
     return _apns.getLaunchNotification();
+  }
+
+  @override
+  Future<void> dismissDeliveredNotificationsForConversation({
+    required int chatId,
+    int? threadRootId,
+  }) {
+    return _apns.dismissDeliveredNotificationsForConversation(
+      chatId: chatId,
+      threadRootId: threadRootId,
+    );
   }
 
   @override
@@ -181,6 +196,12 @@ class UnsupportedPushPlatformClient implements PushPlatformClient {
 
   @override
   Future<Map<String, dynamic>?> getLaunchNotification() async => null;
+
+  @override
+  Future<void> dismissDeliveredNotificationsForConversation({
+    required int chatId,
+    int? threadRootId,
+  }) async {}
 
   @override
   Future<PushSubscriptionDescriptor?> subscriptionDescriptorForToken(

--- a/wetty-chat-flutter/lib/features/shared/data/read_state_repository.dart
+++ b/wetty-chat-flutter/lib/features/shared/data/read_state_repository.dart
@@ -12,6 +12,7 @@ import '../../chat_list/application/thread_list_v2_store.dart';
 import '../../conversation/shared/domain/conversation_identity.dart';
 import '../../conversation/compose/data/message_api_service_v2.dart';
 import '../../../core/notifications/unread_badge_provider.dart';
+import '../../../core/notifications/push_platform_client.dart';
 import 'read_state_models.dart';
 
 enum _ReadReportKind { chat, thread }
@@ -199,6 +200,9 @@ class ReadStateRepository {
           messageId: messageId,
           response: response,
         );
+    if (response.unreadCount == 0) {
+      unawaited(_dismissDeliveredNotifications(identity));
+    }
     ref.read(unreadBadgeProvider.notifier).scheduleReconcile();
   }
 
@@ -220,7 +224,29 @@ class ReadStateRepository {
     ref
         .read(threadListV2StoreProvider.notifier)
         .applyServerReadState(threadRootId: threadRootId, response: response);
+    if (response.unreadCount == 0) {
+      unawaited(_dismissDeliveredNotifications(identity));
+    }
     ref.read(unreadBadgeProvider.notifier).scheduleReconcile();
+  }
+
+  Future<void> _dismissDeliveredNotifications(
+    ConversationIdentity identity,
+  ) async {
+    try {
+      await ref
+          .read(pushPlatformClientProvider)
+          .dismissDeliveredNotificationsForConversation(
+            chatId: identity.chatId,
+            threadRootId: identity.threadRootId,
+          );
+    } catch (error, stackTrace) {
+      log(
+        'dismissDeliveredNotificationsForConversation failed: $error',
+        name: 'ReadStateRepository',
+        stackTrace: stackTrace,
+      );
+    }
   }
 }
 

--- a/wetty-chat-flutter/test/core/notifications/push_notification_provider_test.dart
+++ b/wetty-chat-flutter/test/core/notifications/push_notification_provider_test.dart
@@ -191,6 +191,12 @@ class _FakePushPlatformClient implements PushPlatformClient {
   Future<Map<String, dynamic>?> getLaunchNotification() async => null;
 
   @override
+  Future<void> dismissDeliveredNotificationsForConversation({
+    required int chatId,
+    int? threadRootId,
+  }) async {}
+
+  @override
   Future<PushSubscriptionDescriptor?> subscriptionDescriptorForToken(
     String token,
   ) async {

--- a/wetty-chat-flutter/test/features/shared/data/read_state_repository_test.dart
+++ b/wetty-chat-flutter/test/features/shared/data/read_state_repository_test.dart
@@ -1,0 +1,284 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:chahua/core/api/models/chats_api_models.dart';
+import 'package:chahua/core/api/models/thread_api_models.dart';
+import 'package:chahua/core/api/services/chat_api_service.dart';
+import 'package:chahua/core/api/services/thread_api_service.dart';
+import 'package:chahua/core/notifications/push_platform_client.dart';
+import 'package:chahua/core/session/dev_session_store.dart';
+import 'package:chahua/features/conversation/compose/data/message_api_service_v2.dart';
+import 'package:chahua/features/conversation/shared/domain/conversation_identity.dart';
+import 'package:chahua/features/shared/data/read_state_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ReadStateRepository notification dismissal', () {
+    test(
+      'dismisses delivered chat notifications after chat is fully read',
+      () async {
+        final platform = _RecordingPushPlatformClient();
+        final container = _container(
+          platform: platform,
+          messageApi: _FakeMessageApiService(),
+        );
+        addTearDown(container.dispose);
+
+        container
+            .read(readStateRepositoryProvider)
+            .reportVisibleMessageRead(
+              identity: const (chatId: 10, threadRootId: null),
+              messageId: 42,
+            );
+
+        await _waitForReadFlush();
+
+        expect(platform.dismissCalls, [const (chatId: 10, threadRootId: null)]);
+      },
+    );
+
+    test(
+      'does not dismiss delivered chat notifications when unread remains',
+      () async {
+        final platform = _RecordingPushPlatformClient();
+        final container = _container(
+          platform: platform,
+          messageApi: _FakeMessageApiService(unreadCount: 2),
+        );
+        addTearDown(container.dispose);
+
+        container
+            .read(readStateRepositoryProvider)
+            .reportVisibleMessageRead(
+              identity: const (chatId: 10, threadRootId: null),
+              messageId: 42,
+            );
+
+        await _waitForReadFlush();
+
+        expect(platform.dismissCalls, isEmpty);
+      },
+    );
+
+    test(
+      'dismisses delivered thread notifications after thread is fully read',
+      () async {
+        final platform = _RecordingPushPlatformClient();
+        final container = _container(
+          platform: platform,
+          threadApi: _FakeThreadApiService(),
+        );
+        addTearDown(container.dispose);
+
+        container
+            .read(readStateRepositoryProvider)
+            .reportVisibleMessageRead(
+              identity: const (chatId: 10, threadRootId: 77),
+              messageId: 99,
+            );
+
+        await _waitForReadFlush();
+
+        expect(platform.dismissCalls, [const (chatId: 10, threadRootId: 77)]);
+      },
+    );
+
+    test(
+      'does not dismiss delivered thread notifications when unread remains',
+      () async {
+        final platform = _RecordingPushPlatformClient();
+        final container = _container(
+          platform: platform,
+          threadApi: _FakeThreadApiService(unreadCount: 3),
+        );
+        addTearDown(container.dispose);
+
+        container
+            .read(readStateRepositoryProvider)
+            .reportVisibleMessageRead(
+              identity: const (chatId: 10, threadRootId: 77),
+              messageId: 99,
+            );
+
+        await _waitForReadFlush();
+
+        expect(platform.dismissCalls, isEmpty);
+      },
+    );
+
+    test('does not dismiss delivered notifications when read fails', () async {
+      final platform = _RecordingPushPlatformClient();
+      final container = _container(
+        platform: platform,
+        messageApi: _FakeMessageApiService(throwOnRead: true),
+      );
+      addTearDown(container.dispose);
+
+      container
+          .read(readStateRepositoryProvider)
+          .reportVisibleMessageRead(
+            identity: const (chatId: 10, threadRootId: null),
+            messageId: 42,
+          );
+
+      await _waitForReadFlush();
+
+      expect(platform.dismissCalls, isEmpty);
+    });
+  });
+}
+
+ProviderContainer _container({
+  required _RecordingPushPlatformClient platform,
+  _FakeMessageApiService? messageApi,
+  _FakeThreadApiService? threadApi,
+}) {
+  return ProviderContainer(
+    overrides: [
+      authSessionProvider.overrideWith(_AuthenticatedSessionNotifier.new),
+      messageApiServiceV2Provider.overrideWithValue(
+        messageApi ?? _FakeMessageApiService(),
+      ),
+      chatApiServiceProvider.overrideWithValue(_FakeChatApiService()),
+      threadApiServiceProvider.overrideWithValue(
+        threadApi ?? _FakeThreadApiService(),
+      ),
+      pushPlatformClientProvider.overrideWithValue(platform),
+    ],
+  );
+}
+
+Future<void> _waitForReadFlush() async {
+  await Future<void>.delayed(const Duration(milliseconds: 250));
+}
+
+class _AuthenticatedSessionNotifier extends AuthSessionNotifier {
+  @override
+  AuthSessionState build() {
+    return const AuthSessionState(
+      status: AuthBootstrapStatus.authenticated,
+      mode: AuthSessionMode.devHeader,
+      developerUserId: 1,
+      currentUserId: 1,
+    );
+  }
+}
+
+class _FakeMessageApiService extends MessageApiServiceV2 {
+  _FakeMessageApiService({this.throwOnRead = false, this.unreadCount = 0})
+    : super(Dio(), 1);
+
+  final bool throwOnRead;
+  final int unreadCount;
+
+  @override
+  Future<MarkChatReadStateResponseDto> markMessagesAsRead(
+    String chatId,
+    int messageId,
+  ) async {
+    if (throwOnRead) {
+      throw StateError('read failed');
+    }
+    return MarkChatReadStateResponseDto(
+      lastReadMessageId: messageId.toString(),
+      unreadCount: unreadCount,
+    );
+  }
+}
+
+class _FakeChatApiService extends ChatApiService {
+  _FakeChatApiService() : super(Dio());
+
+  @override
+  Future<UnreadCountResponseDto> fetchUnreadCount() async {
+    return const UnreadCountResponseDto();
+  }
+}
+
+class _FakeThreadApiService extends ThreadApiService {
+  _FakeThreadApiService({this.unreadCount = 0}) : super(Dio());
+
+  final int unreadCount;
+
+  @override
+  Future<MarkThreadReadResponseDto> markThreadAsRead(
+    int threadRootId,
+    int messageId,
+  ) async {
+    return MarkThreadReadResponseDto(
+      lastReadMessageId: messageId.toString(),
+      unreadCount: unreadCount,
+    );
+  }
+
+  @override
+  Future<UnreadThreadCountResponseDto> fetchUnreadThreadCount() async {
+    return const UnreadThreadCountResponseDto();
+  }
+}
+
+class _RecordingPushPlatformClient implements PushPlatformClient {
+  final dismissCalls = <ConversationIdentity>[];
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  String get tokenStorageKey => 'push_test_device_token';
+
+  @override
+  String get unsupportedPermissionStatus => 'unsupported';
+
+  @override
+  Stream<String> get onDeviceToken => const Stream<String>.empty();
+
+  @override
+  Stream<String> get onDeviceTokenError => const Stream<String>.empty();
+
+  @override
+  Stream<Map<String, dynamic>> get onNotificationTapped {
+    return const Stream<Map<String, dynamic>>.empty();
+  }
+
+  @override
+  Future<String> getPermissionStatus() async => 'authorized';
+
+  @override
+  Future<PushPermissionRequestResult> requestPermission() async {
+    return const PushPermissionRequestResult(
+      granted: true,
+      status: 'authorized',
+    );
+  }
+
+  @override
+  Future<void> registerForRemoteNotifications() async {}
+
+  @override
+  Future<void> unregisterForRemoteNotifications() async {}
+
+  @override
+  Future<Map<String, dynamic>?> getLaunchNotification() async => null;
+
+  @override
+  Future<void> dismissDeliveredNotificationsForConversation({
+    required int chatId,
+    int? threadRootId,
+  }) async {
+    dismissCalls.add((chatId: chatId, threadRootId: threadRootId));
+  }
+
+  @override
+  Future<PushSubscriptionDescriptor?> subscriptionDescriptorForToken(
+    String token,
+  ) async {
+    return null;
+  }
+
+  @override
+  String tokenErrorMessage(String error) => 'test registration failed: $error';
+}


### PR DESCRIPTION
- Implemented `dismissDeliveredNotificationsForConversation` method in `PushNotificationPlugin` to clear notifications for specific chat threads.
- Updated `ApnsChannel` to expose the new method for dismissing notifications.
- Enhanced `ReadStateRepository` to automatically dismiss notifications when all messages in a chat or thread are read.
- Added tests to verify the correct behavior of notification dismissal in various scenarios.