### PR TITLE
fix(backend): properly initialize `last_read_message_id`

### DIFF
--- a/backend/src/handlers/groups.rs
+++ b/backend/src/handlers/groups.rs
@@ -267,6 +267,7 @@ async fn post_group(
             joined_at: now,
             join_reason: GroupJoinReason::Creator,
             join_reason_extra: None,
+            last_read_message_id: None,
         })
         .execute(conn)?;
 

--- a/backend/src/handlers/invites.rs
+++ b/backend/src/handlers/invites.rs
@@ -641,6 +641,12 @@ async fn post_redeem_invite(
                 }
             }
 
+            let last_message_id: Option<i64> = crate::schema::groups::table
+                .filter(crate::schema::groups::id.eq(invite.chat_id))
+                .select(crate::schema::groups::last_message_id)
+                .first(conn)
+                .optional()?
+                .flatten();
             match diesel::insert_into(group_membership::table)
                 .values(&NewGroupMembership {
                     chat_id: invite.chat_id,
@@ -653,6 +659,7 @@ async fn post_redeem_invite(
                         "code": invite.code,
                         "creator_uid": invite.creator_uid,
                     })),
+                    last_read_message_id: last_message_id,
                 })
                 .execute(conn)
             {

--- a/backend/src/handlers/members.rs
+++ b/backend/src/handlers/members.rs
@@ -250,6 +250,12 @@ async fn post_add_member(
 
     let role = body.role.unwrap_or(GroupRole::Member);
 
+    let last_message_id: Option<i64> = crate::schema::groups::table
+        .filter(crate::schema::groups::id.eq(chat_id))
+        .select(crate::schema::groups::last_message_id)
+        .first(conn)
+        .optional()?
+        .flatten();
     let now = Utc::now();
     let new_membership = NewGroupMembership {
         chat_id,
@@ -258,6 +264,7 @@ async fn post_add_member(
         joined_at: now,
         join_reason: GroupJoinReason::DirectInvite,
         join_reason_extra: Some(json!({ "inviter_uid": uid })),
+        last_read_message_id: last_message_id,
     };
 
     diesel::insert_into(group_membership::table)

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -464,6 +464,7 @@ pub struct NewGroupMembership {
     pub joined_at: DateTime<Utc>,
     pub join_reason: GroupJoinReason,
     pub join_reason_extra: Option<serde_json::Value>,
+    pub last_read_message_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable, Serialize)]


### PR DESCRIPTION
Newly joined users will now have their `last_read_message_id` initialized to the latest message before joining, preventing the group from showing 99+ unreads by default.