### PR TITLE
 feat(pwa): Improve sticker favoriting and pack management

### DIFF
--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -992,6 +992,15 @@ msgstr "Revoke invite"
 msgid "Save"
 msgstr "Save"
 
+msgid "Favorite Sticker"
+msgstr "Favorite Sticker"
+
+msgid "Failed to add sticker to favorites"
+msgstr "Failed to add sticker to favorites"
+
+msgid "Sticker added to favorites"
+msgstr "Sticker added to favorites"
+
 msgid "Save Settings"
 msgstr "Save Settings"
 

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -426,6 +426,9 @@ msgstr "Failed to load newer messages"
 msgid "Failed to load saved messages"
 msgstr "Failed to load saved messages"
 
+msgid "Failed to load sticker"
+msgstr "Failed to load sticker"
+
 msgid "Failed to load sticker pack"
 msgstr "Failed to load sticker pack"
 
@@ -506,6 +509,9 @@ msgstr "Failed to update role"
 
 msgid "Failed to upload avatar"
 msgstr "Failed to upload avatar"
+
+msgid "Favorite"
+msgstr "Favorite"
 
 msgid "Favorite Sticker"
 msgstr "Favorite Sticker"
@@ -1154,6 +1160,9 @@ msgstr "This invite may have expired or been revoked."
 msgid "This is how your messages will look in chat."
 msgstr "This is how your messages will look in chat."
 
+msgid "This sticker is not part of any pack"
+msgstr "This sticker is not part of any pack"
+
 msgid "This thread will move back to Threads. Continue?"
 msgstr "This thread will move back to Threads. Continue?"
 
@@ -1194,6 +1203,9 @@ msgstr "Unarchive chat?"
 
 msgid "Unarchive thread?"
 msgstr "Unarchive thread?"
+
+msgid "Unfavorite"
+msgstr "Unfavorite"
 
 msgid "Unknown"
 msgstr "Unknown"

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -366,6 +366,9 @@ msgstr "Failed to add member"
 msgid "Failed to add sticker"
 msgstr "Failed to add sticker"
 
+msgid "Failed to add sticker to favorites"
+msgstr "Failed to add sticker to favorites"
+
 msgid "Failed to copy invite code"
 msgstr "Failed to copy invite code"
 
@@ -453,6 +456,9 @@ msgstr "Failed to remove member"
 msgid "Failed to remove sticker"
 msgstr "Failed to remove sticker"
 
+msgid "Failed to rename pack"
+msgstr "Failed to rename pack"
+
 msgid "Failed to revoke invite"
 msgstr "Failed to revoke invite"
 
@@ -500,6 +506,9 @@ msgstr "Failed to update role"
 
 msgid "Failed to upload avatar"
 msgstr "Failed to upload avatar"
+
+msgid "Favorite Sticker"
+msgstr "Favorite Sticker"
 
 msgid "Favorites"
 msgstr "Favorites"
@@ -830,6 +839,9 @@ msgstr "Pack"
 msgid "Pack name"
 msgstr "Pack name"
 
+msgid "Pack renamed"
+msgstr "Pack renamed"
+
 msgid "Packs below this line are not auto-sorted"
 msgstr "Packs below this line are not auto-sorted"
 
@@ -961,6 +973,12 @@ msgstr "Remove this pack from your collection?"
 msgid "Remove this sticker from the pack?"
 msgstr "Remove this sticker from the pack?"
 
+msgid "Rename pack"
+msgstr "Rename pack"
+
+msgid "Rename Pack"
+msgstr "Rename Pack"
+
 msgid "replies"
 msgstr "replies"
 
@@ -991,15 +1009,6 @@ msgstr "Revoke invite"
 
 msgid "Save"
 msgstr "Save"
-
-msgid "Favorite Sticker"
-msgstr "Favorite Sticker"
-
-msgid "Failed to add sticker to favorites"
-msgstr "Failed to add sticker to favorites"
-
-msgid "Sticker added to favorites"
-msgstr "Sticker added to favorites"
 
 msgid "Save Settings"
 msgstr "Save Settings"
@@ -1096,6 +1105,9 @@ msgstr "Sticker"
 
 msgid "Sticker added"
 msgstr "Sticker added"
+
+msgid "Sticker added to favorites"
+msgstr "Sticker added to favorites"
 
 msgid "Sticker packs"
 msgstr "Sticker packs"

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -113,6 +113,9 @@ msgstr "Attachment preview tray"
 msgid "Auto"
 msgstr "Auto"
 
+msgid "Auto-sort favorite stickers"
+msgstr "Auto-sort favorite stickers"
+
 msgid "Auto-sort sticker packs"
 msgstr "Auto-sort sticker packs"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -366,6 +366,9 @@ msgstr "添加成员失败"
 msgid "Failed to add sticker"
 msgstr "添加表情失败"
 
+msgid "Failed to add sticker to favorites"
+msgstr "添加贴纸到收藏失败"
+
 msgid "Failed to copy invite code"
 msgstr "复制邀请码失败"
 
@@ -453,6 +456,9 @@ msgstr "移除成员失败"
 msgid "Failed to remove sticker"
 msgstr "移除贴纸失败"
 
+msgid "Failed to rename pack"
+msgstr "重命名贴纸包失败"
+
 msgid "Failed to revoke invite"
 msgstr "撤销邀请失败"
 
@@ -500,6 +506,9 @@ msgstr "更新角色失败"
 
 msgid "Failed to upload avatar"
 msgstr "上传头像失败"
+
+msgid "Favorite Sticker"
+msgstr "收藏贴纸"
 
 msgid "Favorites"
 msgstr "收藏"
@@ -830,6 +839,9 @@ msgstr "贴纸包"
 msgid "Pack name"
 msgstr "贴纸包名称"
 
+msgid "Pack renamed"
+msgstr "贴纸包已重命名"
+
 msgid "Packs below this line are not auto-sorted"
 msgstr "此行以下的贴纸包不会自动排序"
 
@@ -961,6 +973,12 @@ msgstr "要将这个表情包从你的收藏中移除吗？"
 msgid "Remove this sticker from the pack?"
 msgstr "要从表情包中移除此表情吗？"
 
+msgid "Rename pack"
+msgstr "重命名贴纸包"
+
+msgid "Rename Pack"
+msgstr "重命名贴纸包"
+
 msgid "replies"
 msgstr "条回复"
 
@@ -990,16 +1008,7 @@ msgid "Revoke invite"
 msgstr "撤销邀请"
 
 msgid "Save"
-msgstr "收藏"
-
-msgid "Favorite Sticker"
-msgstr "收藏贴纸"
-
-msgid "Failed to add sticker to favorites"
-msgstr "添加贴纸到收藏失败"
-
-msgid "Sticker added to favorites"
-msgstr "贴纸已添加到收藏"
+msgstr "保存"
 
 msgid "Save Settings"
 msgstr "保存设置"
@@ -1096,6 +1105,9 @@ msgstr "贴纸"
 
 msgid "Sticker added"
 msgstr "贴纸已添加"
+
+msgid "Sticker added to favorites"
+msgstr "贴纸已添加到收藏"
 
 msgid "Sticker packs"
 msgstr "贴纸包"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -992,6 +992,15 @@ msgstr "撤销邀请"
 msgid "Save"
 msgstr "收藏"
 
