### PR TITLE
fix: simplify syncJwtTokenFromLanding (with all feature combos)

### DIFF
--- a/wetty-chat-mobile/src/hooks/useLandingInviteFlow.ts
+++ b/wetty-chat-mobile/src/hooks/useLandingInviteFlow.ts
@@ -17,7 +17,7 @@ export function useLandingInviteFlow({ search, isPwa, appEntryUrl }: UseLandingI
 
   useEffect(() => {
     let cancelled = false;
-    syncJwtTokenFromLanding(search, PENDING_INVITE_PWA_MODAL_ENABLED);
+    syncJwtTokenFromLanding(search);
     const pendingInviteCode = PENDING_INVITE_PWA_MODAL_ENABLED
       ? syncPendingInviteFromLanding(search)
       : parsePendingInviteFromLanding(search);

--- a/wetty-chat-mobile/src/utils/jwtToken.ts
+++ b/wetty-chat-mobile/src/utils/jwtToken.ts
@@ -75,18 +75,14 @@ export async function syncJwtTokenToIdb(): Promise<string> {
   return '';
 }
 
-export function syncJwtTokenFromLanding(search: string, persist: boolean = true): string {
+export function syncJwtTokenFromLanding(search: string): string {
   const queryToken = getJwtTokenFromQuery(search);
   if (queryToken) {
     cachedJwtToken = queryToken;
+    setJwtTokenCookie(queryToken);
     syncClientIdFromJwt(queryToken);
-
-    if (persist) {
-      setJwtTokenCookie(queryToken);
-      void kvSet('jwt_token', queryToken);
-      void SetTokenCacheStorage(queryToken);
-    }
-
+    void kvSet('jwt_token', queryToken);
+    void SetTokenCacheStorage(queryToken);
     return queryToken;
   }
 


### PR DESCRIPTION
- Updated the `syncJwtTokenFromLanding` function to eliminate the `persist` parameter, streamlining its usage.
- Adjusted the call to `syncJwtTokenFromLanding` in `useLandingInviteFlow` to reflect the updated function signature.