### PR TITLE
feat: enhance logging configuration and add tracing support

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4205,6 +4205,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4214,12 +4224,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -21,7 +21,7 @@ diesel_migrations = { version = "2", features = ["postgres"] }
 dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.22", features = ["env-filter", "json"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = [
     "trace",

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -58,5 +58,6 @@ EXPOSE 3001
 # Runtime env vars such as DATABASE_URL and optional CORS_ALLOWED_ORIGINS
 # must be set via docker run -e or compose environment.
 ENV RUST_LOG=info
+ENV BACKEND_LOG_FORMAT=json
 
 ENTRYPOINT ["/app/wetty-chat-backend"]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -17,7 +17,7 @@ use tower_http::trace::{DefaultOnRequest, DefaultOnResponse, TraceLayer};
 use tower_http::LatencyUnit;
 use tower_http::ServiceBuilderExt;
 use tracing::{debug_span, info, Level};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use utils::auth::{X_APP_VERSION, X_CLIENT_ID, X_USER_ID};
 use utoipa::OpenApi;
 
@@ -55,6 +55,13 @@ pub(crate) const MAX_CHAT_ATTACHMENTS_LIMIT: i64 = 100;
 pub(crate) const MAX_MESSAGES_LIMIT: i64 = 100;
 pub(crate) const MAX_MEMBERS_LIMIT: i64 = 100;
 const MAX_REQUEST_BODY_BYTES: usize = 50 * 1024 * 1024;
+const LOG_FORMAT_ENV: &str = "BACKEND_LOG_FORMAT";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LogFormat {
+    Pretty,
+    Json,
+}
 
 #[derive(Clone, Deserialize, Default)]
 pub(crate) enum AuthMethod {
@@ -88,17 +95,17 @@ pub(crate) struct AppState {
 
 #[tokio::main]
 async fn main() {
+    dotenvy::dotenv().ok();
+
     // Tracing: RUST_LOG controls level (e.g. RUST_LOG=info, or
     // RUST_LOG=wetty_chat_backend=debug,tower_http=debug for request-level logs).
+    // BACKEND_LOG_FORMAT controls stdout format: pretty for local development,
+    // json for production collection by agents such as Grafana Alloy.
     // Responses include X-Request-ID for correlation with clients or proxies.
-    tracing_subscriber::registry()
-        .with(EnvFilter::from_default_env())
-        .with(tracing_subscriber::fmt::layer().with_target(true))
-        .init();
+    init_tracing();
 
     db_tracing::install();
 
-    dotenvy::dotenv().ok();
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let manager = ConnectionManager::<PgConnection>::new(&database_url);
 
@@ -349,6 +356,29 @@ fn read_socket_addr(var_name: &str, default: SocketAddr) -> SocketAddr {
         .unwrap_or(default)
 }
 
+fn init_tracing() {
+    let env_filter = EnvFilter::from_default_env();
+    match parse_log_format(std::env::var(LOG_FORMAT_ENV).ok().as_deref()) {
+        LogFormat::Pretty => tracing_subscriber::registry()
+            .with(env_filter)
+            .with(fmt::layer().pretty().with_target(true))
+            .init(),
+        LogFormat::Json => tracing_subscriber::registry()
+            .with(env_filter)
+            .with(fmt::layer().json().with_target(true))
+            .init(),
+    }
+}
+
+fn parse_log_format(value: Option<&str>) -> LogFormat {
+    match value.map(str::trim).filter(|value| !value.is_empty()) {
+        None => LogFormat::Pretty,
+        Some(value) if value.eq_ignore_ascii_case("pretty") => LogFormat::Pretty,
+        Some(value) if value.eq_ignore_ascii_case("json") => LogFormat::Json,
+        Some(_) => panic!("{LOG_FORMAT_ENV} must be one of: pretty, json"),
+    }
+}
+
 fn read_cors_allowed_origins(var_name: &str) -> Option<Vec<HeaderValue>> {
     let raw_value = std::env::var(var_name).ok()?;
     let raw_value = raw_value.trim();
@@ -376,4 +406,28 @@ fn read_cors_allowed_origins(var_name: &str) -> Option<Vec<HeaderValue>> {
     );
 
     Some(origins)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_log_format, LogFormat};
+
+    #[test]
+    fn log_format_defaults_to_pretty_when_unset() {
+        assert_eq!(parse_log_format(None), LogFormat::Pretty);
+    }
+
+    #[test]
+    fn log_format_accepts_json_and_pretty_case_insensitively() {
+        assert_eq!(parse_log_format(Some("json")), LogFormat::Json);
+        assert_eq!(parse_log_format(Some("JSON")), LogFormat::Json);
+        assert_eq!(parse_log_format(Some("pretty")), LogFormat::Pretty);
+        assert_eq!(parse_log_format(Some("Pretty")), LogFormat::Pretty);
+    }
+
+    #[test]
+    #[should_panic(expected = "BACKEND_LOG_FORMAT must be one of: pretty, json")]
+    fn log_format_rejects_unknown_values() {
+        parse_log_format(Some("xml"));
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - 3000:3000
     environment:
       DATABASE_URL: postgresql://wetty_chat:NIM1gs7unjbQumYD@postgres:5432/wetty_chat
+      BACKEND_LOG_FORMAT: pretty
   rustfs:
     image: rustfs/rustfs:latest
     restart: unless-stopped


### PR DESCRIPTION
- Introduced a new environment variable `BACKEND_LOG_FORMAT` to control log output format (pretty or json).
- Updated `tracing-subscriber` to support JSON formatting for production logging.
- Refactored logging initialization in `main.rs` to accommodate the new log format setting.
- Added tests for log format parsing to ensure correct behavior and error handling.