+msgid "Favorite Sticker"
+msgstr "收藏贴纸"
+
+msgid "Failed to add sticker to favorites"
+msgstr "添加贴纸到收藏失败"
+
+msgid "Sticker added to favorites"
+msgstr "贴纸已添加到收藏"
+
 msgid "Save Settings"
 msgstr "保存设置"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -113,6 +113,9 @@ msgstr "附件预览栏"
 msgid "Auto"
 msgstr "自动"
 
+msgid "Auto-sort favorite stickers"
+msgstr "按最近使用自动排序收藏贴纸"
+
 msgid "Auto-sort sticker packs"
 msgstr "按最近使用自动排序贴纸包"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -426,6 +426,9 @@ msgstr "加载新消息失败"
 msgid "Failed to load saved messages"
 msgstr "加载收藏消息失败"
 
+msgid "Failed to load sticker"
+msgstr "加载贴纸失败"
+
 msgid "Failed to load sticker pack"
 msgstr "加载贴纸包失败"
 
@@ -506,6 +509,9 @@ msgstr "更新角色失败"
 
 msgid "Failed to upload avatar"
 msgstr "上传头像失败"
+
+msgid "Favorite"
+msgstr "收藏"
 
 msgid "Favorite Sticker"
 msgstr "收藏贴纸"
@@ -1154,6 +1160,9 @@ msgstr "此邀请可能已过期或被撤销。"
 msgid "This is how your messages will look in chat."
 msgstr "这是你的消息在聊天中的显示效果。"
 
+msgid "This sticker is not part of any pack"
+msgstr "此贴纸不属于任何贴纸包"
+
 msgid "This thread will move back to Threads. Continue?"
 msgstr "此话题将移回话题列表。要继续吗？"
 
@@ -1194,6 +1203,9 @@ msgstr "取消归档聊天？"
 
 msgid "Unarchive thread?"
 msgstr "取消归档话题？"
+
+msgid "Unfavorite"
+msgstr "取消收藏"
 
 msgid "Unknown"
 msgstr "未知"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -426,6 +426,9 @@ msgstr "載入新訊息失敗"
 msgid "Failed to load saved messages"
 msgstr "載入收藏訊息失敗"
 
+msgid "Failed to load sticker"
+msgstr "載入貼紙失敗"
+
 msgid "Failed to load sticker pack"
 msgstr "載入表情包失敗"
 
@@ -506,6 +509,9 @@ msgstr "更新角色失敗"
 
 msgid "Failed to upload avatar"
 msgstr "上傳頭像失敗"
+
+msgid "Favorite"
+msgstr "收藏"
 
 msgid "Favorite Sticker"
 msgstr "收藏貼紙"
@@ -1154,6 +1160,9 @@ msgstr "此邀請可能已過期或被撤銷。"
 msgid "This is how your messages will look in chat."
 msgstr "這是你的訊息在聊天中的顯示效果。"
 
+msgid "This sticker is not part of any pack"
+msgstr "此貼紙不屬於任何貼紙包"
+
 msgid "This thread will move back to Threads. Continue?"
 msgstr "此話題將移回話題列表。要繼續嗎？"
 
@@ -1194,6 +1203,9 @@ msgstr "取消封存聊天？"
 
 msgid "Unarchive thread?"
 msgstr "取消封存話題？"
+
+msgid "Unfavorite"
+msgstr "取消收藏"
 
 msgid "Unknown"
 msgstr "未知"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -113,6 +113,9 @@ msgstr "附件預覽列"
 msgid "Auto"
 msgstr "自動"
 
+msgid "Auto-sort favorite stickers"
+msgstr "按最近使用自動排序收藏貼紙"
+
 msgid "Auto-sort sticker packs"
 msgstr "按最近使用自動排序貼紙包"
 

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -992,6 +992,15 @@ msgstr "撤銷邀請"
 msgid "Save"
 msgstr "收藏"
 
+msgid "Favorite Sticker"
+msgstr "收藏貼紙"
+
+msgid "Failed to add sticker to favorites"
+msgstr "添加貼紙到收藏失敗"
+
+msgid "Sticker added to favorites"
+msgstr "貼紙已添加到收藏"
+
 msgid "Save Settings"
 msgstr "儲存設定"
 

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -366,6 +366,9 @@ msgstr "新增成員失敗"
 msgid "Failed to add sticker"
 msgstr "新增表情失敗"
 
+msgid "Failed to add sticker to favorites"
+msgstr "添加貼紙到收藏失敗"
+
 msgid "Failed to copy invite code"
 msgstr "複製邀請碼失敗"
 
@@ -453,6 +456,9 @@ msgstr "移除成員失敗"
 msgid "Failed to remove sticker"
 msgstr "移除貼紙失敗"
 
+msgid "Failed to rename pack"
+msgstr "重新命名貼紙包失敗"
+
 msgid "Failed to revoke invite"
 msgstr "撤銷邀請失敗"
 
@@ -500,6 +506,9 @@ msgstr "更新角色失敗"
 
 msgid "Failed to upload avatar"
 msgstr "上傳頭像失敗"
+
+msgid "Favorite Sticker"
+msgstr "收藏貼紙"
 
 msgid "Favorites"
 msgstr "收藏"
@@ -830,6 +839,9 @@ msgstr "貼紙包"
 msgid "Pack name"
 msgstr "貼紙包名稱"
 
+msgid "Pack renamed"
+msgstr "貼紙包已重新命名"
+
 msgid "Packs below this line are not auto-sorted"
 msgstr "此行以下的貼紙包不會自動排序"
 
@@ -961,6 +973,12 @@ msgstr "要將這個表情包從你的收藏中移除嗎？"
 msgid "Remove this sticker from the pack?"
 msgstr "要從表情包中移除此表情嗎？"
 
+msgid "Rename pack"
+msgstr "重新命名貼紙包"
+
+msgid "Rename Pack"
+msgstr "重新命名貼紙包"
+
 msgid "replies"
 msgstr "則回覆"
 
@@ -990,16 +1008,7 @@ msgid "Revoke invite"
 msgstr "撤銷邀請"
 
 msgid "Save"
-msgstr "收藏"
-
-msgid "Favorite Sticker"
-msgstr "收藏貼紙"
-
-msgid "Failed to add sticker to favorites"
-msgstr "添加貼紙到收藏失敗"
-
-msgid "Sticker added to favorites"
-msgstr "貼紙已添加到收藏"
+msgstr "儲存"
 
 msgid "Save Settings"
 msgstr "儲存設定"
@@ -1096,6 +1105,9 @@ msgstr "貼紙"
 
 msgid "Sticker added"
 msgstr "已新增表情"
+
+msgid "Sticker added to favorites"
+msgstr "貼紙已添加到收藏"
 
 msgid "Sticker packs"
 msgstr "貼紙包"

--- a/wetty-chat-mobile/src/components/chat/compose/StickerPicker.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/StickerPicker.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { IonIcon, useIonAlert, useIonToast } from '@ionic/react';
-import { heart, heartDislike } from 'ionicons/icons';
-import { starOutline, cubeOutline } from 'ionicons/icons';
+import { heart, heartDislike, heartOutline, cubeOutline } from 'ionicons/icons';
 import { useDispatch, useSelector } from 'react-redux';
 import { t } from '@lingui/core/macro';
 import { StickerImage } from '@/components/shared/StickerImage';
