### PR TITLE
feat: add push delivery failure tracking and metrics

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4924,6 +4924,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
+ "http 0.2.12",
  "image",
  "jsonwebtoken",
  "matroska",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -66,3 +66,6 @@ utoipa-swagger-ui = { version = "9", features = ["axum"] }
 [profile.dev]
 overflow-checks = false
 incremental = true
+
+[dev-dependencies]
+http02 = { package = "http", version = "0.2" }

--- a/backend/migrations/2026-05-20-020903-0000_add_push_delivery_failure_tracking/down.sql
+++ b/backend/migrations/2026-05-20-020903-0000_add_push_delivery_failure_tracking/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE push_subscriptions
+    DROP COLUMN last_delivery_error_at,
+    DROP COLUMN last_delivery_error,
+    DROP COLUMN delivery_failure_count;

--- a/backend/migrations/2026-05-20-020903-0000_add_push_delivery_failure_tracking/up.sql
+++ b/backend/migrations/2026-05-20-020903-0000_add_push_delivery_failure_tracking/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE push_subscriptions
+    ADD COLUMN delivery_failure_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN last_delivery_error TEXT,
+    ADD COLUMN last_delivery_error_at TIMESTAMPTZ;

--- a/backend/src/handlers/push.rs
+++ b/backend/src/handlers/push.rs
@@ -169,6 +169,9 @@ async fn post_subscribe(
         provider_data: validated.provider_data.clone(),
         created_at: Utc::now().naive_utc(),
         client_id: Some(client_id.clone()),
+        delivery_failure_count: 0,
+        last_delivery_error: None,
+        last_delivery_error_at: None,
     };
 
     conn.transaction::<_, diesel::result::Error, _>(|conn| {
@@ -231,6 +234,10 @@ async fn post_subscribe(
                     push_subscriptions::client_id.eq(&current_client_id),
                     push_subscriptions::created_at.eq(created_at),
                     push_subscriptions::provider_data.eq(&provider_data),
+                    push_subscriptions::delivery_failure_count.eq(0),
+                    push_subscriptions::last_delivery_error.eq::<Option<String>>(None),
+                    push_subscriptions::last_delivery_error_at
+                        .eq::<Option<chrono::DateTime<chrono::Utc>>>(None),
                 ))
                 .execute(conn)?;
         } else {
@@ -254,6 +261,13 @@ async fn post_subscribe(
                             push_subscriptions::client_id.eq(&current_client_id),
                             push_subscriptions::created_at.eq(created_at),
                             push_subscriptions::provider_data.eq(&provider_data),
+                            push_subscriptions::delivery_failure_count.eq(0),
+                            push_subscriptions::last_delivery_error.eq::<Option<String>>(None),
+                            push_subscriptions::last_delivery_error_at.eq::<Option<
+                                chrono::DateTime<chrono::Utc>,
+                            >>(
+                                None
+                            ),
                         ))
                         .execute(conn)?;
                 }

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -46,6 +46,8 @@ pub(crate) struct Metrics {
     push_notification_jobs_total: IntCounterVec,
     push_notification_job_duration_seconds: HistogramVec,
     push_notifications_suppressed_total: IntCounter,
+    push_delivery_failures_total: IntCounterVec,
+    push_subscription_prunes_total: IntCounterVec,
     ws_connected_users: IntGauge,
     ws_active_connections: IntGauge,
     ws_inactive_connections: IntGauge,
@@ -147,6 +149,22 @@ impl Metrics {
             "Total number of push notifications skipped because a user had active websocket presence"
         ))
         .expect("push_notifications_suppressed_total metric should be valid");