@@ -326,7 +325,7 @@ export function StickerPicker({ isOpen, onStickerSelect, overlayActiveRef }: Sti
               {pack.previewUrl ? (
                 <StickerImage src={pack.previewUrl} alt="" className={styles.packIconImg} />
               ) : (
-                <IonIcon icon={pack.id === 'favorites' ? starOutline : cubeOutline} />
+                <IonIcon icon={pack.id === 'favorites' ? heartOutline : cubeOutline} />
               )}
             </span>
           </button>

--- a/wetty-chat-mobile/src/components/chat/compose/StickerPicker.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/StickerPicker.tsx
@@ -26,9 +26,13 @@ import type { AppDispatch } from '@/store/index';
 import {
   selectStickerAutoSortEnabled,
   selectStickerPackOrder,
+  selectFavoritesAutoSortEnabled,
+  selectFavoritesOrder,
   sortStickerPacksByPreference,
+  sortFavoriteStickersByPreference,
   syncStickerPackOrder,
   upsertStickerPackOrderItem,
+  upsertFavoriteStickerOrderItem,
 } from '@/store/stickerPreferencesSlice';
 
 interface StickerPickerProps {
@@ -61,6 +65,8 @@ export function StickerPicker({ isOpen, onStickerSelect, overlayActiveRef }: Sti
   const [presentToast] = useIonToast();
   const autoSort = useSelector(selectStickerAutoSortEnabled);
   const packOrder = useSelector(selectStickerPackOrder);
+  const autoSortFavorites = useSelector(selectFavoritesAutoSortEnabled);
+  const favoriteOrder = useSelector(selectFavoritesOrder);
 
   const loadPackDetail = useCallback(async (packId: string) => {
     setLoadingPackIds((prev) => ({ ...prev, [packId]: true }));
@@ -116,18 +122,32 @@ export function StickerPicker({ isOpen, onStickerSelect, overlayActiveRef }: Sti
       isLoading: !!loadingPackIds[pack.id],
     }));
 
+    const sortedFavorites = autoSortFavorites
+      ? sortFavoriteStickersByPreference(favoriteStickers, favoriteOrder)
+      : favoriteStickers;
+
     return [
       {
         id: 'favorites',
         name: t`Favorites`,
         previewUrl: null,
         owned: false,
-        stickers: favoriteStickers,
+        stickers: sortedFavorites,
         isLoading: isLibraryLoading,
       },
       ...sortStickerPacksByPreference(packEntries, packOrder),
     ];
-  }, [favoriteStickers, isLibraryLoading, loadingPackIds, ownedPacks, packDetails, subscribedPacks, packOrder]);
+  }, [
+    favoriteStickers,
+    isLibraryLoading,
+    loadingPackIds,
+    ownedPacks,
+    packDetails,
+    subscribedPacks,
+    packOrder,
+    autoSortFavorites,
+    favoriteOrder,
+  ]);
 
   useEffect(() => {
     if (!packs.some((pack) => pack.id === selectedPackId)) {
@@ -161,16 +181,19 @@ export function StickerPicker({ isOpen, onStickerSelect, overlayActiveRef }: Sti
             dispatch(upsertStickerPackOrderItem(updatedItem));
             void dispatch(syncStickerPackOrder([{ ...updatedItem, isAutoSort: true }]));
           }
+
+          if (autoSortFavorites && activePack && activePack.id === 'favorites') {
+            dispatch(upsertFavoriteStickerOrderItem({ stickerId: sticker.id, lastUsedOn: Date.now() }));
+          }
         } catch (err) {
-          console.error('Failed to auto-sort sticker pack order window event:', err);
+          console.error('Failed to auto-sort sticker preferences:', err);
         }
       };
       void run();
       onStickerSelect(sticker);
     },
-    [activePack, autoSort, dispatch, onStickerSelect, packs],
+    [activePack, autoSort, autoSortFavorites, dispatch, onStickerSelect, packs],
   );