+        let push_delivery_failures_total = IntCounterVec::new(
+            opts!(
+                "push_delivery_failures_total",
+                "Total number of classified push delivery failures"
+            ),
+            &["provider", "class"],
+        )
+        .expect("push_delivery_failures_total metric should be valid");
+        let push_subscription_prunes_total = IntCounterVec::new(
+            opts!(
+                "push_subscription_prunes_total",
+                "Total number of push subscriptions pruned after delivery failures"
+            ),
+            &["provider", "reason"],
+        )
+        .expect("push_subscription_prunes_total metric should be valid");
         let ws_connected_users = IntGauge::with_opts(opts!(
             "ws_connected_users",
             "Current number of users with at least one active websocket connection"
@@ -398,6 +416,12 @@ impl Metrics {
             .register(Box::new(push_notifications_suppressed_total.clone()))
             .expect("push_notifications_suppressed_total registration should succeed");
         registry
+            .register(Box::new(push_delivery_failures_total.clone()))
+            .expect("push_delivery_failures_total registration should succeed");
+        registry
+            .register(Box::new(push_subscription_prunes_total.clone()))
+            .expect("push_subscription_prunes_total registration should succeed");
+        registry
             .register(Box::new(ws_connected_users.clone()))
             .expect("ws_connected_users registration should succeed");
         registry
@@ -501,6 +525,8 @@ impl Metrics {
             push_notification_jobs_total,
             push_notification_job_duration_seconds,
             push_notifications_suppressed_total,
+            push_delivery_failures_total,
+            push_subscription_prunes_total,
             ws_connected_users,
             ws_active_connections,
             ws_inactive_connections,
@@ -640,6 +666,18 @@ impl Metrics {
 
     pub(crate) fn record_push_suppressed(&self) {
         self.push_notifications_suppressed_total.inc();
+    }
+
+    pub(crate) fn record_push_delivery_failure(&self, provider: &str, class: &str) {
+        self.push_delivery_failures_total
+            .with_label_values(&[provider, class])
+            .inc();
+    }
+
+    pub(crate) fn record_push_subscription_prune(&self, provider: &str, reason: &str) {
+        self.push_subscription_prunes_total
+            .with_label_values(&[provider, reason])
+            .inc();
     }
 
     pub(crate) fn record_ws_connection_open(&self) {

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -766,6 +766,9 @@ pub struct PushSubscription {
     pub provider_data: serde_json::Value,
     pub created_at: chrono::NaiveDateTime,
     pub client_id: Option<String>,
+    pub delivery_failure_count: i32,
+    pub last_delivery_error: Option<String>,
+    pub last_delivery_error_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl PushSubscription {
@@ -790,4 +793,7 @@ pub struct NewPushSubscription {
     pub provider_data: serde_json::Value,
     pub created_at: chrono::NaiveDateTime,
     pub client_id: Option<String>,
+    pub delivery_failure_count: i32,
+    pub last_delivery_error: Option<String>,
+    pub last_delivery_error_at: Option<chrono::DateTime<chrono::Utc>>,
 }

--- a/backend/src/schema/primary.rs
+++ b/backend/src/schema/primary.rs
@@ -266,6 +266,9 @@ diesel::table! {
         device_token -> Nullable<Text>,
         apns_environment -> Nullable<PushEnvironment>,
         provider_data -> Jsonb,
+        delivery_failure_count -> Int4,
+        last_delivery_error -> Nullable<Text>,
+        last_delivery_error_at -> Nullable<Timestamptz>,
     }
 }
 

--- a/backend/src/services/push/delivery.rs
+++ b/backend/src/services/push/delivery.rs
@@ -54,9 +54,62 @@ pub(super) struct ApnsSender {
     topic: String,
 }
 
-pub(super) enum SendFailure {
-    Stale(i64),
-    Transient,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DeliveryFailureAction {
+    None,
+    Counted,
+    PruneImmediate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DeliveryFailureClass {
+    InvalidSubscription,
+    ProviderRejected,
+    ProviderTransient,
+    BackendConfig,
+    PayloadBuild,
+}
+
+impl DeliveryFailureClass {
+    pub(super) fn as_metrics_label(self) -> &'static str {
+        match self {
+            Self::InvalidSubscription => "invalid_subscription",
+            Self::ProviderRejected => "provider_rejected",
+            Self::ProviderTransient => "provider_transient",
+            Self::BackendConfig => "backend_config",
+            Self::PayloadBuild => "payload_build",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DeliveryFailureDetails {
+    pub(super) class: DeliveryFailureClass,
+    pub(super) reason: String,
+    pub(super) action: DeliveryFailureAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DeliveryFailure {
+    pub(super) subscription_id: i64,
+    pub(super) user_id: i32,
+    pub(super) provider: PushProvider,
+    pub(super) class: DeliveryFailureClass,
+    pub(super) reason: String,
+    pub(super) action: DeliveryFailureAction,
+}
+
+impl DeliveryFailure {
+    fn from_details(sub: &PushSubscription, details: DeliveryFailureDetails) -> Self {
+        Self {
+            subscription_id: sub.id,
+            user_id: sub.user_id,
+            provider: sub.provider,
+            class: details.class,
+            reason: details.reason,
+            action: details.action,
+        }
+    }
 }
 
 impl PushService {
@@ -65,7 +118,7 @@ impl PushService {
         sub: &PushSubscription,
         web_payload: &[u8],
         apns_notification: &ApnsNotification,
-    ) -> Result<(), SendFailure> {
+    ) -> Result<(), DeliveryFailure> {
         match sub.provider {
             PushProvider::WebPush => self.send_web_push(sub, web_payload).await,
             PushProvider::Apns => self.send_apns_push(sub, apns_notification).await,
@@ -76,14 +129,20 @@ impl PushService {
         &self,
         sub: &PushSubscription,
         payload: &[u8],
-    ) -> Result<(), SendFailure> {
+    ) -> Result<(), DeliveryFailure> {
         let endpoint = match &sub.endpoint {
             Some(endpoint) => endpoint.clone(),
             None => {
                 self.metrics
                     .record_push_notification(PushProvider::WebPush.as_metrics_label(), false);
-                warn!("web push subscription {} missing endpoint", sub.id);
-                return Err(SendFailure::Stale(sub.id));
+                return Err(DeliveryFailure::from_details(
+                    sub,
+                    DeliveryFailureDetails {
+                        class: DeliveryFailureClass::InvalidSubscription,
+                        reason: "missing_endpoint".to_string(),
+                        action: DeliveryFailureAction::PruneImmediate,
+                    },
+                ));
             }
         };
         let data = match sub.web_push_data() {
@@ -95,7 +154,14 @@ impl PushService {
                     "web push subscription {} has invalid provider data: {:?}",
                     sub.id, e
                 );
-                return Err(SendFailure::Stale(sub.id));
+                return Err(DeliveryFailure::from_details(
+                    sub,
+                    DeliveryFailureDetails {
+                        class: DeliveryFailureClass::InvalidSubscription,
+                        reason: "invalid_provider_data".to_string(),
+                        action: DeliveryFailureAction::PruneImmediate,
+                    },
+                ));
             }
         };
 
@@ -112,7 +178,14 @@ impl PushService {
                     );
                     self.metrics
                         .record_push_notification(PushProvider::WebPush.as_metrics_label(), false);
-                    return Err(SendFailure::Transient);
+                    return Err(DeliveryFailure::from_details(
+                        sub,
+                        DeliveryFailureDetails {
+                            class: DeliveryFailureClass::BackendConfig,
+                            reason: "vapid_config".to_string(),
+                            action: DeliveryFailureAction::None,
+                        },
+                    ));
                 }
             };
 
@@ -124,7 +197,14 @@ impl PushService {
                 error!("Failed to build VAPID signature: {:?}", e);
                 self.metrics
                     .record_push_notification(PushProvider::WebPush.as_metrics_label(), false);
-                return Err(SendFailure::Transient);
+                return Err(DeliveryFailure::from_details(
+                    sub,
+                    DeliveryFailureDetails {
+                        class: DeliveryFailureClass::BackendConfig,
+                        reason: "vapid_signature".to_string(),
+                        action: DeliveryFailureAction::None,
+                    },
+                ));
             }
         };
 
@@ -142,24 +222,42 @@ impl PushService {
                 Err(e) => {
                     self.metrics
                         .record_push_notification(PushProvider::WebPush.as_metrics_label(), false);
-                    if matches!(
-                        e,
-                        web_push::WebPushError::EndpointNotValid(_)
-                            | web_push::WebPushError::EndpointNotFound(_)
-                    ) {
-                        warn!("stale web push subscription for endpoint {}", endpoint);
-                        Err(SendFailure::Stale(sub.id))
+                    let details = classify_web_push_error(&e);
+                    if details.action == DeliveryFailureAction::PruneImmediate {
+                        warn!(
+                            provider = PushProvider::WebPush.as_metrics_label(),
+                            subscription_id = sub.id,
+                            user_id = sub.user_id,
+                            reason = %details.reason,
+                            action = "prune",
+                            "stale web push subscription"
+                        );
                     } else {
-                        error!("Failed to send web push notification: {:?}", e);
-                        Err(SendFailure::Transient)
+                        error!(
+                            provider = PushProvider::WebPush.as_metrics_label(),
+                            subscription_id = sub.id,
+                            user_id = sub.user_id,
+                            failure_class = details.class.as_metrics_label(),
+                            reason = %details.reason,
+                            action = "retry",
+                            "failed to send web push notification"
+                        );
                     }
+                    Err(DeliveryFailure::from_details(sub, details))
                 }
             },
             Err(e) => {
                 error!("Failed to build web push message: {:?}", e);
                 self.metrics
                     .record_push_notification(PushProvider::WebPush.as_metrics_label(), false);
-                Err(SendFailure::Transient)
+                Err(DeliveryFailure::from_details(
+                    sub,
+                    DeliveryFailureDetails {
+                        class: DeliveryFailureClass::PayloadBuild,
+                        reason: "message_build".to_string(),
+                        action: DeliveryFailureAction::None,
+                    },
+                ))
             }
         }
     }
@@ -168,7 +266,7 @@ impl PushService {
         &self,
         sub: &PushSubscription,
         notification: &ApnsNotification,
-    ) -> Result<(), SendFailure> {
+    ) -> Result<(), DeliveryFailure> {
         let sender = match &self.apns_sender {
             Some(sender) => sender,
             None => {
@@ -178,7 +276,14 @@ impl PushService {
                 );
                 self.metrics
                     .record_push_notification(PushProvider::Apns.as_metrics_label(), false);
-                return Err(SendFailure::Transient);
+                return Err(DeliveryFailure::from_details(
+                    sub,
+                    DeliveryFailureDetails {
+                        class: DeliveryFailureClass::BackendConfig,
+                        reason: "apns_not_configured".to_string(),
+                        action: DeliveryFailureAction::None,
+                    },
+                ));
             }
         };
         let device_token = match &sub.device_token {
@@ -187,7 +292,14 @@ impl PushService {
                 warn!("APNs subscription {} missing device token", sub.id);
                 self.metrics
                     .record_push_notification(PushProvider::Apns.as_metrics_label(), false);
-                return Err(SendFailure::Stale(sub.id));
+                return Err(DeliveryFailure::from_details(
+                    sub,
+                    DeliveryFailureDetails {
+                        class: DeliveryFailureClass::InvalidSubscription,
+                        reason: "missing_device_token".to_string(),
+                        action: DeliveryFailureAction::PruneImmediate,
+                    },
+                ));
             }
         };
         if let Err(e) = sub.apns_data() {
@@ -197,7 +309,14 @@ impl PushService {
             );
             self.metrics
                 .record_push_notification(PushProvider::Apns.as_metrics_label(), false);
-            return Err(SendFailure::Stale(sub.id));
+            return Err(DeliveryFailure::from_details(
+                sub,
+                DeliveryFailureDetails {
+                    class: DeliveryFailureClass::InvalidSubscription,
+                    reason: "invalid_provider_data".to_string(),
+                    action: DeliveryFailureAction::PruneImmediate,
+                },
+            ));
         }
         let environment = match sub.apns_environment {
             Some(environment) => environment,
@@ -205,7 +324,14 @@ impl PushService {
                 warn!("APNs subscription {} missing environment", sub.id);
                 self.metrics
                     .record_push_notification(PushProvider::Apns.as_metrics_label(), false);
-                return Err(SendFailure::Stale(sub.id));
+                return Err(DeliveryFailure::from_details(
+                    sub,
+                    DeliveryFailureDetails {
+                        class: DeliveryFailureClass::InvalidSubscription,
+                        reason: "missing_environment".to_string(),
+                        action: DeliveryFailureAction::PruneImmediate,
+                    },
+                ));
             }
         };
 
@@ -215,32 +341,35 @@ impl PushService {
                     .record_push_notification(PushProvider::Apns.as_metrics_label(), true);
                 Ok(())
             }
-            Err(ApnsSendError::Stale(reason)) => {
+            Err(details) if details.action == DeliveryFailureAction::PruneImmediate => {
                 warn!(
-                    "stale APNs subscription {} for token {}: {:?}",
-                    sub.id, device_token, reason
+                    provider = PushProvider::Apns.as_metrics_label(),
+                    subscription_id = sub.id,
+                    user_id = sub.user_id,
+                    reason = %details.reason,
+                    action = "prune",
+                    "stale APNs subscription"
                 );
                 self.metrics
                     .record_push_notification(PushProvider::Apns.as_metrics_label(), false);
-                Err(SendFailure::Stale(sub.id))
+                Err(DeliveryFailure::from_details(sub, details))
             }
-            Err(ApnsSendError::Transient(reason)) => {
+            Err(details) => {
                 error!(
-                    "failed to send APNs notification for subscription {}: {}",
-                    sub.id, reason
+                    provider = PushProvider::Apns.as_metrics_label(),
+                    subscription_id = sub.id,
+                    user_id = sub.user_id,
+                    failure_class = details.class.as_metrics_label(),
+                    reason = %details.reason,
+                    action = "retry",
+                    "failed to send APNs notification"
                 );
                 self.metrics
                     .record_push_notification(PushProvider::Apns.as_metrics_label(), false);
-                Err(SendFailure::Transient)
+                Err(DeliveryFailure::from_details(sub, details))
             }
         }
     }
-}
-
-#[derive(Debug)]
-enum ApnsSendError {
-    Stale(ApnsErrorReason),
-    Transient(String),
 }
 
 impl ApnsSender {
@@ -297,7 +426,7 @@ impl ApnsSender {
         device_token: &str,
         environment: &PushEnvironment,
         notification: &ApnsNotification,
-    ) -> Result<(), ApnsSendError> {
+    ) -> Result<(), DeliveryFailureDetails> {
         let title_loc_args = [notification.title_loc_args[0].as_str()];
         let body_loc_args: Vec<&str> = notification
             .body_loc_args
@@ -321,8 +450,10 @@ impl ApnsSender {
         let mut inner_payload = builder.build(device_token, options);
         inner_payload
             .add_custom_data(APNS_CUSTOM_DATA_ROOT, &notification.custom_data)
-            .map_err(|e| {
-                ApnsSendError::Transient(format!("failed to serialize APNs payload: {:?}", e))
+            .map_err(|e| DeliveryFailureDetails {
+                class: DeliveryFailureClass::PayloadBuild,
+                reason: format!("payload_serialize: {:?}", e),
+                action: DeliveryFailureAction::None,
             })?;
         let payload = PayloadWithThreadId {
             inner: inner_payload,
@@ -336,22 +467,107 @@ impl ApnsSender {
         let response = client
             .send(payload)
             .await
-            .map_err(|e| ApnsSendError::Transient(format!("{:?}", e)))?;
+            .map_err(|e| classify_apns_send_error(&e))?;
 
         if response.code == 200 {
             Ok(())
         } else if let Some(error) = response.error {
             if is_stale_apns_error_reason(&error.reason) {
-                Err(ApnsSendError::Stale(error.reason))
+                Err(stale_apns_failure(&error.reason))
             } else {
-                Err(ApnsSendError::Transient(format!("{:?}", error.reason)))
+                Err(DeliveryFailureDetails {
+                    class: DeliveryFailureClass::ProviderTransient,
+                    reason: format!("{:?}", error.reason),
+                    action: DeliveryFailureAction::None,
+                })
             }
         } else {
-            Err(ApnsSendError::Transient(format!(
-                "APNs request failed with status {}",
-                response.code
-            )))
+            Err(DeliveryFailureDetails {
+                class: DeliveryFailureClass::ProviderTransient,
+                reason: format!("status_{}", response.code),
+                action: DeliveryFailureAction::None,
+            })
         }
+    }
+}
+
+pub(super) fn classify_web_push_error(error: &web_push::WebPushError) -> DeliveryFailureDetails {
+    match error {
+        web_push::WebPushError::EndpointNotValid(_) => DeliveryFailureDetails {
+            class: DeliveryFailureClass::ProviderRejected,
+            reason: "endpoint_not_valid".to_string(),
+            action: DeliveryFailureAction::PruneImmediate,
+        },
+        web_push::WebPushError::EndpointNotFound(_) => DeliveryFailureDetails {
+            class: DeliveryFailureClass::ProviderRejected,
+            reason: "endpoint_not_found".to_string(),
+            action: DeliveryFailureAction::PruneImmediate,
+        },
+        web_push::WebPushError::Unspecified => DeliveryFailureDetails {
+            class: DeliveryFailureClass::ProviderTransient,
+            reason: "unspecified".to_string(),
+            action: DeliveryFailureAction::Counted,
+        },
+        other => DeliveryFailureDetails {
+            class: DeliveryFailureClass::ProviderTransient,
+            reason: other.short_description().to_string(),
+            action: DeliveryFailureAction::None,
+        },
+    }
+}
+
+pub(super) fn classify_apns_send_error(error: &a2::Error) -> DeliveryFailureDetails {
+    match error {
+        a2::Error::ResponseError(response) => match &response.error {
+            Some(body) if is_stale_apns_error_reason(&body.reason) => {
+                stale_apns_failure(&body.reason)
+            }
+            Some(body) => DeliveryFailureDetails {
+                class: DeliveryFailureClass::ProviderTransient,
+                reason: format!("{:?}", body.reason),
+                action: DeliveryFailureAction::None,
+            },
+            None => DeliveryFailureDetails {
+                class: DeliveryFailureClass::ProviderTransient,
+                reason: format!("status_{}", response.code),
+                action: DeliveryFailureAction::None,
+            },
+        },
+        a2::Error::RequestTimeout(_) => DeliveryFailureDetails {
+            class: DeliveryFailureClass::ProviderTransient,
+            reason: "request_timeout".to_string(),
+            action: DeliveryFailureAction::None,
+        },
+        a2::Error::SignerError(_) | a2::Error::InvalidOptions(_) => DeliveryFailureDetails {
+            class: DeliveryFailureClass::BackendConfig,
+            reason: "apns_config".to_string(),
+            action: DeliveryFailureAction::None,
+        },
+        a2::Error::SerializeError(_) | a2::Error::BuildRequestError(_) => DeliveryFailureDetails {
+            class: DeliveryFailureClass::PayloadBuild,
+            reason: "apns_payload".to_string(),
+            action: DeliveryFailureAction::None,
+        },
+        a2::Error::ConnectionError(_) | a2::Error::ClientError(_) => DeliveryFailureDetails {
+            class: DeliveryFailureClass::ProviderTransient,
+            reason: "connection".to_string(),
+            action: DeliveryFailureAction::None,
+        },
+        a2::Error::ReadError(_) | a2::Error::Tls(_) | a2::Error::InvalidCertificate => {
+            DeliveryFailureDetails {
+                class: DeliveryFailureClass::BackendConfig,
+                reason: "apns_config".to_string(),
+                action: DeliveryFailureAction::None,
+            }
+        }
+    }
+}
+
+fn stale_apns_failure(reason: &ApnsErrorReason) -> DeliveryFailureDetails {
+    DeliveryFailureDetails {
+        class: DeliveryFailureClass::ProviderRejected,
+        reason: format!("{:?}", reason),
+        action: DeliveryFailureAction::PruneImmediate,
     }
 }
 

--- a/backend/src/services/push/mod.rs
+++ b/backend/src/services/push/mod.rs
@@ -143,7 +143,10 @@ pub(crate) async fn supervise_worker<F, Fut>(
 
 #[cfg(test)]
 mod tests {
-    use super::delivery::is_stale_apns_error_reason;
+    use super::delivery::{
+        classify_apns_send_error, classify_web_push_error, is_stale_apns_error_reason,
+        DeliveryFailureAction,
+    };
     use super::payload::{
         build_apns_notification, build_push_payload, format_push_body, truncate_preview,
         APNS_BODY_LOC_KEY_AUDIO, APNS_BODY_LOC_KEY_IMAGE, APNS_BODY_LOC_KEY_IMAGE_WITH_PREVIEW,
@@ -460,6 +463,115 @@ mod tests {
         assert!(!is_stale_apns_error_reason(
             &ApnsErrorReason::InternalServerError
         ));
+    }
+
+    #[test]
+    fn apns_response_error_with_bad_device_token_prunes_subscription() {
+        let error = a2::Error::ResponseError(a2::Response {
+            apns_id: Some("test-apns-id".to_string()),
+            error: Some(a2::ErrorBody {
+                reason: ApnsErrorReason::BadDeviceToken,
+                timestamp: None,
+            }),
+            code: 400,
+        });
+
+        let failure = classify_apns_send_error(&error);
+
+        assert_eq!(failure.action, DeliveryFailureAction::PruneImmediate);
+        assert_eq!(failure.reason, "BadDeviceToken");
+    }
+
+    #[test]
+    fn apns_response_error_with_unregistered_prunes_subscription() {
+        let error = a2::Error::ResponseError(a2::Response {
+            apns_id: Some("test-apns-id".to_string()),
+            error: Some(a2::ErrorBody {
+                reason: ApnsErrorReason::Unregistered,
+                timestamp: None,
+            }),
+            code: 410,
+        });
+
+        let failure = classify_apns_send_error(&error);
+
+        assert_eq!(failure.action, DeliveryFailureAction::PruneImmediate);
+        assert_eq!(failure.reason, "Unregistered");
+    }
+
+    #[test]
+    fn apns_response_error_with_too_many_requests_is_retryable() {
+        let error = a2::Error::ResponseError(a2::Response {
+            apns_id: Some("test-apns-id".to_string()),
+            error: Some(a2::ErrorBody {
+                reason: ApnsErrorReason::TooManyRequests,
+                timestamp: None,
+            }),
+            code: 429,
+        });
+
+        let failure = classify_apns_send_error(&error);
+
+        assert_eq!(failure.action, DeliveryFailureAction::None);
+        assert_eq!(failure.reason, "TooManyRequests");
+    }
+
+    #[test]
+    fn apns_timeout_is_retryable() {
+        let error = a2::Error::RequestTimeout(30);
+
+        let failure = classify_apns_send_error(&error);
+
+        assert_eq!(failure.action, DeliveryFailureAction::None);
+        assert_eq!(failure.reason, "request_timeout");
+    }
+
+    #[test]
+    fn web_push_endpoint_not_found_prunes_immediately() {
+        let error = web_push::request_builder::parse_response(
+            http02::StatusCode::NOT_FOUND,
+            b"not found".to_vec(),
+        )
+        .expect_err("404 should classify as endpoint not found");
+
+        let failure = classify_web_push_error(&error);
+
+        assert_eq!(failure.action, DeliveryFailureAction::PruneImmediate);
+        assert_eq!(failure.reason, "endpoint_not_found");
+    }
+
+    #[test]
+    fn web_push_endpoint_not_valid_prunes_immediately() {
+        let error =
+            web_push::request_builder::parse_response(http02::StatusCode::GONE, b"gone".to_vec())
+                .expect_err("410 should classify as endpoint not valid");
+
+        let failure = classify_web_push_error(&error);
+
+        assert_eq!(failure.action, DeliveryFailureAction::PruneImmediate);
+        assert_eq!(failure.reason, "endpoint_not_valid");
+    }
+
+    #[test]
+    fn web_push_unspecified_counts_toward_pruning() {
+        let failure = classify_web_push_error(&web_push::WebPushError::Unspecified);
+
+        assert_eq!(failure.action, DeliveryFailureAction::Counted);
+        assert_eq!(failure.reason, "unspecified");
+    }
+
+    #[test]
+    fn web_push_server_error_is_retryable_without_pruning() {
+        let error = web_push::request_builder::parse_response(
+            http02::StatusCode::SERVICE_UNAVAILABLE,
+            b"temporarily unavailable".to_vec(),
+        )
+        .expect_err("503 should classify as server error");
+
+        let failure = classify_web_push_error(&error);
+
+        assert_eq!(failure.action, DeliveryFailureAction::None);
+        assert_eq!(failure.reason, "server_error");
     }
 
     #[test]

--- a/backend/src/services/push/worker.rs
+++ b/backend/src/services/push/worker.rs
@@ -12,7 +12,7 @@ use crate::models::PushSubscription;
 use crate::schema::push_subscriptions;
 use crate::services::ws_registry::ConnectionRegistry;
 
-use super::delivery::SendFailure;
+use super::delivery::{DeliveryFailure, DeliveryFailureAction};
 use super::payload::{build_apns_notification, build_push_payload, format_push_body};
 use super::policy::{
     should_send_push, PushDecision, PushRecipientContext, PushSkipReason, ThreadPushState,
@@ -22,6 +22,7 @@ use super::{panic_payload_message, PushJob, PushService};
 const PUSH_CONCURRENCY: usize = 10;
 const PUSH_SUPPRESSION_FRESHNESS_SECS: u64 = 30;
 const PUSH_WORKER_RESTART_DELAY: Duration = Duration::from_secs(1);
+const PUSH_COUNTED_FAILURE_PRUNE_THRESHOLD: i32 = 3;
 
 pub(super) async fn supervise_push_worker(
     mut rx: mpsc::Receiver<PushJob>,
@@ -106,6 +107,32 @@ struct RecipientCandidate {
     muted_until: Option<chrono::DateTime<chrono::Utc>>,
     chat_archived: bool,
     thread_state: ThreadPushState,
+}
+
+#[derive(Debug)]
+enum DeliveryAttemptResult {
+    Success {
+        subscription_id: i64,
+        should_reset_failure_state: bool,
+    },
+    Failure {
+        failure: DeliveryFailure,
+        next_failure_count: i32,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CountedFailurePersistenceAction {
+    Record,
+    Prune,
+}
+
+fn counted_failure_persistence_action(next_failure_count: i32) -> CountedFailurePersistenceAction {
+    if next_failure_count >= PUSH_COUNTED_FAILURE_PRUNE_THRESHOLD {
+        CountedFailurePersistenceAction::Prune
+    } else {
+        CountedFailurePersistenceAction::Record
+    }
 }
 
 fn load_recipient_candidates(
@@ -288,7 +315,7 @@ async fn process_push_job(
     let body_text = format_push_body(&job.sender_username, job.body_preview.as_deref());
 
     // 5. Send concurrently with bounded parallelism.
-    let stale_ids: Vec<i64> = stream::iter(subs)
+    let delivery_results: Vec<DeliveryAttemptResult> = stream::iter(subs)
         .map(|sub| {
             let service = service.clone();
 
@@ -302,27 +329,145 @@ async fn process_push_job(
                     .send_to_subscription(&sub, &web_payload, &apns_notification)
                     .await
                 {
-                    Ok(()) => None,
-                    Err(SendFailure::Stale(id)) => Some(id),
-                    Err(SendFailure::Transient) => None,
+                    Ok(()) => DeliveryAttemptResult::Success {
+                        subscription_id: sub.id,
+                        should_reset_failure_state: sub.delivery_failure_count != 0
+                            || sub.last_delivery_error.is_some()
+                            || sub.last_delivery_error_at.is_some(),
+                    },
+                    Err(failure) => DeliveryAttemptResult::Failure {
+                        failure,
+                        next_failure_count: sub.delivery_failure_count.saturating_add(1),
+                    },
                 }
             }
         })
         .buffer_unordered(PUSH_CONCURRENCY)
-        .filter_map(|result| async move { result })
         .collect()
         .await;
 
-    // 6. Clean up stale subscriptions.
-    if !stale_ids.is_empty() {
-        debug!("Cleaning up {} stale push subscriptions", stale_ids.len());
-        let _ = diesel::delete(
-            push_subscriptions::table.filter(push_subscriptions::dsl::id.eq_any(&stale_ids)),
+    apply_delivery_results(service, &mut conn, delivery_results)?;
+
+    Ok(())
+}
+
+fn apply_delivery_results(
+    service: &PushService,
+    conn: &mut PgConnection,
+    results: Vec<DeliveryAttemptResult>,
+) -> Result<(), String> {
+    let mut reset_ids = Vec::new();
+    let mut prune_ids = Vec::new();
+    let mut counted_failures = Vec::new();
+    let now = chrono::Utc::now();
+
+    for result in results {
+        match result {
+            DeliveryAttemptResult::Success {
+                subscription_id,
+                should_reset_failure_state,
+            } => {
+                if should_reset_failure_state {
+                    reset_ids.push(subscription_id);
+                }
+            }
+            DeliveryAttemptResult::Failure {
+                failure,
+                next_failure_count,
+            } => {
+                service.metrics.record_push_delivery_failure(
+                    failure.provider.as_metrics_label(),
+                    failure.class.as_metrics_label(),
+                );
+
+                match failure.action {
+                    DeliveryFailureAction::PruneImmediate => {
+                        warn!(
+                            provider = failure.provider.as_metrics_label(),
+                            subscription_id = failure.subscription_id,
+                            user_id = failure.user_id,
+                            failure_class = failure.class.as_metrics_label(),
+                            reason = %failure.reason,
+                            failure_count = next_failure_count,
+                            action = "prune",
+                            "pruning push subscription after immediate delivery failure"
+                        );
+                        service.metrics.record_push_subscription_prune(
+                            failure.provider.as_metrics_label(),
+                            failure.reason.as_str(),
+                        );
+                        prune_ids.push(failure.subscription_id);
+                    }
+                    DeliveryFailureAction::Counted
+                        if counted_failure_persistence_action(next_failure_count)
+                            == CountedFailurePersistenceAction::Prune =>
+                    {
+                        warn!(
+                            provider = failure.provider.as_metrics_label(),
+                            subscription_id = failure.subscription_id,
+                            user_id = failure.user_id,
+                            failure_class = failure.class.as_metrics_label(),
+                            reason = %failure.reason,
+                            failure_count = next_failure_count,
+                            action = "prune",
+                            "pruning push subscription after repeated delivery failures"
+                        );
+                        service.metrics.record_push_subscription_prune(
+                            failure.provider.as_metrics_label(),
+                            failure.reason.as_str(),
+                        );
+                        prune_ids.push(failure.subscription_id);
+                    }
+                    DeliveryFailureAction::Counted => {
+                        warn!(
+                            provider = failure.provider.as_metrics_label(),
+                            subscription_id = failure.subscription_id,
+                            user_id = failure.user_id,
+                            failure_class = failure.class.as_metrics_label(),
+                            reason = %failure.reason,
+                            failure_count = next_failure_count,
+                            action = "retry",
+                            "recording counted push delivery failure"
+                        );
+                        counted_failures.push((failure, next_failure_count));
+                    }
+                    DeliveryFailureAction::None => {}
+                }
+            }
+        }
+    }
+
+    if !reset_ids.is_empty() {
+        diesel::update(
+            push_subscriptions::table.filter(push_subscriptions::dsl::id.eq_any(&reset_ids)),
         )
-        .execute(&mut conn)
-        .map_err(|e| {
-            error!("Failed to clean up stale push subscriptions: {:?}", e);
-        });
+        .set((
+            push_subscriptions::dsl::delivery_failure_count.eq(0),
+            push_subscriptions::dsl::last_delivery_error.eq::<Option<String>>(None),
+            push_subscriptions::dsl::last_delivery_error_at
+                .eq::<Option<chrono::DateTime<chrono::Utc>>>(None),
+        ))
+        .execute(conn)
+        .map_err(|e| format!("Failed to reset push delivery failure state: {:?}", e))?;
+    }
+
+    for (failure, next_failure_count) in counted_failures {
+        diesel::update(push_subscriptions::table.find(failure.subscription_id))
+            .set((
+                push_subscriptions::dsl::delivery_failure_count.eq(next_failure_count),
+                push_subscriptions::dsl::last_delivery_error.eq(Some(failure.reason)),
+                push_subscriptions::dsl::last_delivery_error_at.eq(Some(now)),
+            ))
+            .execute(conn)
+            .map_err(|e| format!("Failed to update push delivery failure state: {:?}", e))?;
+    }
+
+    if !prune_ids.is_empty() {
+        diesel::delete(
+            push_subscriptions::table.filter(push_subscriptions::dsl::id.eq_any(&prune_ids)),
+        )
+        .execute(conn)
+        .map_err(|e| format!("Failed to prune push subscriptions: {:?}", e))?;
     }
 
     Ok(())
@@ -338,3 +483,32 @@ fn maybe_panic_for_test(job: &PushJob) {
 #[cfg(test)]
 static TEST_PANIC_MESSAGE_ID: std::sync::atomic::AtomicI64 =
     std::sync::atomic::AtomicI64::new(i64::MIN);
+
+#[cfg(test)]
+mod tests {
+    use super::{counted_failure_persistence_action, CountedFailurePersistenceAction};
+
+    #[test]
+    fn first_counted_delivery_failure_is_recorded() {
+        assert_eq!(
+            counted_failure_persistence_action(1),
+            CountedFailurePersistenceAction::Record
+        );
+    }
+
+    #[test]
+    fn second_counted_delivery_failure_is_recorded() {
+        assert_eq!(
+            counted_failure_persistence_action(2),
+            CountedFailurePersistenceAction::Record
+        );
+    }
+
+    #[test]
+    fn third_counted_delivery_failure_prunes_subscription() {
+        assert_eq!(
+            counted_failure_persistence_action(3),
+            CountedFailurePersistenceAction::Prune
+        );
+    }
+}


### PR DESCRIPTION
- Implemented database schema changes to track delivery failures in push subscriptions, including new columns for failure count and error details.
- Enhanced metrics to monitor push delivery failures and subscription pruning actions.
- Updated push notification handling to classify and respond to delivery failures, including immediate pruning for invalid subscriptions.
- Added tests to validate the new delivery failure classification and metrics tracking functionality.