-
   const { addStickerFile, setAddStickerFile, fileInputRef, handleFileChange, handleAddSticker } = useAddSticker({
     packId: activePack.owned && activePack.id !== 'favorites' ? activePack.id : undefined,
     onSuccess: (newSticker) => {

--- a/wetty-chat-mobile/src/components/chat/compose/StickerPreviewModal.module.scss
+++ b/wetty-chat-mobile/src/components/chat/compose/StickerPreviewModal.module.scss
@@ -171,23 +171,53 @@
   height: 72px; // enough room for the floating button + safe area
 }
 
+.orphanedMessage {
+  text-align: center;
+  opacity: 0.5;
+  padding: 0 16px 16px;
+}
+
 .floatingAction {
   position: absolute;
   bottom: calc(16px + var(--ion-safe-area-bottom, 0px));
   left: 16px;
   right: 16px;
   display: flex;
+  gap: 8px;
+  z-index: 1;
+}
+
+.floatingActionBtn {
+  flex: 1;
+  display: flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
-  padding: 14px 20px;
+  padding: 14px 12px;
   border-radius: 14px;
   border: none;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 600;
   cursor: pointer;
-  z-index: 1;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+}
+
+.favoriteBtn {
+  background: var(--ion-color-light);
+  color: var(--ion-color-primary);
+
+  &:hover {
+    background: var(--ion-color-light-shade);
+  }
+}
+
+.unfavoriteBtn {
+  background: var(--ion-color-light);
+  color: var(--ion-color-danger);
+
+  &:hover {
+    background: var(--ion-color-light-shade);
+  }
 }
 
 .subscribeBtn {

--- a/wetty-chat-mobile/src/components/chat/compose/StickerPreviewModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/StickerPreviewModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IonContent, IonIcon, IonModal } from '@ionic/react';
-import { close, addCircleOutline, removeCircleOutline, settingsOutline } from 'ionicons/icons';
+import { close, addCircleOutline, removeCircleOutline, settingsOutline, heart, heartDislike } from 'ionicons/icons';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import type { RootState } from '@/store';
@@ -12,6 +12,8 @@ import {
   getStickerPack,
   subscribeStickerPack,
   unsubscribeStickerPack,
+  favoriteSticker,
+  unfavoriteSticker,
   type StickerDetailResponse,
   type StickerPackDetailResponse,
 } from '@/api/stickers';
@@ -51,8 +53,11 @@ function StickerPreviewModalContent({ stickerId, isDesktop, onDismiss }: Sticker
   const [packDetail, setPackDetail] = useState<{ id: string; data: StickerPackDetailResponse } | null>(null);
   const [isSubscribed, setIsSubscribed] = useState(false);
   const [selectedStickerId, setSelectedStickerId] = useState<string | null>(null);
+  const [favoriteOverrides, setFavoriteOverrides] = useState<Record<string, boolean>>({});
+  const [loadError, setLoadError] = useState(false);
+  const [detailLoaded, setDetailLoaded] = useState(false);
 
-  const loading = detail?.id !== stickerId || !packDetail;
+  const loading = !loadError && !detailLoaded;
   const stickerData = detail?.id === stickerId ? detail.data : null;
   const pack = packDetail?.data ?? null;
 
@@ -60,6 +65,7 @@ function StickerPreviewModalContent({ stickerId, isDesktop, onDismiss }: Sticker
     ? (pack?.stickers.find((sticker) => sticker.id === selectedStickerId) ?? stickerData)
     : stickerData;
   const heroUrl = heroSticker?.media.url ?? null;
+  const heroIsFavorited = heroSticker ? (favoriteOverrides[heroSticker.id] ?? heroSticker.isFavorited) : false;
 
   useEffect(() => {
     let cancelled = false;
@@ -68,20 +74,24 @@ function StickerPreviewModalContent({ stickerId, isDesktop, onDismiss }: Sticker
       .then((res) => {
         if (cancelled) return;
         setDetail({ id: stickerId, data: res.data });
-
         const firstPack = res.data.packs[0];
-        if (!firstPack) return;
+        if (!firstPack) {
+          setDetailLoaded(true);
+          return;
+        }
 
         setIsSubscribed(firstPack.isSubscribed);
 
         return getStickerPack(firstPack.id).then((packRes) => {
           if (cancelled) return;
           setPackDetail({ id: firstPack.id, data: packRes.data });
+          setDetailLoaded(true);
         });
       })
       .catch((err) => {
         if (cancelled) return;
         console.error('Failed to load sticker detail', err);
+        setLoadError(true);
       });
 
     return () => {
@@ -106,11 +116,35 @@ function StickerPreviewModalContent({ stickerId, isDesktop, onDismiss }: Sticker
     }
   }
 
+  async function handleFavoriteToggle() {
+    if (!heroSticker) return;
+    const id = heroSticker.id;
+    const prev = heroIsFavorited;
+    setFavoriteOverrides((m) => ({ ...m, [id]: !prev }));
+    try {
+      if (prev) {
+        await unfavoriteSticker(id);
+      } else {
+        await favoriteSticker(id);
+      }
+    } catch {
+      setFavoriteOverrides((m) => ({ ...m, [id]: prev }));
+    }
+  }
+
   const packName = pack?.name ?? stickerData?.packs[0]?.name ?? '';
   const stickerCount = pack?.stickers.length ?? stickerData?.packs[0]?.stickerCount ?? 0;
   const stickers = pack?.stickers ?? [];
 
   function renderContent() {
+    if (loadError) {
+      return (
+        <div className={styles.heroSection}>
+          <p style={{ opacity: 0.5 }}>{t`Failed to load sticker`}</p>
+        </div>
+      );
+    }
+
     if (loading) {
       return (
         <div className={styles.heroSection}>
@@ -126,69 +160,96 @@ function StickerPreviewModalContent({ stickerId, isDesktop, onDismiss }: Sticker
           {heroSticker && <span className={styles.heroEmoji}>{heroSticker.emoji}</span>}
         </div>
 
-        <div className={styles.packHeader}>
-          <span className={styles.packName}>{packName}</span>
-          <span className={styles.packCount}>
-            {stickerCount} <Trans>stickers</Trans>
-          </span>
-        </div>
+        {pack ? (
+          <>
+            <div className={styles.packHeader}>
+              <span className={styles.packName}>{packName}</span>
+              <span className={styles.packCount}>
+                {stickerCount} <Trans>stickers</Trans>
+              </span>
+            </div>
 
-        <div className={styles.grid}>
-          {stickers.map((sticker) => (
-            <button
-              key={sticker.id}
-              type="button"
-              className={`${styles.gridCell} ${(selectedStickerId ?? stickerId) === sticker.id ? styles.gridCellActive : ''}`}
-              onClick={() => setSelectedStickerId(sticker.id)}
-              aria-label={sticker.name || sticker.emoji}
-            >
-              <StickerImage src={sticker.media.url} alt="" className={styles.gridMedia} />
-            </button>
-          ))}
-        </div>
-        <div className={styles.gridBottomSpacer} />
+            <div className={styles.grid}>
+              {stickers.map((sticker) => (
+                <button
+                  key={sticker.id}
+                  type="button"
+                  className={`${styles.gridCell} ${(selectedStickerId ?? stickerId) === sticker.id ? styles.gridCellActive : ''}`}
+                  onClick={() => setSelectedStickerId(sticker.id)}
+                  aria-label={sticker.name || sticker.emoji}
+                >
+                  <StickerImage src={sticker.media.url} alt="" className={styles.gridMedia} />
+                </button>
+              ))}
+            </div>
+            <div className={styles.gridBottomSpacer} />
+          </>
+        ) : (
+          <p className={styles.orphanedMessage}>
+            <Trans>This sticker is not part of any pack</Trans>
+          </p>
+        )}
       </>
     );
   }
 
-  function renderActionButton() {
-    if (loading || !pack) return null;
+  function renderActionButtons() {
+    if (loading) return null;
 
-    if (pack.ownerUid === currentUserId) {
-      return (
-        <button
-          type="button"
-          className={`${styles.floatingAction} ${styles.subscribeBtn}`}
-          onClick={() => {
-            onDismiss();
-
-            const chatMatch = location.pathname.match(/^\/chats\/chat\/([^/]+)/);
-            if (!isDesktop && chatMatch) {
-              const chatId = chatMatch[1];
-              history.push(`/chats/chat/${chatId}/stickers/${pack.id}`);
-            } else {
-              history.push({
-                pathname: `/settings/stickers/${pack.id}`,
-                state: { backgroundPath: location.pathname, fromChat: true },
-              });
-            }
-          }}
-        >
-          <IonIcon icon={settingsOutline} />
-          <Trans>Manage</Trans>
-        </button>
-      );
-    }
-
-    return (
+    const favoriteBtn = (
       <button
         type="button"
-        className={`${styles.floatingAction} ${isSubscribed ? styles.unsubscribeBtn : styles.subscribeBtn}`}
-        onClick={handleSubscriptionToggle}
+        className={`${styles.floatingActionBtn} ${heroIsFavorited ? styles.unfavoriteBtn : styles.favoriteBtn}`}
+        onClick={handleFavoriteToggle}
       >
-        <IonIcon icon={isSubscribed ? removeCircleOutline : addCircleOutline} />
-        {isSubscribed ? <Trans>Unsubscribe</Trans> : <Trans>Subscribe</Trans>}
+        <IonIcon icon={heroIsFavorited ? heartDislike : heart} />
+        {heroIsFavorited ? <Trans>Unfavorite</Trans> : <Trans>Favorite</Trans>}
       </button>
+    );
+
+    if (!pack) {
+      return <div className={styles.floatingAction}>{favoriteBtn}</div>;
+    }
+
+    const isOwner = pack.ownerUid === currentUserId;
+
+    return (
+      <div className={styles.floatingAction}>
+        {favoriteBtn}
+
+        {isOwner ? (
+          <button
+            type="button"
+            className={`${styles.floatingActionBtn} ${styles.subscribeBtn}`}
+            onClick={() => {
+              onDismiss();
+
+              const chatMatch = location.pathname.match(/^\/chats\/chat\/([^/]+)/);
+              if (!isDesktop && chatMatch) {
+                const chatId = chatMatch[1];
+                history.push(`/chats/chat/${chatId}/stickers/${pack.id}`);
+              } else {
+                history.push({
+                  pathname: `/settings/stickers/${pack.id}`,
+                  state: { backgroundPath: location.pathname, fromChat: true },
+                });
+              }
+            }}
+          >
+            <IonIcon icon={settingsOutline} />
+            <Trans>Manage</Trans>
+          </button>
+        ) : (
+          <button
+            type="button"
+            className={`${styles.floatingActionBtn} ${isSubscribed ? styles.unsubscribeBtn : styles.subscribeBtn}`}
+            onClick={handleSubscriptionToggle}
+          >
+            <IonIcon icon={isSubscribed ? removeCircleOutline : addCircleOutline} />
+            {isSubscribed ? <Trans>Unsubscribe</Trans> : <Trans>Subscribe</Trans>}
+          </button>
+        )}
+      </div>
     );
   }
 
@@ -201,7 +262,7 @@ function StickerPreviewModalContent({ stickerId, isDesktop, onDismiss }: Sticker
           </button>
           {renderContent()}
         </IonContent>
-        {renderActionButton()}
+        {renderActionButtons()}
       </IonModal>
     );
   }
@@ -217,7 +278,7 @@ function StickerPreviewModalContent({ stickerId, isDesktop, onDismiss }: Sticker
           <span className={styles.sheetTitle}>{packName}</span>
         </div>
         <div className={styles.sheetBody}>{renderContent()}</div>
-        {renderActionButton()}
+        {renderActionButtons()}
       </div>
     </>
   );

--- a/wetty-chat-mobile/src/main.tsx
+++ b/wetty-chat-mobile/src/main.tsx
@@ -39,16 +39,24 @@ installBootstrapRecoveryHandlers();
 
 async function bootstrap() {
   // Load persisted state from IndexedDB
-  const [savedSettings, savedStickerPackOrder, savedAutoSort] = await Promise.all([
-    kvGet<Partial<SettingsState>>('settings'),
-    kvGet<unknown>('stickerPackOrder'),
-    kvGet<unknown>('autoSortStickerPacks'),
-    initializeClientId(),
-    syncJwtTokenToIdb(),
-  ]);
+  const [savedSettings, savedStickerPackOrder, savedAutoSort, savedFavoriteOrder, savedAutoSortFavorites] =
+    await Promise.all([
+      kvGet<Partial<SettingsState>>('settings'),
+      kvGet<unknown>('stickerPackOrder'),
+      kvGet<unknown>('autoSortStickerPacks'),
+      kvGet<unknown>('favoriteStickerOrder'),
+      kvGet<unknown>('autoSortFavoriteStickers'),
+      initializeClientId(),
+      syncJwtTokenToIdb(),
+    ]);
 
   const settings = hydrateSettings(savedSettings);
-  const hydratedStickerPreferences = hydrateStickerPreferences(savedStickerPackOrder, savedAutoSort);
+  const hydratedStickerPreferences = hydrateStickerPreferences(
+    savedStickerPackOrder,
+    savedAutoSort,
+    savedFavoriteOrder,
+    savedAutoSortFavorites,
+  );
 
   if (hydratedStickerPreferences.clearPackOrder) {
     await kvDelete('stickerPackOrder');
@@ -62,6 +70,17 @@ async function bootstrap() {
     await kvSet('autoSortStickerPacks', hydratedStickerPreferences.state.autoSortEnabled);
   }
 
+  if (hydratedStickerPreferences.clearFavoriteOrder) {
+    await kvDelete('favoriteStickerOrder');
+  } else if (hydratedStickerPreferences.persistFavoriteOrder) {
+    await kvSet('favoriteStickerOrder', hydratedStickerPreferences.state.favoriteStickerOrder);
+  }
+
+  if (hydratedStickerPreferences.clearAutoSortFavorites) {
+    await kvDelete('autoSortFavoriteStickers');
+  } else if (hydratedStickerPreferences.persistAutoSortFavorites) {
+    await kvSet('autoSortFavoriteStickers', hydratedStickerPreferences.state.autoSortFavoritesEnabled);
+  }
   await activateDetectedLocale(settings.locale);
 
   const store = createStore(settings, hydratedStickerPreferences.state);

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -28,7 +28,7 @@ import {
   informationCircleOutline,
   notificationsOffOutline,
   linkOutline,
-  starOutline,
+  heartOutline,
   notifications,
   people,
   pin as pinIcon,
@@ -1743,7 +1743,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
       actions.push({
         key: 'favorite',
         label: t`Favorite Sticker`,
-        icon: starOutline,
+        icon: heartOutline,
         handler: () => {
           favoriteSticker(msg.sticker!.id)
             .then(() => {

--- a/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
+++ b/wetty-chat-mobile/src/pages/chat-thread/chat-thread.tsx
@@ -28,6 +28,7 @@ import {
   informationCircleOutline,
   notificationsOffOutline,
   linkOutline,
+  starOutline,
   notifications,
   people,
   pin as pinIcon,
@@ -139,6 +140,7 @@ import {
   addRecentReaction,
 } from '@/store/settingsSlice';
 import { MAX_REACTIONS_PER_USER_PER_MESSAGE } from '@/constants/emojiAndStickers';
+import { favoriteSticker } from '@/api/stickers';
 import { saveMessage } from '@/api/savedMessages';
 import { useFeatureGate } from '@/hooks/useFeatureGate';
 
@@ -1689,8 +1691,9 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
     const audioMessage = isAudioMessage(msg);
     const stickerMessage = msg.messageType === 'sticker';
     const isOwn = msg.sender.uid === currentUserId;
-    const canSaveMessage =
-      savedMessagesEnabled && !msg.isDeleted && msg.messageType !== 'system' && !msg.id.startsWith('cg_');
+    const isDeletableAction = !msg.isDeleted && !msg.id.startsWith('cg_');
+    const canSaveMessage = savedMessagesEnabled && isDeletableAction && msg.messageType !== 'system';
+    const canFavoriteSticker = isDeletableAction;
     const actions: MessageOverlayAction[] = [];
 
     if (!audioMessage && !stickerMessage) {
@@ -1736,7 +1739,22 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
       },
     });
 
-    if (canSaveMessage) {
+    if (stickerMessage && canFavoriteSticker) {
+      actions.push({
+        key: 'favorite',
+        label: t`Favorite Sticker`,
+        icon: starOutline,
+        handler: () => {
+          favoriteSticker(msg.sticker!.id)
+            .then(() => {
+              showToast(t`Sticker added to favorites`, 2000);
+            })
+            .catch((e: Error) => {
+              showToast(e.message || t`Failed to add sticker to favorites`);
+            });
+        },
+      });
+    } else if (!stickerMessage && canSaveMessage) {
       actions.push({
         key: 'save',
         label: t`Save`,
@@ -1854,7 +1872,7 @@ function ChatThreadCore({ chatId, threadId, backAction }: ChatThreadCoreProps) {
     }
     if (stickerMessage) {
       return actions.filter(
-        (a) => a.key === 'reply' || a.key === 'delete' || a.key === 'copy-link' || a.key === 'save',
+        (a) => a.key === 'reply' || a.key === 'delete' || a.key === 'copy-link' || a.key === 'favorite',
       );
     }
     return actions;

--- a/wetty-chat-mobile/src/pages/settings/sticker-pack-detail.tsx
+++ b/wetty-chat-mobile/src/pages/settings/sticker-pack-detail.tsx
@@ -12,12 +12,11 @@ import {
   useIonAlert,
   useIonToast,
 } from '@ionic/react';
-import { trashOutline } from 'ionicons/icons';
-import { useParams } from 'react-router-dom';
+import { trashOutline, pencilOutline } from 'ionicons/icons';
+import { useParams, useHistory } from 'react-router-dom';
 import { t } from '@lingui/core/macro';
 import { StickerImage } from '@/components/shared/StickerImage';
 import { Trans } from '@lingui/react/macro';
-import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { BackButton } from '@/components/BackButton';
 import { AddStickerModal } from '@/components/chat/compose/AddStickerModal';
@@ -26,6 +25,7 @@ import {
   deleteStickerPack,
   getStickerPack,
   removeStickerFromPack,
+  updateStickerPack,
   type StickerPackDetailResponse,
   type StickerSummary,
   unsubscribeStickerPack,
@@ -189,6 +189,38 @@ export function StickerPackDetailCore({ packId, backAction }: StickerPackDetailC
     });
   };
 
+  const handleRenamePack = () => {
+    presentAlert({
+      header: t`Rename Pack`,
+      inputs: [
+        {
+          name: 'name',
+          type: 'text',
+          placeholder: t`Pack name`,
+          value: pack?.name,
+        },
+      ],
+      buttons: [
+        { text: t`Cancel`, role: 'cancel' },
+        {
+          text: t`Save`,
+          handler: async (data: { name: string }) => {
+            const newName = data.name.trim();
+            if (!newName || newName === pack?.name) return false;
+            try {
+              const res = await updateStickerPack(packId, { name: newName });
+              setPack((prev) => (prev ? { ...prev, name: res.data.name } : prev));
+              presentToast({ message: t`Pack renamed`, duration: 2000, position: 'bottom' });
+            } catch (error) {
+              console.error('Failed to rename sticker pack', error);
+              presentToast({ message: t`Failed to rename pack`, duration: 2000, position: 'bottom' });
+            }
+          },
+        },
+      ],
+    });
+  };
+
   return (
     <IonPage>
       <IonHeader>
@@ -203,6 +235,9 @@ export function StickerPackDetailCore({ packId, backAction }: StickerPackDetailC
           <IonTitle>{pack.name}</IonTitle>
           {owned && (
             <IonButtons slot="end">
+              <IonButton onClick={handleRenamePack} aria-label={t`Rename pack`}>
+                <IonIcon slot="icon-only" icon={pencilOutline} />
+              </IonButton>
               <IonButton color="danger" onClick={handleDeletePack} aria-label={t`Delete pack`}>
                 <IonIcon slot="icon-only" icon={trashOutline} />
               </IonButton>

--- a/wetty-chat-mobile/src/pages/settings/sticker-pack-detail.tsx
+++ b/wetty-chat-mobile/src/pages/settings/sticker-pack-detail.tsx
@@ -12,7 +12,7 @@ import {
   useIonAlert,
   useIonToast,
 } from '@ionic/react';
-import { trashOutline, pencilOutline } from 'ionicons/icons';
+import { trashOutline, createOutline } from 'ionicons/icons';
 import { useParams, useHistory } from 'react-router-dom';
 import { t } from '@lingui/core/macro';
 import { StickerImage } from '@/components/shared/StickerImage';
@@ -236,7 +236,7 @@ export function StickerPackDetailCore({ packId, backAction }: StickerPackDetailC
           {owned && (
             <IonButtons slot="end">
               <IonButton onClick={handleRenamePack} aria-label={t`Rename pack`}>
-                <IonIcon slot="icon-only" icon={pencilOutline} />
+                <IonIcon slot="icon-only" icon={createOutline} />
               </IonButton>
               <IonButton color="danger" onClick={handleDeletePack} aria-label={t`Delete pack`}>
                 <IonIcon slot="icon-only" icon={trashOutline} />

--- a/wetty-chat-mobile/src/pages/settings/stickers.tsx
+++ b/wetty-chat-mobile/src/pages/settings/stickers.tsx
@@ -41,7 +41,9 @@ import type { AppDispatch } from '@/store/index';
 import {
   selectStickerAutoSortEnabled,
   selectStickerPackOrder,
+  selectFavoritesAutoSortEnabled,
   setAutoSortEnabled,
+  setAutoSortFavoritesEnabled,
   sortStickerPacksByPreference,
   syncStickerPackOrder,
   upsertStickerPackOrderItem,
@@ -63,6 +65,7 @@ export function StickerSettingsCore({ backAction, onOpenPack }: StickerSettingsC
   const [itemHeight, setItemHeight] = useState(0);
   const listRef = useRef<HTMLIonReorderGroupElement>(null);
   const autoSort = useSelector(selectStickerAutoSortEnabled);
+  const autoSortFavorites = useSelector(selectFavoritesAutoSortEnabled);
   const packOrder = useSelector(selectStickerPackOrder);
   const pinnedReactions = useSelector(selectPinnedReactions);
   const ownedPackIds = useMemo(() => new Set(ownedPacks.map((pack) => pack.id)), [ownedPacks]);
@@ -236,6 +239,18 @@ export function StickerSettingsCore({ backAction, onOpenPack }: StickerSettingsC
               checked={autoSort}
               onIonChange={(e) => {
                 dispatch(setAutoSortEnabled(e.detail.checked));
+              }}
+            />
+          </IonItem>
+          <IonItem lines="full">
+            <IonLabel>
+              <Trans>Auto-sort favorite stickers</Trans>
+            </IonLabel>
+            <IonToggle
+              slot="end"
+              checked={autoSortFavorites}
+              onIonChange={(e) => {
+                dispatch(setAutoSortFavoritesEnabled(e.detail.checked));
               }}
             />
           </IonItem>

--- a/wetty-chat-mobile/src/store/index.ts
+++ b/wetty-chat-mobile/src/store/index.ts
@@ -7,8 +7,10 @@ import stickerPreferencesReducer, {
   removeStickerPackOrderItem,
   replaceStickerPackOrderFromWs,
   setAutoSortEnabled,
+  setAutoSortFavoritesEnabled,
   syncStickerPackOrder,
   upsertStickerPackOrderItem,
+  upsertFavoriteStickerOrderItem,
   type StickerPreferencesState,
 } from './stickerPreferencesSlice';
 import threadsReducer, {
@@ -215,12 +217,19 @@ listenerMiddleware.startListening({
     removeStickerPackOrderItem,
     replaceStickerPackOrderFromWs,
     setAutoSortEnabled,
+    setAutoSortFavoritesEnabled,
     upsertStickerPackOrderItem,
+    upsertFavoriteStickerOrderItem,
   ),
   effect: async (_action, api) => {
     const state = api.getState() as RootState;
-    const { packOrder, autoSortEnabled } = state.stickerPreferences;
-    await Promise.all([kvSet('stickerPackOrder', packOrder), kvSet('autoSortStickerPacks', autoSortEnabled)]);
+    const { packOrder, autoSortEnabled, favoriteStickerOrder, autoSortFavoritesEnabled } = state.stickerPreferences;
+    await Promise.all([
+      kvSet('stickerPackOrder', packOrder),
+      kvSet('autoSortStickerPacks', autoSortEnabled),
+      kvSet('favoriteStickerOrder', favoriteStickerOrder),
+      kvSet('autoSortFavoriteStickers', autoSortFavoritesEnabled),
+    ]);
   },
 });
 

--- a/wetty-chat-mobile/src/store/stickerPreferencesSlice.ts
+++ b/wetty-chat-mobile/src/store/stickerPreferencesSlice.ts
@@ -4,9 +4,16 @@ import type { RootState } from './index';
 import { fetchCurrentUser } from './userSlice';
 import { usersApi, type StickerPackOrderItem, type UpdateStickerPackOrderItem } from '@/api/users';
 
+export interface FavoriteStickerOrderItem {
+  stickerId: string;
+  lastUsedOn: number;
+}
+
 export interface StickerPreferencesState {
   packOrder: StickerPackOrderItem[];
   autoSortEnabled: boolean;
+  favoriteStickerOrder: FavoriteStickerOrderItem[];
+  autoSortFavoritesEnabled: boolean;
   hydrationStatus: 'idle' | 'kv' | 'server';
 }
 
@@ -16,123 +23,157 @@ export interface HydratedStickerPreferences {
   clearPackOrder: boolean;
   persistAutoSort: boolean;
   clearAutoSort: boolean;
+  persistFavoriteOrder: boolean;
+  clearFavoriteOrder: boolean;
+  persistAutoSortFavorites: boolean;
+  clearAutoSortFavorites: boolean;
 }
 
 const initialState: StickerPreferencesState = {
   packOrder: [],
   autoSortEnabled: false,
+  favoriteStickerOrder: [],
+  autoSortFavoritesEnabled: false,
   hydrationStatus: 'idle',
 };
 
-function normalizeOrderItems(items: StickerPackOrderItem[]): {
-  packOrder: StickerPackOrderItem[];
-  changed: boolean;
-} {
-  const deduped = new Map<string, StickerPackOrderItem>();
+// --- Generic keyed-order helpers ---
+// Both StickerPackOrderItem and FavoriteStickerOrderItem are structurally
+// { id: string; lastUsedOn: number }, differing only in the ID field name.
+// These helpers operate on either via a `key` parameter.
+// TS interfaces lack implicit index signatures, so we cast to Record inside
+// the helpers when accessing dynamic keys.
+
+function normalizeKeyedOrderItems<T extends { lastUsedOn: number }>(
+  items: T[],
+  key: keyof T & string,
+): { items: T[]; changed: boolean } {
+  const deduped = new Map<string, T>();
   let changed = false;
 
   for (const item of items) {
-    const normalized = {
-      stickerPackId: item.stickerPackId,
-      lastUsedOn: Math.trunc(item.lastUsedOn),
-    };
-
-    if (normalized.lastUsedOn !== item.lastUsedOn || deduped.has(normalized.stickerPackId)) {
+    const id = (item as unknown as Record<string, string>)[key];
+    const truncated = Math.trunc(item.lastUsedOn);
+    if (truncated !== item.lastUsedOn || deduped.has(id)) {
       changed = true;
     }
-
-    deduped.set(normalized.stickerPackId, normalized);
+    deduped.set(id, { ...item, [key]: id, lastUsedOn: truncated });
   }
 
-  return { packOrder: Array.from(deduped.values()), changed };
+  return { items: Array.from(deduped.values()), changed };
 }
 
-function isStickerPackOrderItem(value: unknown): value is StickerPackOrderItem {
+function isKeyedOrderItem(value: unknown, key: string): boolean {
   if (value == null || typeof value !== 'object') {
     return false;
   }
 
   const candidate = value as Record<string, unknown>;
   return (
-    typeof candidate.stickerPackId === 'string' &&
-    candidate.stickerPackId.length > 0 &&
+    typeof candidate[key] === 'string' &&
+    (candidate[key] as string).length > 0 &&
     typeof candidate.lastUsedOn === 'number' &&
     Number.isFinite(candidate.lastUsedOn)
   );
 }
 
-function normalizePackOrderValue(savedOrder: unknown): {
-  packOrder: StickerPackOrderItem[];
-  persist: boolean;
-  clear: boolean;
-} {
+function normalizeKeyedOrderValue<T extends { lastUsedOn: number }>(
+  savedOrder: unknown,
+  key: keyof T & string,
+  makeItem: (id: string) => T,
+): { order: T[]; persist: boolean; clear: boolean } {
   if (savedOrder == null) {
-    return { packOrder: [], persist: false, clear: false };
+    return { order: [], persist: false, clear: false };
   }
 
   if (!Array.isArray(savedOrder)) {
-    return { packOrder: [], persist: false, clear: true };
+    return { order: [], persist: false, clear: true };
   }
 
   if (savedOrder.length === 0) {
-    return { packOrder: [], persist: false, clear: false };
+    return { order: [], persist: false, clear: false };
   }
 
+  // Legacy migration: plain string[] (pack order only, but harmless generically)
   if (savedOrder.every((item) => typeof item === 'string')) {
     const deduped = Array.from(new Set(savedOrder));
     return {
-      packOrder: deduped.map((stickerPackId) => ({ stickerPackId, lastUsedOn: 0 })),
+      order: deduped.map((id) => makeItem(id)),
       persist: true,
       clear: false,
     };
   }
 
-  if (!savedOrder.every(isStickerPackOrderItem)) {
-    return { packOrder: [], persist: false, clear: true };
+  if (!savedOrder.every((item) => isKeyedOrderItem(item, key))) {
+    return { order: [], persist: false, clear: true };
   }
 
-  const normalized = normalizeOrderItems(savedOrder);
+  const normalized = normalizeKeyedOrderItems(savedOrder as T[], key);
   return {
-    packOrder: normalized.packOrder,
+    order: normalized.items,
     persist: normalized.changed,
     clear: false,
   };
 }
 
-function normalizeAutoSortValue(savedAutoSort: unknown): {
-  autoSortEnabled: boolean;
+function normalizeBooleanValue(saved: unknown): {
+  value: boolean;
   persist: boolean;
   clear: boolean;
 } {
-  if (savedAutoSort == null) {
-    return { autoSortEnabled: false, persist: false, clear: false };
+  if (saved == null) {
+    return { value: false, persist: false, clear: false };
   }
 
-  if (typeof savedAutoSort !== 'boolean') {
-    return { autoSortEnabled: false, persist: false, clear: true };
+  if (typeof saved !== 'boolean') {
+    return { value: false, persist: false, clear: true };
   }
 
-  return { autoSortEnabled: savedAutoSort, persist: false, clear: false };
+  return { value: saved, persist: false, clear: false };
 }
 
 function replacePackOrder(state: StickerPreferencesState, packOrder: StickerPackOrderItem[]) {
-  state.packOrder = normalizeOrderItems(packOrder).packOrder;
+  state.packOrder = normalizeKeyedOrderItems(packOrder, 'stickerPackId').items;
 }
 
-export function hydrateStickerPreferences(savedOrder: unknown, savedAutoSort: unknown): HydratedStickerPreferences {
-  const normalizedOrder = normalizePackOrderValue(savedOrder);
-  const normalizedAutoSort = normalizeAutoSortValue(savedAutoSort);
+function replaceFavoriteOrder(state: StickerPreferencesState, favoriteOrder: FavoriteStickerOrderItem[]) {
+  state.favoriteStickerOrder = normalizeKeyedOrderItems(favoriteOrder, 'stickerId').items;
+}
+
+export function hydrateStickerPreferences(
+  savedOrder: unknown,
+  savedAutoSort: unknown,
+  savedFavoriteOrder?: unknown,
+  savedAutoSortFavorites?: unknown,
+): HydratedStickerPreferences {
+  const normalizedOrder = normalizeKeyedOrderValue<StickerPackOrderItem>(savedOrder, 'stickerPackId', (id) => ({
+    stickerPackId: id,
+    lastUsedOn: 0,
+  }));
+  const normalizedAutoSort = normalizeBooleanValue(savedAutoSort);
+  const normalizedFavoriteOrder = normalizeKeyedOrderValue<FavoriteStickerOrderItem>(
+    savedFavoriteOrder,
+    'stickerId',
+    (id) => ({ stickerId: id, lastUsedOn: 0 }),
+  );
+  const normalizedAutoSortFavorites = normalizeBooleanValue(savedAutoSortFavorites);
 
   return {
     state: {
-      packOrder: normalizedOrder.packOrder,
-      autoSortEnabled: normalizedAutoSort.autoSortEnabled,
+      packOrder: normalizedOrder.order,
+      autoSortEnabled: normalizedAutoSort.value,
+      favoriteStickerOrder: normalizedFavoriteOrder.order,
+      autoSortFavoritesEnabled: normalizedAutoSortFavorites.value,
       hydrationStatus: 'kv',
     },
     persistPackOrder: normalizedOrder.persist,
     clearPackOrder: normalizedOrder.clear,
     persistAutoSort: normalizedAutoSort.persist,
     clearAutoSort: normalizedAutoSort.clear,
+    persistFavoriteOrder: normalizedFavoriteOrder.persist,
+    clearFavoriteOrder: normalizedFavoriteOrder.clear,
+    persistAutoSortFavorites: normalizedAutoSortFavorites.persist,
+    clearAutoSortFavorites: normalizedAutoSortFavorites.clear,
   };
 }
 
@@ -140,12 +181,27 @@ export function sortStickerPacksByPreference<T extends { id: string }>(
   packs: T[],
   packOrder: StickerPackOrderItem[],
 ): T[] {
-  const originalIndex = new Map(packs.map((pack, index) => [pack.id, index]));
-  const lastUsedByPackId = new Map(packOrder.map((item) => [item.stickerPackId, item.lastUsedOn]));
+  return sortByKeyedOrder(packs, packOrder, 'stickerPackId');
+}
 
-  return [...packs].sort((a, b) => {
-    const lastUsedA = lastUsedByPackId.get(a.id);
-    const lastUsedB = lastUsedByPackId.get(b.id);
+export function sortFavoriteStickersByPreference<T extends { id: string }>(
+  stickers: T[],
+  favoriteOrder: FavoriteStickerOrderItem[],
+): T[] {
+  return sortByKeyedOrder(stickers, favoriteOrder, 'stickerId');
+}
+
+function sortByKeyedOrder<T extends { id: string }, O extends { lastUsedOn: number }>(
+  items: T[],
+  order: O[],
+  key: keyof O & string,
+): T[] {
+  const originalIndex = new Map(items.map((item, index) => [item.id, index]));
+  const lastUsedById = new Map(order.map((item) => [item[key] as string, item.lastUsedOn as number]));
+
+  return [...items].sort((a, b) => {
+    const lastUsedA = lastUsedById.get(a.id);
+    const lastUsedB = lastUsedById.get(b.id);
 
     if (lastUsedA != null && lastUsedB != null && lastUsedA !== lastUsedB) {
       return lastUsedB - lastUsedA;
@@ -181,14 +237,24 @@ const stickerPreferencesSlice = createSlice({
   reducers: {
     hydrateStickerPreferencesFromKv(
       state,
-      action: PayloadAction<Pick<StickerPreferencesState, 'packOrder' | 'autoSortEnabled'>>,
+      action: PayloadAction<
+        Pick<
+          StickerPreferencesState,
+          'packOrder' | 'autoSortEnabled' | 'favoriteStickerOrder' | 'autoSortFavoritesEnabled'
+        >
+      >,
     ) {
       replacePackOrder(state, action.payload.packOrder);
       state.autoSortEnabled = action.payload.autoSortEnabled;
+      replaceFavoriteOrder(state, action.payload.favoriteStickerOrder);
+      state.autoSortFavoritesEnabled = action.payload.autoSortFavoritesEnabled;
       state.hydrationStatus = 'kv';
     },
     setAutoSortEnabled(state, action: PayloadAction<boolean>) {
       state.autoSortEnabled = action.payload;
+    },
+    setAutoSortFavoritesEnabled(state, action: PayloadAction<boolean>) {
+      state.autoSortFavoritesEnabled = action.payload;
     },
     upsertStickerPackOrderItem(state, action: PayloadAction<StickerPackOrderItem>) {
       const existing = state.packOrder.find((item) => item.stickerPackId === action.payload.stickerPackId);
@@ -201,6 +267,18 @@ const stickerPreferencesSlice = createSlice({
         });
       }
       replacePackOrder(state, state.packOrder);
+    },
+    upsertFavoriteStickerOrderItem(state, action: PayloadAction<FavoriteStickerOrderItem>) {
+      const existing = state.favoriteStickerOrder.find((item) => item.stickerId === action.payload.stickerId);
+      if (existing) {
+        existing.lastUsedOn = Math.trunc(action.payload.lastUsedOn);
+      } else {
+        state.favoriteStickerOrder.push({
+          stickerId: action.payload.stickerId,
+          lastUsedOn: Math.trunc(action.payload.lastUsedOn),
+        });
+      }
+      replaceFavoriteOrder(state, state.favoriteStickerOrder);
     },
     removeStickerPackOrderItem(state, action: PayloadAction<string>) {
       state.packOrder = state.packOrder.filter((item) => item.stickerPackId !== action.payload);
@@ -222,13 +300,17 @@ export const {
   removeStickerPackOrderItem,
   replaceStickerPackOrderFromWs,
   setAutoSortEnabled,
+  setAutoSortFavoritesEnabled,
   upsertStickerPackOrderItem,
+  upsertFavoriteStickerOrderItem,
 } = stickerPreferencesSlice.actions;
 
 export const selectStickerPreferences = (state: RootState) => state.stickerPreferences;
 export const selectStickerPackOrder = (state: RootState) => state.stickerPreferences.packOrder;
 export const selectStickerAutoSortEnabled = (state: RootState) => state.stickerPreferences.autoSortEnabled;
 export const selectStickerHydrationStatus = (state: RootState) => state.stickerPreferences.hydrationStatus;
+export const selectFavoritesAutoSortEnabled = (state: RootState) => state.stickerPreferences.autoSortFavoritesEnabled;
+export const selectFavoritesOrder = (state: RootState) => state.stickerPreferences.favoriteStickerOrder;
 export const selectStickerPackOrderRankMap = (state: RootState) => {
   const sortedOrder = [...state.stickerPreferences.packOrder].sort((a, b) => b.lastUsedOn - a.lastUsedOn);
   return new Map(sortedOrder.map((item, index) => [item.stickerPackId, index]));


### PR DESCRIPTION
- Replaced "Save" with "Favorite Sticker" in context menu. It now saves directly to sticker collection instead of message bookmarks, which is much more intuitive.

- We can now favorite a single sticker from the click modal, alongside the option to subscribe to the whole pack.

- Stickers that no longer belong to a pack (e.g., deleted from the pack, or the pack itself was deleted) can now also be clicked and favorited.

- Added the ability to rename self-created sticker packs in Settings.

- Added an auto-sort option for favorited stickers.