### PR TITLE
fix(pwa): Miscellaneous fixes and improvements

### DIFF
--- a/backend/src/dto/messages.rs
+++ b/backend/src/dto/messages.rs
@@ -112,6 +112,12 @@ pub struct MessagePreviewSticker {
     pub emoji: String,
 }
 
+#[derive(Debug, Serialize, Clone, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MessagePreviewAttachment {
+    pub kind: String,
+}
+
 #[derive(Debug, Serialize, Clone, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MessagePreview {
@@ -126,6 +132,7 @@ pub struct MessagePreview {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker: Option<MessagePreviewSticker>,
     pub first_attachment_kind: Option<String>,
+    pub attachments: Vec<MessagePreviewAttachment>,
     pub is_deleted: bool,
     pub mentions: Vec<MentionInfo>,
 }

--- a/backend/src/dto/messages.rs
+++ b/backend/src/dto/messages.rs
@@ -112,7 +112,7 @@ pub struct MessagePreviewSticker {
     pub emoji: String,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MessagePreviewAttachment {
     pub kind: String,
@@ -131,7 +131,6 @@ pub struct MessagePreview {
     pub message_type: MessageType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker: Option<MessagePreviewSticker>,
-    pub first_attachment_kind: Option<String>,
     pub attachments: Vec<MessagePreviewAttachment>,
     pub is_deleted: bool,
     pub mentions: Vec<MentionInfo>,

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -17,9 +17,9 @@ use crate::{
         attachments::AttachmentResponse,
         chats::{ChatListItem, ListChatsResponse, MarkChatReadStateResponse, UnreadCountResponse},
         messages::{
-            MentionInfo, MessagePreview, MessagePreviewSticker, MessageResponse,
-            MessageStickerResponse, ReactionReactor, ReactionSummary, StickerMediaResponse,
-            ThreadInfo,
+            MentionInfo, MessagePreview, MessagePreviewAttachment, MessagePreviewSticker,
+            MessageResponse, MessageStickerResponse, ReactionReactor, ReactionSummary,
+            StickerMediaResponse, ThreadInfo,
         },
         users::User,
         ws::{ChatArchiveStateChangedPayload, ServerWsMessage},
@@ -311,6 +311,13 @@ fn message_response_preview(response: MessageResponse) -> MessagePreview {
             .attachments
             .first()
             .map(|attachment| attachment.kind.clone()),
+        attachments: response
+            .attachments
+            .iter()
+            .map(|a| MessagePreviewAttachment {
+                kind: a.kind.clone(),
+            })
+            .collect(),
         is_deleted,
         mentions: response.mentions,
     }
@@ -341,6 +348,21 @@ fn first_attachment_kind(
         .map(|attachment| attachment.kind.clone())
 }
 
+fn attachment_previews(
+    map: &std::collections::HashMap<i64, Vec<Attachment>>,
+    message_id: i64,
+) -> Vec<MessagePreviewAttachment> {
+    map.get(&message_id)
+        .map(|atts| {
+            atts.iter()
+                .map(|a| MessagePreviewAttachment {
+                    kind: a.kind.clone(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 pub(crate) fn message_is_visible_in_thread_scope(message: &Message, thread_root_id: i64) -> bool {
     if !message.is_published {
@@ -362,6 +384,7 @@ pub(crate) fn redact_deleted_message_preview(preview: &mut MessagePreview) {
     preview.message = None;
     preview.sticker = None;
     preview.first_attachment_kind = None;
+    preview.attachments.clear();
     preview.mentions.clear();
 }
 
@@ -997,6 +1020,10 @@ pub async fn attach_metadata(
                         })
                     }),
                     first_attachment_kind: first_attachment_kind(
+                        &message_attachments_map,
+                        reply_msg.id,
+                    ),
+                    attachments: attachment_previews(
                         &message_attachments_map,
                         reply_msg.id,
                     ),
@@ -1725,8 +1752,8 @@ mod tests {
         attachment_preview_text, build_push_preview_bundle, extract_mention_uids,
         first_attachment_kind, message_is_visible_in_thread_scope, redact_deleted_message_preview,
         redact_deleted_message_response, render_mentions_as_text, sticker_preview_text,
-        MentionInfo, MessagePreview, MessageResponse, MessageStickerResponse, PreparedMessageSend,
-        ReactionSummary, StickerMediaResponse,
+        MentionInfo, MessagePreview, MessagePreviewAttachment, MessageResponse,
+        MessageStickerResponse, PreparedMessageSend, ReactionSummary, StickerMediaResponse,
     };
     use crate::{
         dto::{attachments::AttachmentResponse, users::User},
@@ -2068,6 +2095,9 @@ mod tests {
             message_type: MessageType::Audio,
             sticker: None,
             first_attachment_kind: Some("audio/webm".to_string()),
+            attachments: vec![MessagePreviewAttachment {
+                kind: "audio/webm".to_string(),
+            }],
             is_deleted: false,
             mentions: Vec::new(),
         };
@@ -2077,6 +2107,7 @@ mod tests {
         assert_eq!(value["messageType"], json!("audio"));
         assert_eq!(value["isDeleted"], json!(false));
         assert_eq!(value["firstAttachmentKind"], json!("audio/webm"));
+        assert_eq!(value["attachments"], json!([{"kind": "audio/webm"}]));
         assert!(value.get("message_type").is_none());
     }
 
@@ -2201,6 +2232,9 @@ mod tests {
                 emoji: "🙂".to_string(),
             }),
             first_attachment_kind: Some("image/png".to_string()),
+            attachments: vec![MessagePreviewAttachment {
+                kind: "image/png".to_string(),
+            }],
             is_deleted: true,
             mentions: vec![MentionInfo {
                 uid: 9,
@@ -2220,6 +2254,7 @@ mod tests {
         assert_eq!(preview.message, None);
         assert!(preview.sticker.is_none());
         assert!(preview.first_attachment_kind.is_none());
+        assert!(preview.attachments.is_empty());
         assert!(preview.mentions.is_empty());
     }
 }

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -349,23 +349,39 @@ fn attachment_previews(
         .unwrap_or_default()
 }
 
+pub(crate) struct MessagePreviewInput {
+    pub id: i64,
+    pub client_generated_id: String,
+    pub created_at: DateTime<Utc>,
+    pub sender: User,
+    pub message: Option<String>,
+    pub message_type: MessageType,
+    pub sticker_id: Option<i64>,
+    pub attachments: Vec<MessagePreviewAttachment>,
+    pub deleted_at: Option<DateTime<Utc>>,
+    pub mention_source: Option<String>,
+    pub mention_uids: Option<Vec<i32>>,
+}
+
 pub(crate) fn build_message_preview(
-    id: i64,
-    client_generated_id: String,
-    created_at: DateTime<Utc>,
-    sender: User,
-    message: Option<String>,
-    message_type: MessageType,
-    sticker_id: Option<i64>,
+    input: MessagePreviewInput,
     sticker_emoji_map: &std::collections::HashMap<i64, String>,
-    attachments: Vec<MessagePreviewAttachment>,
-    deleted_at: Option<DateTime<Utc>>,
-    mention_source: Option<&str>,
-    mention_uids_map: Option<&std::collections::HashMap<i64, Vec<i32>>>,
-    mention_map_key: Option<i64>,
     user_avatars: &std::collections::HashMap<i32, Option<String>>,
     user_profiles: &std::collections::HashMap<i32, UserProfile>,
 ) -> MessagePreview {
+    let MessagePreviewInput {
+        id,
+        client_generated_id,
+        created_at,
+        sender,
+        message,
+        message_type,
+        sticker_id,
+        attachments,
+        deleted_at,
+        mention_source,
+        mention_uids,
+    } = input;
     let is_deleted = deleted_at.is_some();
     let sticker_emoji = sticker_id.and_then(|sid| sticker_emoji_map.get(&sid).cloned());
     MessagePreview {
@@ -383,21 +399,16 @@ pub(crate) fn build_message_preview(
         mentions: mention_source
             .filter(|_| !is_deleted)
             .map(|text| {
-                extract_mention_uids(text)
+                extract_mention_uids(&text)
                     .into_iter()
                     .map(|uid| build_mention_info(uid, user_avatars, user_profiles))
                     .collect()
             })
             .or_else(|| {
-                mention_uids_map.map(|uids_map| {
-                    uids_map
-                        .get(&mention_map_key.unwrap_or(id))
-                        .map(|uids| {
-                            uids.iter()
-                                .map(|&uid| build_mention_info(uid, user_avatars, user_profiles))
-                                .collect()
-                        })
-                        .unwrap_or_default()
+                mention_uids.map(|uids| {
+                    uids.into_iter()
+                        .map(|uid| build_mention_info(uid, user_avatars, user_profiles))
+                        .collect()
                 })
             })
             .unwrap_or_default(),
@@ -1039,19 +1050,20 @@ pub async fn attach_metadata(
                     .map(|(&id, (sticker, _))| (id, sticker.emoji.clone()))
                     .collect();
                 let preview = build_message_preview(
-                    reply_msg.id,
-                    reply_msg.client_generated_id.clone(),
-                    reply_msg.created_at,
-                    build_sender(reply_msg.sender_uid, &user_avatars, &user_profiles),
-                    reply_msg.message.clone(),
-                    reply_msg.message_type.clone(),
-                    reply_msg.sticker_id,
+                    MessagePreviewInput {
+                        id: reply_msg.id,
+                        client_generated_id: reply_msg.client_generated_id.clone(),
+                        created_at: reply_msg.created_at,
+                        sender: build_sender(reply_msg.sender_uid, &user_avatars, &user_profiles),
+                        message: reply_msg.message.clone(),
+                        message_type: reply_msg.message_type.clone(),
+                        sticker_id: reply_msg.sticker_id,
+                        attachments: attachment_previews(&message_attachments_map, reply_msg.id),
+                        deleted_at: reply_msg.deleted_at,
+                        mention_source: reply_msg.message.clone(),
+                        mention_uids: None,
+                    },
                     &sticker_emoji_map,
-                    attachment_previews(&message_attachments_map, reply_msg.id),
-                    reply_msg.deleted_at,
-                    reply_msg.message.as_deref(),
-                    None,
-                    None,
                     &user_avatars,
                     &user_profiles,
                 );
@@ -1764,12 +1776,12 @@ mod tests {
         attachment_preview_text, build_message_preview, build_push_preview_bundle,
         extract_mention_uids, message_is_visible_in_thread_scope, redact_deleted_message_response,
         render_mentions_as_text, sticker_preview_text, MentionInfo, MessagePreview,
-        MessagePreviewAttachment, MessageResponse, MessageStickerResponse, PreparedMessageSend,
-        ReactionSummary, StickerMediaResponse,
+        MessagePreviewAttachment, MessagePreviewInput, MessageResponse, MessageStickerResponse,
+        PreparedMessageSend, ReactionSummary, StickerMediaResponse,
     };
     use crate::{
         dto::{attachments::AttachmentResponse, users::User},
-        models::{Attachment, Message, MessageType, TranscodeStatus},
+        models::{Message, MessageType, TranscodeStatus},
     };
     use chrono::{TimeZone, Utc};
     use serde_json::json;
@@ -2206,21 +2218,22 @@ mod tests {
     fn build_message_preview_deleted_message_clears_sensitive_data() {
         let sticker_map = HashMap::from([(42, "🙂".to_string())]);
         let preview = build_message_preview(
-            10,
-            "client-10".to_string(),
-            Utc::now(),
-            sender(),
-            Some("secret root".to_string()),
-            MessageType::Text,
-            Some(42),
+            MessagePreviewInput {
+                id: 10,
+                client_generated_id: "client-10".to_string(),
+                created_at: Utc::now(),
+                sender: sender(),
+                message: Some("secret root".to_string()),
+                message_type: MessageType::Text,
+                sticker_id: Some(42),
+                attachments: vec![MessagePreviewAttachment {
+                    kind: "image/png".to_string(),
+                }],
+                deleted_at: Some(Utc::now()),
+                mention_source: Some("@mention".to_string()),
+                mention_uids: None,
+            },
             &sticker_map,
-            vec![MessagePreviewAttachment {
-                kind: "image/png".to_string(),
-            }],
-            Some(Utc::now()),
-            Some("@mention"),
-            None,
-            None,
             &HashMap::new(),
             &HashMap::new(),
         );

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -307,10 +307,6 @@ fn message_response_preview(response: MessageResponse) -> MessagePreview {
                 emoji: sticker.emoji,
             })
         }),
-        first_attachment_kind: response
-            .attachments
-            .first()
-            .map(|attachment| attachment.kind.clone()),
         attachments: response
             .attachments
             .iter()
@@ -338,16 +334,6 @@ pub fn build_mention_info(
     }
 }
 
-fn first_attachment_kind(
-    message_attachments_map: &std::collections::HashMap<i64, Vec<Attachment>>,
-    message_id: i64,
-) -> Option<String> {
-    message_attachments_map
-        .get(&message_id)
-        .and_then(|attachments| attachments.first())
-        .map(|attachment| attachment.kind.clone())
-}
-
 fn attachment_previews(
     map: &std::collections::HashMap<i64, Vec<Attachment>>,
     message_id: i64,
@@ -363,6 +349,61 @@ fn attachment_previews(
         .unwrap_or_default()
 }
 
+pub(crate) fn build_message_preview(
+    id: i64,
+    client_generated_id: String,
+    created_at: DateTime<Utc>,
+    sender: User,
+    message: Option<String>,
+    message_type: MessageType,
+    sticker_id: Option<i64>,
+    sticker_emoji_map: &std::collections::HashMap<i64, String>,
+    attachments: Vec<MessagePreviewAttachment>,
+    deleted_at: Option<DateTime<Utc>>,
+    mention_source: Option<&str>,
+    mention_uids_map: Option<&std::collections::HashMap<i64, Vec<i32>>>,
+    mention_map_key: Option<i64>,
+    user_avatars: &std::collections::HashMap<i32, Option<String>>,
+    user_profiles: &std::collections::HashMap<i32, UserProfile>,
+) -> MessagePreview {
+    let is_deleted = deleted_at.is_some();
+    let sticker_emoji = sticker_id.and_then(|sid| sticker_emoji_map.get(&sid).cloned());
+    MessagePreview {
+        id,
+        client_generated_id,
+        created_at,
+        sender,
+        message: if is_deleted { None } else { message },
+        message_type,
+        sticker: sticker_emoji
+            .filter(|_| !is_deleted)
+            .map(|emoji| MessagePreviewSticker { emoji }),
+        attachments: if is_deleted { vec![] } else { attachments },
+        is_deleted,
+        mentions: mention_source
+            .filter(|_| !is_deleted)
+            .map(|text| {
+                extract_mention_uids(text)
+                    .into_iter()
+                    .map(|uid| build_mention_info(uid, user_avatars, user_profiles))
+                    .collect()
+            })
+            .or_else(|| {
+                mention_uids_map.map(|uids_map| {
+                    uids_map
+                        .get(&mention_map_key.unwrap_or(id))
+                        .map(|uids| {
+                            uids.iter()
+                                .map(|&uid| build_mention_info(uid, user_avatars, user_profiles))
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                })
+            })
+            .unwrap_or_default(),
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn message_is_visible_in_thread_scope(message: &Message, thread_root_id: i64) -> bool {
     if !message.is_published {
@@ -374,18 +415,6 @@ pub(crate) fn message_is_visible_in_thread_scope(message: &Message, thread_root_
     }
 
     message.reply_root_id == Some(thread_root_id) && message.deleted_at.is_none()
-}
-
-pub(crate) fn redact_deleted_message_preview(preview: &mut MessagePreview) {
-    if !preview.is_deleted {
-        return;
-    }
-
-    preview.message = None;
-    preview.sticker = None;
-    preview.first_attachment_kind = None;
-    preview.attachments.clear();
-    preview.mentions.clear();
 }
 
 pub(crate) fn redact_deleted_message_response(response: &mut MessageResponse) {
@@ -470,10 +499,13 @@ fn build_push_preview_bundle(response: &MessageResponse) -> PushPreviewBundle {
             emoji: sticker.emoji.clone(),
         })
     });
-    let first_attachment_kind = response
+    let push_attachments: Vec<MessagePreviewAttachment> = response
         .attachments
-        .first()
-        .map(|attachment| attachment.kind.clone());
+        .iter()
+        .map(|a| MessagePreviewAttachment {
+            kind: a.kind.clone(),
+        })
+        .collect();
     let is_deleted = response.is_deleted;
 
     let body_preview = if is_deleted {
@@ -484,9 +516,10 @@ fn build_push_preview_bundle(response: &MessageResponse) -> PushPreviewBundle {
             MessageType::Sticker => Some(sticker_preview_text(
                 response.sticker.as_ref().map(|s| s.emoji.as_str()),
             )),
-            MessageType::File => {
-                Some(attachment_preview_text(first_attachment_kind.as_deref()).to_string())
-            }
+            MessageType::File => Some(
+                attachment_preview_text(push_attachments.first().map(|a| a.kind.as_str()))
+                    .to_string(),
+            ),
             _ => rendered_message.clone(),
         }
     };
@@ -505,7 +538,7 @@ fn build_push_preview_bundle(response: &MessageResponse) -> PushPreviewBundle {
             message: preview_message,
             message_type: response.message_type.clone(),
             sticker,
-            first_attachment_kind,
+            attachments: push_attachments,
             is_deleted,
         },
         body_preview,
@@ -1001,48 +1034,27 @@ pub async fn attach_metadata(
                     );
                 }
 
-                let mut preview = MessagePreview {
-                    id: reply_msg.id,
-                    client_generated_id: reply_msg.client_generated_id.clone(),
-                    created_at: reply_msg.created_at,
-                    sender: build_sender(reply_msg.sender_uid, &user_avatars, &user_profiles),
-                    message: if reply_msg.deleted_at.is_some() {
-                        None
-                    } else {
-                        reply_msg.message.clone()
-                    },
-                    message_type: reply_msg.message_type.clone(),
-                    sticker: reply_msg.sticker_id.and_then(|sticker_id| {
-                        sticker_rows.get(&sticker_id).and_then(|(sticker, _)| {
-                            (reply_msg.deleted_at.is_none()).then_some(MessagePreviewSticker {
-                                emoji: sticker.emoji.clone(),
-                            })
-                        })
-                    }),
-                    first_attachment_kind: first_attachment_kind(
-                        &message_attachments_map,
-                        reply_msg.id,
-                    ),
-                    attachments: attachment_previews(
-                        &message_attachments_map,
-                        reply_msg.id,
-                    ),
-                    is_deleted: reply_msg.deleted_at.is_some(),
-                    mentions: reply_msg
-                        .message
-                        .as_deref()
-                        .filter(|_| reply_msg.deleted_at.is_none())
-                        .map(|text| {
-                            extract_mention_uids(text)
-                                .into_iter()
-                                .map(|uid| {
-                                    build_mention_info(uid, &user_avatars, &user_profiles)
-                                })
-                                .collect()
-                        })
-                        .unwrap_or_default(),
-                };
-                redact_deleted_message_preview(&mut preview);
+                let sticker_emoji_map: std::collections::HashMap<i64, String> = sticker_rows
+                    .iter()
+                    .map(|(&id, (sticker, _))| (id, sticker.emoji.clone()))
+                    .collect();
+                let preview = build_message_preview(
+                    reply_msg.id,
+                    reply_msg.client_generated_id.clone(),
+                    reply_msg.created_at,
+                    build_sender(reply_msg.sender_uid, &user_avatars, &user_profiles),
+                    reply_msg.message.clone(),
+                    reply_msg.message_type.clone(),
+                    reply_msg.sticker_id,
+                    &sticker_emoji_map,
+                    attachment_previews(&message_attachments_map, reply_msg.id),
+                    reply_msg.deleted_at,
+                    reply_msg.message.as_deref(),
+                    None,
+                    None,
+                    &user_avatars,
+                    &user_profiles,
+                );
                 Box::new(preview)
             })
         });
@@ -1749,11 +1761,11 @@ pub fn router() -> OpenApiRouter<crate::AppState> {
 #[cfg(test)]
 mod tests {
     use super::{
-        attachment_preview_text, build_push_preview_bundle, extract_mention_uids,
-        first_attachment_kind, message_is_visible_in_thread_scope, redact_deleted_message_preview,
-        redact_deleted_message_response, render_mentions_as_text, sticker_preview_text,
-        MentionInfo, MessagePreview, MessagePreviewAttachment, MessageResponse,
-        MessageStickerResponse, PreparedMessageSend, ReactionSummary, StickerMediaResponse,
+        attachment_preview_text, build_message_preview, build_push_preview_bundle,
+        extract_mention_uids, message_is_visible_in_thread_scope, redact_deleted_message_response,
+        render_mentions_as_text, sticker_preview_text, MentionInfo, MessagePreview,
+        MessagePreviewAttachment, MessageResponse, MessageStickerResponse, PreparedMessageSend,
+        ReactionSummary, StickerMediaResponse,
     };
     use crate::{
         dto::{attachments::AttachmentResponse, users::User},
@@ -2073,8 +2085,10 @@ mod tests {
             Some("look at this".to_string())
         );
         assert_eq!(
-            preview.message_preview.first_attachment_kind,
-            Some("image/png".to_string())
+            preview.message_preview.attachments,
+            vec![MessagePreviewAttachment {
+                kind: "image/png".to_string()
+            }]
         );
     }
 
@@ -2094,7 +2108,6 @@ mod tests {
             message: Some("voice".to_string()),
             message_type: MessageType::Audio,
             sticker: None,
-            first_attachment_kind: Some("audio/webm".to_string()),
             attachments: vec![MessagePreviewAttachment {
                 kind: "audio/webm".to_string(),
             }],
@@ -2106,38 +2119,8 @@ mod tests {
         assert_eq!(value["clientGeneratedId"], json!("cgid"));
         assert_eq!(value["messageType"], json!("audio"));
         assert_eq!(value["isDeleted"], json!(false));
-        assert_eq!(value["firstAttachmentKind"], json!("audio/webm"));
         assert_eq!(value["attachments"], json!([{"kind": "audio/webm"}]));
         assert!(value.get("message_type").is_none());
-    }
-
-    #[test]
-    fn first_attachment_kind_can_be_read_multiple_times_for_same_message() {
-        let attachment = Attachment {
-            id: 1,
-            message_id: Some(42),
-            file_name: "image.png".to_string(),
-            kind: "image/png".to_string(),
-            external_reference: "attachments/image.png".to_string(),
-            size: 123,
-            created_at: Utc::now(),
-            deleted_at: None,
-            width: Some(100),
-            height: Some(100),
-            order: 0,
-        };
-
-        let mut attachments_map = HashMap::new();
-        attachments_map.insert(42, vec![attachment]);
-
-        assert_eq!(
-            first_attachment_kind(&attachments_map, 42),
-            Some("image/png".to_string())
-        );
-        assert_eq!(
-            first_attachment_kind(&attachments_map, 42),
-            Some("image/png".to_string())
-        );
     }
 
     #[test]
@@ -2220,32 +2203,27 @@ mod tests {
     }
 
     #[test]
-    fn deleted_message_preview_redaction_preserves_metadata_only() {
-        let mut preview = MessagePreview {
-            id: 10,
-            client_generated_id: "client-10".to_string(),
-            created_at: Utc::now(),
-            sender: sender(),
-            message: Some("secret root".to_string()),
-            message_type: MessageType::Text,
-            sticker: Some(super::MessagePreviewSticker {
-                emoji: "🙂".to_string(),
-            }),
-            first_attachment_kind: Some("image/png".to_string()),
-            attachments: vec![MessagePreviewAttachment {
+    fn build_message_preview_deleted_message_clears_sensitive_data() {
+        let sticker_map = HashMap::from([(42, "🙂".to_string())]);
+        let preview = build_message_preview(
+            10,
+            "client-10".to_string(),
+            Utc::now(),
+            sender(),
+            Some("secret root".to_string()),
+            MessageType::Text,
+            Some(42),
+            &sticker_map,
+            vec![MessagePreviewAttachment {
                 kind: "image/png".to_string(),
             }],
-            is_deleted: true,
-            mentions: vec![MentionInfo {
-                uid: 9,
-                username: Some("Mentioned".to_string()),
-                avatar_url: None,
-                gender: 0,
-                user_group: None,
-            }],
-        };
-
-        redact_deleted_message_preview(&mut preview);
+            Some(Utc::now()),
+            Some("@mention"),
+            None,
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+        );
 
         assert_eq!(preview.id, 10);
         assert_eq!(preview.client_generated_id, "client-10");
@@ -2253,7 +2231,6 @@ mod tests {
         assert!(preview.is_deleted);
         assert_eq!(preview.message, None);
         assert!(preview.sticker.is_none());
-        assert!(preview.first_attachment_kind.is_none());
         assert!(preview.attachments.is_empty());
         assert!(preview.mentions.is_empty());
     }

--- a/backend/src/services/push/mod.rs
+++ b/backend/src/services/push/mod.rs
@@ -160,6 +160,7 @@ mod tests {
         MESSAGE_PREVIEW_MAX,
     };
     use super::*;
+    use crate::dto::messages::MessagePreviewAttachment;
     use crate::models::MessageType;
     use a2::ErrorReason as ApnsErrorReason;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -206,7 +207,7 @@ mod tests {
                 sticker: Some(PushMessagePreviewSticker {
                     emoji: "🙂".to_string(),
                 }),
-                first_attachment_kind: None,
+                attachments: Vec::new(),
                 is_deleted: false,
             },
             body_preview: Some("[Sticker] 🙂".to_string()),
@@ -251,7 +252,7 @@ mod tests {
                 message: Some("Hello".to_string()),
                 message_type: MessageType::Text,
                 sticker: None,
-                first_attachment_kind: None,
+                attachments: Vec::new(),
                 is_deleted: false,
             },
             body_preview: Some("hello there".to_string()),
@@ -287,7 +288,7 @@ mod tests {
                 message: None,
                 message_type: MessageType::Text,
                 sticker: None,
-                first_attachment_kind: None,
+                attachments: Vec::new(),
                 is_deleted: false,
             },
             body_preview: None,
@@ -315,7 +316,7 @@ mod tests {
                 message: None,
                 message_type: MessageType::Audio,
                 sticker: None,
-                first_attachment_kind: None,
+                attachments: Vec::new(),
                 is_deleted: false,
             },
             body_preview: None,
@@ -343,7 +344,7 @@ mod tests {
                 sticker: Some(PushMessagePreviewSticker {
                     emoji: "🎉".to_string(),
                 }),
-                first_attachment_kind: None,
+                attachments: Vec::new(),
                 is_deleted: false,
             },
             body_preview: Some("[Sticker] 🎉".to_string()),
@@ -369,7 +370,9 @@ mod tests {
                 message: None,
                 message_type: MessageType::File,
                 sticker: None,
-                first_attachment_kind: Some("image/jpeg".to_string()),
+                attachments: vec![MessagePreviewAttachment {
+                    kind: "image/jpeg".to_string(),
+                }],
                 is_deleted: false,
             },
             body_preview: None,
@@ -395,7 +398,9 @@ mod tests {
                 message: Some("look at this".to_string()),
                 message_type: MessageType::File,
                 sticker: None,
-                first_attachment_kind: Some("image/jpeg".to_string()),
+                attachments: vec![MessagePreviewAttachment {
+                    kind: "image/jpeg".to_string(),
+                }],
                 is_deleted: false,
             },
             body_preview: Some("[Image]".to_string()),
@@ -424,7 +429,9 @@ mod tests {
                 message: None,
                 message_type: MessageType::File,
                 sticker: None,
-                first_attachment_kind: Some("video/mp4".to_string()),
+                attachments: vec![MessagePreviewAttachment {
+                    kind: "video/mp4".to_string(),
+                }],
                 is_deleted: false,
             },
             body_preview: None,
@@ -449,7 +456,7 @@ mod tests {
                 message: None,
                 message_type: MessageType::Invite,
                 sticker: None,
-                first_attachment_kind: None,
+                attachments: Vec::new(),
                 is_deleted: false,
             },
             body_preview: Some("sent an invite".to_string()),

--- a/backend/src/services/push/payload.rs
+++ b/backend/src/services/push/payload.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+use crate::dto::messages::MessagePreviewAttachment;
 use crate::models::MessageType;
 
 use super::PushJob;
@@ -42,8 +43,7 @@ pub struct PushMessagePreview {
     pub message_type: MessageType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sticker: Option<PushMessagePreviewSticker>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_attachment_kind: Option<String>,
+    pub attachments: Vec<MessagePreviewAttachment>,
     pub is_deleted: bool,
 }
 
@@ -128,15 +128,16 @@ pub(super) fn build_apns_notification(job: &PushJob, unread_count: i64) -> ApnsN
             },
             MessageType::Invite => (APNS_BODY_LOC_KEY_INVITE, vec![job.sender_username.clone()]),
             _ => {
-                if let Some(ref kind) = preview.first_attachment_kind {
+                if let Some(first_att) = preview.attachments.first() {
+                    let kind = &first_att.kind;
                     if let Some(ref msg) = preview.message {
                         (
-                            attachment_kind_loc_key_with_preview(kind),
+                            attachment_kind_loc_key(kind, true),
                             vec![job.sender_username.clone(), truncate_preview(msg)],
                         )
                     } else {
                         (
-                            attachment_kind_loc_key(kind),
+                            attachment_kind_loc_key(kind, false),
                             vec![job.sender_username.clone()],
                         )
                     }
@@ -179,27 +180,16 @@ pub(super) fn build_apns_notification(job: &PushJob, unread_count: i64) -> ApnsN
     }
 }
 
-fn attachment_kind_loc_key(kind: &str) -> &'static str {
-    if kind.starts_with("image/") {
-        APNS_BODY_LOC_KEY_IMAGE
-    } else if kind.starts_with("video/") {
-        APNS_BODY_LOC_KEY_VIDEO
-    } else if kind.starts_with("audio/") {
-        APNS_BODY_LOC_KEY_AUDIO
-    } else {
-        APNS_BODY_LOC_KEY_ATTACHMENT
-    }
-}
-
-fn attachment_kind_loc_key_with_preview(kind: &str) -> &'static str {
-    if kind.starts_with("image/") {
-        APNS_BODY_LOC_KEY_IMAGE_WITH_PREVIEW
-    } else if kind.starts_with("video/") {
-        APNS_BODY_LOC_KEY_VIDEO_WITH_PREVIEW
-    } else if kind.starts_with("audio/") {
-        APNS_BODY_LOC_KEY_AUDIO_WITH_PREVIEW
-    } else {
-        APNS_BODY_LOC_KEY_ATTACHMENT_WITH_PREVIEW
+fn attachment_kind_loc_key(kind: &str, with_preview: bool) -> &'static str {
+    match (kind.split('/').next(), with_preview) {
+        (Some("image"), false) => APNS_BODY_LOC_KEY_IMAGE,
+        (Some("image"), true) => APNS_BODY_LOC_KEY_IMAGE_WITH_PREVIEW,
+        (Some("video"), false) => APNS_BODY_LOC_KEY_VIDEO,
+        (Some("video"), true) => APNS_BODY_LOC_KEY_VIDEO_WITH_PREVIEW,
+        (Some("audio"), false) => APNS_BODY_LOC_KEY_AUDIO,
+        (Some("audio"), true) => APNS_BODY_LOC_KEY_AUDIO_WITH_PREVIEW,
+        (_, false) => APNS_BODY_LOC_KEY_ATTACHMENT,
+        (_, true) => APNS_BODY_LOC_KEY_ATTACHMENT_WITH_PREVIEW,
     }
 }
 

--- a/backend/src/services/threads.rs
+++ b/backend/src/services/threads.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use crate::constants::MAX_UNREAD_COUNT;
 use crate::dto::{
-    messages::{MessagePreview, MessagePreviewSticker},
+    messages::{MessagePreview, MessagePreviewAttachment, MessagePreviewSticker},
     threads::{ListThreadsResponse, ThreadListItem},
     users::User,
     ws::{ServerWsMessage, ThreadMembershipChangedPayload, ThreadUpdatePayload},
@@ -600,11 +600,13 @@ pub fn get_unread_summary_counts(
 
 // --- Thread list enrichment types and logic ---
 
-fn first_attachment_kind_map(atts: Vec<Attachment>) -> HashMap<i64, String> {
-    let mut map: HashMap<i64, String> = HashMap::new();
+fn attachment_preview_map(atts: Vec<Attachment>) -> HashMap<i64, Vec<MessagePreviewAttachment>> {
+    let mut map: HashMap<i64, Vec<MessagePreviewAttachment>> = HashMap::new();
     for att in atts {
         if let Some(msg_id) = att.message_id {
-            map.entry(msg_id).or_insert(att.kind);
+            map.entry(msg_id)
+                .or_default()
+                .push(MessagePreviewAttachment { kind: att.kind });
         }
     }
     map
@@ -819,8 +821,11 @@ pub fn enrich_thread_list(
             attachment_msg_ids.push(msg.id);
         }
     }
-    let first_attachment_map: HashMap<i64, String> = if attachment_msg_ids.is_empty() {
-        HashMap::new()
+    let (first_attachment_map, attachment_preview_all_map): (
+        HashMap<i64, String>,
+        HashMap<i64, Vec<MessagePreviewAttachment>>,
+    ) = if attachment_msg_ids.is_empty() {
+        (HashMap::new(), HashMap::new())
     } else {
         let atts: Vec<Attachment> = attachments::table
             .filter(attachments::message_id.eq_any(&attachment_msg_ids))
@@ -833,7 +838,12 @@ pub fn enrich_thread_list(
             .select(Attachment::as_select())
             .load(conn)
             .unwrap_or_default();
-        first_attachment_kind_map(atts)
+        let preview_map = attachment_preview_map(atts);
+        let kind_map: HashMap<i64, String> = preview_map
+            .iter()
+            .filter_map(|(&msg_id, previews)| previews.first().map(|p| (msg_id, p.kind.clone())))
+            .collect();
+        (kind_map, preview_map)
     };
 
     // 7. Build latest reply map
@@ -859,6 +869,10 @@ pub fn enrich_thread_list(
                 } else {
                     None
                 },
+                attachments: attachment_preview_all_map
+                    .get(&lr.id)
+                    .cloned()
+                    .unwrap_or_default(),
                 is_deleted: false,
                 mentions: mention_uids_per_reply
                     .get(&lr.reply_root_id)
@@ -909,6 +923,14 @@ pub fn enrich_thread_list(
                     first_attachment_map.get(&root_msg.id).cloned()
                 } else {
                     None
+                },
+                attachments: if root_msg.deleted_at.is_none() && root_msg.has_attachments {
+                    attachment_preview_all_map
+                        .get(&root_msg.id)
+                        .cloned()
+                        .unwrap_or_default()
+                } else {
+                    vec![]
                 },
                 is_deleted: root_msg.deleted_at.is_some(),
                 mentions: mention_uids_per_root
@@ -989,7 +1011,8 @@ pub fn unarchive_thread(
 
 #[cfg(test)]
 mod tests {
-    use super::first_attachment_kind_map;
+    use super::attachment_preview_map;
+    use crate::dto::messages::MessagePreviewAttachment;
     use crate::models::Attachment;
     use chrono::Utc;
 
@@ -1010,15 +1033,40 @@ mod tests {
     }
 
     #[test]
-    fn first_attachment_kind_map_uses_first_row_per_message() {
-        let map = first_attachment_kind_map(vec![
+    fn attachment_preview_map_returns_all_attachments_per_message() {
+        let map = attachment_preview_map(vec![
             attachment(2, 10, "image/png", 1),
             attachment(1, 10, "video/mp4", 0),
             attachment(4, 20, "audio/webm", 1),
             attachment(3, 20, "image/jpeg", 0),
         ]);
 
-        assert_eq!(map.get(&10), Some(&"image/png".to_string()));
-        assert_eq!(map.get(&20), Some(&"audio/webm".to_string()));
+        let msg10 = map.get(&10).unwrap();
+        assert_eq!(msg10.len(), 2);
+        assert_eq!(
+            msg10,
+            &[
+                MessagePreviewAttachment {
+                    kind: "image/png".to_string()
+                },
+                MessagePreviewAttachment {
+                    kind: "video/mp4".to_string()
+                },
+            ]
+        );
+
+        let msg20 = map.get(&20).unwrap();
+        assert_eq!(msg20.len(), 2);
+        assert_eq!(
+            msg20,
+            &[
+                MessagePreviewAttachment {
+                    kind: "audio/webm".to_string()
+                },
+                MessagePreviewAttachment {
+                    kind: "image/jpeg".to_string()
+                },
+            ]
+        );
     }
 }

--- a/backend/src/services/threads.rs
+++ b/backend/src/services/threads.rs
@@ -6,14 +6,12 @@ use std::collections::HashMap;
 
 use crate::constants::MAX_UNREAD_COUNT;
 use crate::dto::{
-    messages::{MessagePreview, MessagePreviewAttachment, MessagePreviewSticker},
+    messages::{MessagePreview, MessagePreviewAttachment},
     threads::{ListThreadsResponse, ThreadListItem},
     users::User,
     ws::{ServerWsMessage, ThreadMembershipChangedPayload, ThreadUpdatePayload},
 };
-use crate::handlers::chats::{
-    build_mention_info, build_sender, extract_mention_uids, redact_deleted_message_preview,
-};
+use crate::handlers::chats::{build_message_preview, build_sender, extract_mention_uids};
 use crate::models::{Attachment, Message, MessageType};
 use crate::schema::{attachments, messages, stickers, thread_meta, thread_user_states};
 use crate::services::media::build_public_object_url;
@@ -821,7 +819,7 @@ pub fn enrich_thread_list(
             attachment_msg_ids.push(msg.id);
         }
     }
-    let (first_attachment_map, attachment_preview_all_map): (
+    let (_first_attachment_map, attachment_preview_all_map): (
         HashMap<i64, String>,
         HashMap<i64, Vec<MessagePreviewAttachment>>,
     ) = if attachment_msg_ids.is_empty() {
@@ -851,38 +849,26 @@ pub fn enrich_thread_list(
     for lr in latest_reply_rows {
         latest_reply_map.insert(
             lr.reply_root_id,
-            MessagePreview {
-                id: lr.id,
-                client_generated_id: lr.client_generated_id,
-                created_at: lr.created_at,
-                sender: make_sender(lr.sender_uid),
-                message: lr.message,
-                message_type: lr.message_type,
-                sticker: lr.sticker_id.and_then(|sid| {
-                    sticker_emoji_map
-                        .get(&sid)
-                        .cloned()
-                        .map(|emoji| MessagePreviewSticker { emoji })
-                }),
-                first_attachment_kind: if lr.has_attachments {
-                    first_attachment_map.get(&lr.id).cloned()
-                } else {
-                    None
-                },
-                attachments: attachment_preview_all_map
+            build_message_preview(
+                lr.id,
+                lr.client_generated_id,
+                lr.created_at,
+                make_sender(lr.sender_uid),
+                lr.message,
+                lr.message_type,
+                lr.sticker_id,
+                &sticker_emoji_map,
+                attachment_preview_all_map
                     .get(&lr.id)
                     .cloned()
                     .unwrap_or_default(),
-                is_deleted: false,
-                mentions: mention_uids_per_reply
-                    .get(&lr.reply_root_id)
-                    .map(|uids| {
-                        uids.iter()
-                            .map(|&uid| build_mention_info(uid, &user_avatars, &user_profiles))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-            },
+                None,
+                None,
+                Some(&mention_uids_per_reply),
+                Some(lr.reply_root_id),
+                &user_avatars,
+                &user_profiles,
+            ),
         );
     }
 
@@ -897,34 +883,16 @@ pub fn enrich_thread_list(
         .into_iter()
         .filter_map(|row| {
             let root_msg = root_msg_map.get(&row.thread_root_id)?;
-            let mut root_preview = MessagePreview {
-                id: root_msg.id,
-                client_generated_id: root_msg.client_generated_id.clone(),
-                created_at: root_msg.created_at,
-                sender: make_sender(root_msg.sender_uid),
-                message: if root_msg.deleted_at.is_some() {
-                    None
-                } else {
-                    root_msg.message.clone()
-                },
-                message_type: root_msg.message_type.clone(),
-                sticker: root_msg.sticker_id.and_then(|sid| {
-                    (root_msg.deleted_at.is_none())
-                        .then(|| {
-                            sticker_emoji_map
-                                .get(&sid)
-                                .cloned()
-                                .map(|emoji| MessagePreviewSticker { emoji })
-                        })
-                        .flatten()
-                }),
-                first_attachment_kind: if root_msg.deleted_at.is_none() && root_msg.has_attachments
-                {
-                    first_attachment_map.get(&root_msg.id).cloned()
-                } else {
-                    None
-                },
-                attachments: if root_msg.deleted_at.is_none() && root_msg.has_attachments {
+            let root_preview = build_message_preview(
+                root_msg.id,
+                root_msg.client_generated_id.clone(),
+                root_msg.created_at,
+                make_sender(root_msg.sender_uid),
+                root_msg.message.clone(),
+                root_msg.message_type.clone(),
+                root_msg.sticker_id,
+                &sticker_emoji_map,
+                if root_msg.deleted_at.is_none() && root_msg.has_attachments {
                     attachment_preview_all_map
                         .get(&root_msg.id)
                         .cloned()
@@ -932,17 +900,13 @@ pub fn enrich_thread_list(
                 } else {
                     vec![]
                 },
-                is_deleted: root_msg.deleted_at.is_some(),
-                mentions: mention_uids_per_root
-                    .get(&root_msg.id)
-                    .map(|uids| {
-                        uids.iter()
-                            .map(|&uid| build_mention_info(uid, &user_avatars, &user_profiles))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-            };
-            redact_deleted_message_preview(&mut root_preview);
+                root_msg.deleted_at,
+                None,
+                Some(&mention_uids_per_root),
+                Some(root_msg.id),
+                &user_avatars,
+                &user_profiles,
+            );
             Some(ThreadListItem {
                 chat_id: row.chat_id,
                 chat_name: row.chat_name,

--- a/backend/src/services/threads.rs
+++ b/backend/src/services/threads.rs
@@ -11,7 +11,9 @@ use crate::dto::{
     users::User,
     ws::{ServerWsMessage, ThreadMembershipChangedPayload, ThreadUpdatePayload},
 };
-use crate::handlers::chats::{build_message_preview, build_sender, extract_mention_uids};
+use crate::handlers::chats::{
+    build_message_preview, build_sender, extract_mention_uids, MessagePreviewInput,
+};
 use crate::models::{Attachment, Message, MessageType};
 use crate::schema::{attachments, messages, stickers, thread_meta, thread_user_states};
 use crate::services::media::build_public_object_url;
@@ -850,22 +852,23 @@ pub fn enrich_thread_list(
         latest_reply_map.insert(
             lr.reply_root_id,
             build_message_preview(
-                lr.id,
-                lr.client_generated_id,
-                lr.created_at,
-                make_sender(lr.sender_uid),
-                lr.message,
-                lr.message_type,
-                lr.sticker_id,
+                MessagePreviewInput {
+                    id: lr.id,
+                    client_generated_id: lr.client_generated_id,
+                    created_at: lr.created_at,
+                    sender: make_sender(lr.sender_uid),
+                    message: lr.message,
+                    message_type: lr.message_type,
+                    sticker_id: lr.sticker_id,
+                    attachments: attachment_preview_all_map
+                        .get(&lr.id)
+                        .cloned()
+                        .unwrap_or_default(),
+                    deleted_at: None,
+                    mention_source: None,
+                    mention_uids: mention_uids_per_reply.get(&lr.reply_root_id).cloned(),
+                },
                 &sticker_emoji_map,
-                attachment_preview_all_map
-                    .get(&lr.id)
-                    .cloned()
-                    .unwrap_or_default(),
-                None,
-                None,
-                Some(&mention_uids_per_reply),
-                Some(lr.reply_root_id),
                 &user_avatars,
                 &user_profiles,
             ),
@@ -884,26 +887,27 @@ pub fn enrich_thread_list(
         .filter_map(|row| {
             let root_msg = root_msg_map.get(&row.thread_root_id)?;
             let root_preview = build_message_preview(
-                root_msg.id,
-                root_msg.client_generated_id.clone(),
-                root_msg.created_at,
-                make_sender(root_msg.sender_uid),
-                root_msg.message.clone(),
-                root_msg.message_type.clone(),
-                root_msg.sticker_id,
-                &sticker_emoji_map,
-                if root_msg.deleted_at.is_none() && root_msg.has_attachments {
-                    attachment_preview_all_map
-                        .get(&root_msg.id)
-                        .cloned()
-                        .unwrap_or_default()
-                } else {
-                    vec![]
+                MessagePreviewInput {
+                    id: root_msg.id,
+                    client_generated_id: root_msg.client_generated_id.clone(),
+                    created_at: root_msg.created_at,
+                    sender: make_sender(root_msg.sender_uid),
+                    message: root_msg.message.clone(),
+                    message_type: root_msg.message_type.clone(),
+                    sticker_id: root_msg.sticker_id,
+                    attachments: if root_msg.deleted_at.is_none() && root_msg.has_attachments {
+                        attachment_preview_all_map
+                            .get(&root_msg.id)
+                            .cloned()
+                            .unwrap_or_default()
+                    } else {
+                        vec![]
+                    },
+                    deleted_at: root_msg.deleted_at,
+                    mention_source: None,
+                    mention_uids: mention_uids_per_root.get(&root_msg.id).cloned(),
                 },
-                root_msg.deleted_at,
-                None,
-                Some(&mention_uids_per_root),
-                Some(root_msg.id),
+                &sticker_emoji_map,
                 &user_avatars,
                 &user_profiles,
             );

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -558,6 +558,8 @@ msgstr "Groups"
 msgid "Images"
 msgstr "Images"
 
+msgid "In thread"
+msgstr "In thread"
 msgid "indefinitely"
 msgstr "indefinitely"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -558,6 +558,8 @@ msgstr "群组"
 msgid "Images"
 msgstr "图片"
 
+msgid "In thread"
+msgstr "在话题中"
 msgid "indefinitely"
 msgstr "永久"
 

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -558,6 +558,8 @@ msgstr "群組"
 msgid "Images"
 msgstr "圖片"
 
+msgid "In thread"
+msgstr "在話題中"
 msgid "indefinitely"
 msgstr "永久"
 

--- a/wetty-chat-mobile/src/api/messages.ts
+++ b/wetty-chat-mobile/src/api/messages.ts
@@ -33,7 +33,6 @@ export interface MessagePreview {
   sender: User;
   isDeleted: boolean;
   attachments?: Attachment[];
-  firstAttachmentKind?: string | null;
   mentions?: MentionInfo[] | null;
 }
 
@@ -121,7 +120,6 @@ export function toMessagePreview(message: MessageResponse): MessagePreview {
     },
     isDeleted: message.isDeleted,
     attachments: message.attachments,
-    firstAttachmentKind: message.attachments?.[0]?.kind ?? null,
     mentions: message.mentions ?? null,
   };
 }

--- a/wetty-chat-mobile/src/components/chat/compose/types.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/types.ts
@@ -9,7 +9,6 @@ export interface ReplyTo {
   text?: string | null;
   sticker?: StickerSummary;
   attachments?: Attachment[];
-  firstAttachmentKind?: string;
   isDeleted?: boolean;
   mentions?: MentionInfo[];
 }

--- a/wetty-chat-mobile/src/components/chat/compose/useComposeAttachments.ts
+++ b/wetty-chat-mobile/src/components/chat/compose/useComposeAttachments.ts
@@ -15,16 +15,9 @@ import {
   isSupportedMediaFile,
   isVideoFile,
 } from '@/utils/heicMedia';
+import { createClientGeneratedId } from '@/utils/clientGeneratedId';
 
 const isAbortError = (error: unknown) => error instanceof DOMException && error.name === 'AbortError';
-
-const createUploadId = () => {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-
-  return `upload_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
-};
 
 const getNativeImageDimensions = (file: File): Promise<{ width?: number; height?: number }> =>
   new Promise((resolve) => {
@@ -262,7 +255,7 @@ export function useComposeAttachments({
       const queuedRecords: UploadRecord[] = allowedFiles.map((file, index) => ({
         file,
         state: {
-          localId: createUploadId(),
+          localId: createClientGeneratedId('upload_'),
           kind: isImageFile(file) ? 'image' : 'video',
           name: file.name,
           previewUrl: URL.createObjectURL(file),

--- a/wetty-chat-mobile/src/components/chat/lists/ChatList.tsx
+++ b/wetty-chat-mobile/src/components/chat/lists/ChatList.tsx
@@ -178,7 +178,7 @@ export function ChatList({
   const messageChats = useSelector((state: RootState) => state.messages.chats);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [drafts, setDrafts] = useState<Record<string, { text: string; savedAt: number }>>({});
   const [activeTab, setActiveTab] = useState<ChatListTab>(initialTab ?? (showAllTab ? 'all' : 'groups'));
   const effectiveTab = activeTab === 'all' && !showAllTab ? 'groups' : activeTab;
   const chats = archivedMode ? archivedChats : activeChats;
@@ -238,7 +238,7 @@ export function ChatList({
         .then((draft) => {
           setDrafts((prev) => {
             if (draft) {
-              return { ...prev, [draftKey]: draft.text };
+              return { ...prev, [draftKey]: { text: draft.text, savedAt: draft.savedAt ?? 0 } };
             }
             // Draft was cleared — remove from map
             const next = { ...prev };
@@ -356,19 +356,34 @@ export function ChatList({
       items.push({
         type: 'group',
         chat,
-        sortTime: chat.lastMessageAt ? new Date(chat.lastMessageAt).getTime() : 0,
+        sortTime: Math.max(
+          chat.lastMessageAt ? new Date(chat.lastMessageAt).getTime() : 0,
+          drafts[chat.id]?.savedAt ?? 0,
+        ),
       });
     }
     for (const thread of threads) {
       items.push({
         type: 'thread',
         thread,
-        sortTime: thread.lastReplyAt ? new Date(thread.lastReplyAt).getTime() : 0,
+        sortTime: Math.max(
+          thread.lastReplyAt ? new Date(thread.lastReplyAt).getTime() : 0,
+          drafts[`${thread.chatId}_thread_${thread.threadRootMessage.id}`]?.savedAt ?? 0,
+        ),
       });
     }
     items.sort((a, b) => b.sortTime - a.sortTime);
     return items;
-  }, [chats, threads]);
+  }, [chats, threads, drafts]);
+
+  const sortedChats = useMemo(() => {
+    if (Object.keys(drafts).length === 0) return chats;
+    return [...chats].sort((a, b) => {
+      const aTime = Math.max(a.lastMessageAt ? new Date(a.lastMessageAt).getTime() : 0, drafts[a.id]?.savedAt ?? 0);
+      const bTime = Math.max(b.lastMessageAt ? new Date(b.lastMessageAt).getTime() : 0, drafts[b.id]?.savedAt ?? 0);
+      return bTime - aTime;
+    });
+  }, [chats, drafts]);
 
   const handleThreadSelect = useCallback(
     (chatId: string, threadRootId: string, thread: StoredThreadListItem) => {
@@ -490,7 +505,7 @@ export function ChatList({
             {chat.id in drafts ? (
               <>
                 <span className={styles.chatsListDraftLabel}>{t`Draft: `}</span>
-                {truncatePreview(drafts[chat.id])}
+                {truncatePreview(drafts[chat.id].text)}
               </>
             ) : (
               getMessagePreview(chat.lastMessage, locale)
@@ -520,7 +535,7 @@ export function ChatList({
         locale={locale}
         isActive={activeThreadId === thread.threadRootMessage.id}
         onSelect={handleThreadSelect}
-        draftText={drafts[threadDraftKey]}
+        draftText={drafts[threadDraftKey]?.text}
         endAction={{
           color: archivedMode ? 'success' : 'medium',
           icon: archivedMode ? arrowUndoOutline : archiveOutline,
@@ -606,7 +621,7 @@ export function ChatList({
       return (
         <IonList>
           {!archivedMode && archivedGroupsVisible ? renderArchivedEntry(archivedUnreadChats) : null}
-          {chats.map(renderChatItem)}
+          {sortedChats.map(renderChatItem)}
         </IonList>
       );
     }

--- a/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
@@ -64,7 +64,7 @@
   border-radius: 14px;
   box-shadow: none;
   --box-shadow: none;
-  --background: var(--ion-background-color);
+  --background: var(--ion-background-color-step-100, #f0f0f0);
   border: 1px solid var(--ion-color-light-shade);
   box-sizing: border-box;
 }

--- a/wetty-chat-mobile/src/components/chat/search/ChatMessageSearchPanel.module.scss
+++ b/wetty-chat-mobile/src/components/chat/search/ChatMessageSearchPanel.module.scss
@@ -76,6 +76,19 @@
   white-space: nowrap;
 }
 
+.threadLabel {
+  font-size: 0.78rem;
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+.threadIcon {
+  font-size: 0.85rem;
+}
+
 .loadMoreWrap {
   padding: 4px 16px 16px;
 }

--- a/wetty-chat-mobile/src/components/chat/search/ChatMessageSearchPanel.tsx
+++ b/wetty-chat-mobile/src/components/chat/search/ChatMessageSearchPanel.tsx
@@ -1,5 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { IonButton, IonItem, IonLabel, IonList, IonNote, IonSearchbar, IonSpinner, IonText } from '@ionic/react';
+import {
+  IonButton,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonNote,
+  IonSearchbar,
+  IonSpinner,
+  IonText,
+} from '@ionic/react';
+import { chatbubbles } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { useSelector } from 'react-redux';
@@ -63,6 +74,11 @@ function MessageSearchResultRow({ message, locale, onSelect }: MessageSearchResu
           {timestamp ? <IonNote className={styles.timestamp}>{timestamp}</IonNote> : null}
         </div>
         <p className={styles.previewText}>{previewText}</p>
+        {message.replyRootId != null && (
+          <p className={styles.threadLabel}>
+            <IonIcon icon={chatbubbles} className={styles.threadIcon} /> {t`In thread`}
+          </p>
+        )}
       </IonLabel>
     </IonItem>
   );

--- a/wetty-chat-mobile/src/components/chat/settings/ShareInviteModal.module.scss
+++ b/wetty-chat-mobile/src/components/chat/settings/ShareInviteModal.module.scss
@@ -16,7 +16,7 @@
   height: 32px;
   border: none;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.86);
+  background: var(--ion-color-light, rgba(255, 255, 255, 0.86));
   color: var(--ion-color-dark);
   font-size: 20px;
   z-index: 1;

--- a/wetty-chat-mobile/src/components/chat/settings/ShareInviteModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/settings/ShareInviteModal.tsx
@@ -32,7 +32,6 @@ import { ShareInviteMemberSelectorModal } from './ShareInviteMemberSelectorModal
 import {
   canCopyInviteCode,
   copyInviteCode,
-  createInviteMessageClientGeneratedId,
   getExpiresAt,
   getExpiryLabel,
   getExpiryOptions,
@@ -40,6 +39,7 @@ import {
   type InviteExpiryOption,
   type InviteMode,
 } from './shareInviteHelpers';
+import { createClientGeneratedId } from '@/utils/clientGeneratedId';
 import { useShareInviteModalState } from './useShareInviteModalState';
 import styles from './ShareInviteModal.module.scss';
 
@@ -378,7 +378,7 @@ function ShareInviteModalSession({ chatId, onDismiss }: Omit<ShareInviteModalPro
         destinationChatId: selectedDestinationGroup.id,
         inviteId: draftInvite?.id,
         expiresAt: getExpiresAt(expiryOption),
-        clientGeneratedId: createInviteMessageClientGeneratedId(),
+        clientGeneratedId: createClientGeneratedId('invite_'),
       });
 
       dispatch(

--- a/wetty-chat-mobile/src/components/chat/settings/shareInviteHelpers.ts
+++ b/wetty-chat-mobile/src/components/chat/settings/shareInviteHelpers.ts
@@ -47,10 +47,6 @@ export function getExpiryLabel(expiryOption: InviteExpiryOption): string {
   return getExpiryOptions().find((option) => option.value === expiryOption)?.label ?? t`Never`;
 }
 
-export function createInviteMessageClientGeneratedId(): string {
-  return `invite_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-}
-
 export function canCopyInviteCode(): boolean {
   return typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function';
 }

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -159,6 +159,7 @@ export function ChatVirtualScroll({
   const initialAnchorConsumedRef = useRef(false);
   const pendingScrollBehaviorRef = useRef<ScrollBehavior>('auto');
   const pendingScrollToBottomRef = useRef(false);
+  const pendingScrollAlignRef = useRef<'top' | 'bottom'>('top');
   const pendingScrollToBottomBehaviorRef = useRef<ScrollBehavior>('auto');
   const pendingScrollToBottomSourceRef = useRef<string | null>(null);
   const pendingPrependRestoreRef = useRef<{ key: string; offsetTop: number } | null>(null);
@@ -537,37 +538,40 @@ export function ChatVirtualScroll({
     container.scrollTop = target;
   }, []);
 
-  const scrollToKeyInternal = useCallback((key: string, behavior: ScrollBehavior = 'auto') => {
-    const container = containerRef.current;
-    const row = rowRefsMap.current.get(key);
-    if (!container || !row) {
-      logVirtualScroll('scroll-to-item-missed-row', {
+  const scrollToKeyInternal = useCallback(
+    (key: string, behavior: ScrollBehavior = 'auto', align: 'top' | 'bottom' = 'top') => {
+      const container = containerRef.current;
+      const row = rowRefsMap.current.get(key);
+      if (!container || !row) {
+        logVirtualScroll('scroll-to-item-missed-row', {
+          key,
+          behavior,
+          hasContainer: container != null,
+          hasRow: row != null,
+          mounted: mountedRef.current,
+        });
+        return false;
+      }
+
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      const rawTarget = align === 'bottom' ? row.offsetTop + row.offsetHeight - container.clientHeight : row.offsetTop;
+      const target = roundScrollValue(Math.max(0, Math.min(rawTarget, maxScroll)));
+      if (behavior === 'auto' && !hasMeaningfulScrollDelta(container.scrollTop, target)) {
+        return true;
+      }
+      logVirtualScroll('scroll-to-item-execute', {
         key,
         behavior,
-        hasContainer: container != null,
-        hasRow: row != null,
+        mode: behavior === 'smooth' ? 'smooth-scroll' : 'jump-scroll',
+        from: container.scrollTop,
+        to: target,
         mounted: mountedRef.current,
       });
-      return false;
-    }
-
-    const target = roundScrollValue(
-      Math.max(0, Math.min(row.offsetTop, container.scrollHeight - container.clientHeight)),
-    );
-    if (behavior === 'auto' && !hasMeaningfulScrollDelta(container.scrollTop, target)) {
+      container.scrollTo({ top: target, behavior });
       return true;
-    }
-    logVirtualScroll('scroll-to-item-execute', {
-      key,
-      behavior,
-      mode: behavior === 'smooth' ? 'smooth-scroll' : 'jump-scroll',
-      from: container.scrollTop,
-      to: target,
-      mounted: mountedRef.current,
-    });
-    container.scrollTo({ top: target, behavior });
-    return true;
-  }, []);
+    },
+    [],
+  );
 
   const triggerJumpTargetHighlight = useCallback((key: string) => {
     if (highlightTimerRef.current) {
@@ -1382,9 +1386,14 @@ export function ChatVirtualScroll({
         mounted: mountedRef.current,
       });
       if (target) {
-        const scrolled = scrollToKeyInternal(target.key, intent.scrollToMessageId.behavior);
+        const scrolled = scrollToKeyInternal(
+          target.key,
+          intent.scrollToMessageId.behavior,
+          intent.scrollToMessageId.align ?? 'top',
+        );
         if (scrolled && pendingScrollMessageIdRef.current === intent.scrollToMessageId.messageId) {
           pendingScrollMessageIdRef.current = null;
+          pendingScrollAlignRef.current = 'top';
           if (
             initialAnchorRef.current.type === 'message' &&
             initialAnchorRef.current.messageId === intent.scrollToMessageId.messageId
@@ -1701,6 +1710,7 @@ export function ChatVirtualScroll({
     pendingScrollMessageIdRef.current = null;
     initialAnchorConsumedRef.current = false;
     pendingScrollToBottomRef.current = false;
+    pendingScrollAlignRef.current = 'top';
     pendingScrollToBottomBehaviorRef.current = 'auto';
     pendingScrollToBottomSourceRef.current = null;
     pendingPrependRestoreRef.current = null;
@@ -1852,6 +1862,7 @@ export function ChatVirtualScroll({
       action: 'scrollToMessageId',
     });
     pendingScrollMessageIdRef.current = anchor.messageId;
+    pendingScrollAlignRef.current = 'bottom';
     pendingScrollBehaviorRef.current = 'auto';
     updateMountedRange(capRange(mounted, rowKeys.length - 1));
     setPhaseState('READY');
@@ -1918,6 +1929,7 @@ export function ChatVirtualScroll({
           scrollToMessageId: {
             messageId: pendingScrollMessageIdRef.current,
             behavior: pendingScrollBehaviorRef.current,
+            align: pendingScrollAlignRef.current,
           },
         };
       } else if (pendingScrollKeyRef.current) {
@@ -1993,6 +2005,7 @@ export function ChatVirtualScroll({
           scrollToMessageId: {
             messageId: pendingScrollMessageIdRef.current,
             behavior: pendingScrollBehaviorRef.current,
+            align: pendingScrollAlignRef.current,
           },
         };
         triggerRender();
@@ -2095,6 +2108,7 @@ export function ChatVirtualScroll({
         pendingScrollKeyRef.current = key;
         pendingScrollMessageIdRef.current = null;
         pendingScrollToBottomRef.current = false;
+        pendingScrollAlignRef.current = 'top';
         pendingScrollToBottomBehaviorRef.current = 'auto';
         pendingScrollToBottomSourceRef.current = null;
         logVirtualScroll('scroll-to-item-requested', {
@@ -2151,6 +2165,7 @@ export function ChatVirtualScroll({
         pendingScrollMessageIdRef.current = messageId;
         pendingScrollKeyRef.current = null;
         pendingScrollToBottomRef.current = false;
+        pendingScrollAlignRef.current = 'top';
         pendingScrollToBottomBehaviorRef.current = 'auto';
         pendingScrollToBottomSourceRef.current = null;
         logVirtualScroll('scroll-to-message-requested', {

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -163,6 +163,7 @@ export function ChatVirtualScroll({
   const pendingScrollToBottomBehaviorRef = useRef<ScrollBehavior>('auto');
   const pendingScrollToBottomSourceRef = useRef<string | null>(null);
   const pendingPrependRestoreRef = useRef<{ key: string; offsetTop: number } | null>(null);
+  const pendingDeleteRestoreRef = useRef<{ key: string; offsetTop: number } | null>(null);
   const pendingPrependCompensationRef = useRef<number | null>(null);
   const pendingLayoutAnchorRestoreRef = useRef<{
     source: string;
@@ -1499,6 +1500,31 @@ export function ChatVirtualScroll({
       }
     }
 
+    const pendingDeleteRestore = pendingDeleteRestoreRef.current;
+    if (pendingDeleteRestore) {
+      logVirtualScroll('delete-restore-attempt', {
+        key: pendingDeleteRestore.key,
+        offsetTop: pendingDeleteRestore.offsetTop,
+      });
+      let restored = restoreAnchorOffset(pendingDeleteRestore.key, pendingDeleteRestore.offsetTop);
+      if (!restored) {
+        // Anchor was deleted — walk backward to find nearest surviving key
+        const oldKeys = prevKeysRef.current;
+        const oldIndex = oldKeys.indexOf(pendingDeleteRestore.key);
+        for (let i = oldIndex - 1; i >= 0; i--) {
+          if (keyToIndex.has(oldKeys[i])) {
+            restored = restoreAnchorOffset(oldKeys[i], pendingDeleteRestore.offsetTop);
+            if (restored) logVirtualScroll('delete-restore-fallback', { key: oldKeys[i] });
+            break;
+          }
+        }
+      } else {
+        logVirtualScroll('delete-restore-complete');
+      }
+      pendingDeleteRestoreRef.current = null;
+      mutationSnapshotRef.current = null;
+    }
+
     const pendingAnchorDriftCheck = pendingAnchorDriftCheckRef.current;
     if (pendingAnchorDriftCheck) {
       const row = rowRefsMap.current.get(pendingAnchorDriftCheck.key);
@@ -1718,6 +1744,7 @@ export function ChatVirtualScroll({
     pendingScrollToBottomBehaviorRef.current = 'auto';
     pendingScrollToBottomSourceRef.current = null;
     pendingPrependRestoreRef.current = null;
+    pendingDeleteRestoreRef.current = null;
     pendingPrependCompensationRef.current = null;
     pendingLayoutAnchorRestoreRef.current = null;
     mutationSnapshotRef.current = null;
@@ -2320,6 +2347,39 @@ export function ChatVirtualScroll({
               previousMounted: mounted,
               nextMounted: mountedRef.current,
             });
+          }
+        }
+      } else if (mutation === 'delete') {
+        const anchor = captureVisibleAnchor();
+        mutationSnapshotRef.current = {
+          mutation,
+          anchor,
+          rowCountDelta: rowKeys.length - adjustPrevKeysRef.current.length,
+        };
+        logMutationSnapshot('delete-detected', {
+          previousCount: adjustPrevKeysRef.current.length,
+          nextCount: rowKeys.length,
+        });
+        if (anchor) {
+          pendingDeleteRestoreRef.current = anchor;
+        }
+        // Adjust mounted window for the reduced row count
+        const mounted = mountedRef.current;
+        if (mounted) {
+          const newEnd = Math.min(mounted.end, rowKeys.length - 1);
+          if (newEnd < mounted.start) {
+            // All mounted rows were deleted — recenter around anchor
+            const anchorIndex = anchor ? keyToIndex.get(anchor.key) : null;
+            if (anchorIndex != null) {
+              const halfWindow = Math.floor(WINDOW_CAP / 2);
+              mountedRef.current = normalizeRange(
+                anchorIndex - halfWindow,
+                anchorIndex + halfWindow,
+                rowKeys.length - 1,
+              );
+            }
+          } else if (newEnd !== mounted.end) {
+            mountedRef.current = { start: mounted.start, end: newEnd };
           }
         }
       }

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -1402,7 +1402,10 @@ export function ChatVirtualScroll({
           }
         }
         if (scrolled) {
-          triggerJumpTargetHighlight(target.key);
+          // Skip highlight when resuming the latest message — no jump is happening.
+          if (target.index < rowKeys.length - 1) {
+            triggerJumpTargetHighlight(target.key);
+          }
         }
       } else {
         logVirtualScroll('layout-intent-scroll-to-message-missed', {
@@ -1568,6 +1571,7 @@ export function ChatVirtualScroll({
     prevKeysRef.current = rowKeys;
   }, [
     rowKeys,
+    rowKeys.length,
     renderTick,
     cancelBatch,
     containerHeight,
@@ -2183,7 +2187,10 @@ export function ChatVirtualScroll({
         if (mounted && target.index >= mounted.start && target.index <= mounted.end) {
           const scrolled = scrollToKeyInternal(target.key, resolvedBehavior);
           if (scrolled) {
-            triggerJumpTargetHighlight(target.key);
+            // Skip highlight when resuming the latest message — no jump is happening.
+            if (target.index < rowKeys.length - 1) {
+              triggerJumpTargetHighlight(target.key);
+            }
             pendingScrollMessageIdRef.current = null;
           }
           return;
@@ -2209,6 +2216,7 @@ export function ChatVirtualScroll({
       }
     };
   }, [
+    rowKeys.length,
     ensureBottomMeasured,
     enterRecentering,
     keyToIndex,

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.ts
@@ -16,12 +16,22 @@ function isSuffix(suffix: string[], full: string[]): boolean {
   return suffix.every((value, index) => full[offset + index] === value);
 }
 
+function isSubsequence(sub: string[], full: string[]): boolean {
+  let i = 0;
+  for (let j = 0; j < full.length && i < sub.length; j++) {
+    if (sub[i] === full[j]) i++;
+  }
+  return i === sub.length;
+}
+
 export function classifyKeyMutation(prev: string[], next: string[]): MutationType {
   const prevMsgs = prev.filter((key) => key.startsWith('msg:'));
   const nextMsgs = next.filter((key) => key.startsWith('msg:'));
 
   if (arraysEqual(prevMsgs, nextMsgs)) return 'none';
-  if (prevMsgs.length === 0 || nextMsgs.length === 0 || nextMsgs.length < prevMsgs.length) return 'reset';
+  if (prevMsgs.length === 0 || nextMsgs.length === 0) return 'reset';
+  if (nextMsgs.length < prevMsgs.length && isSubsequence(nextMsgs, prevMsgs)) return 'delete';
+  if (nextMsgs.length < prevMsgs.length) return 'reset';
   if (isSuffix(prevMsgs, nextMsgs)) return 'prepend';
   if (isPrefix(prevMsgs, nextMsgs)) return 'append';
   return 'reset';

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
@@ -47,7 +47,7 @@ export interface PendingBatch {
 export interface LayoutIntent {
   preserveHeightDelta?: number;
   scrollToBottom?: { behavior: ScrollBehavior };
-  scrollToMessageId?: { messageId: string; behavior: ScrollBehavior };
+  scrollToMessageId?: { messageId: string; behavior: ScrollBehavior; align?: 'top' | 'bottom' };
   scrollToKey?: { key: string; behavior: ScrollBehavior };
 }
 

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
@@ -32,7 +32,7 @@ export type Phase = 'WAITING_VIEWPORT' | 'BOOTSTRAP' | 'READY' | 'RECENTERING';
 
 // ── Mutations ──
 
-export type MutationType = 'none' | 'prepend' | 'append' | 'reset';
+export type MutationType = 'none' | 'prepend' | 'append' | 'delete' | 'reset';
 export type BatchDirection = 'backward' | 'forward';
 export type BatchReason = 'bootstrap' | 'preload' | 'recenter' | 'jump';
 

--- a/wetty-chat-mobile/src/components/invites/InvitePreviewCard.module.scss
+++ b/wetty-chat-mobile/src/components/invites/InvitePreviewCard.module.scss
@@ -21,19 +21,19 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #876b2a;
+  color: var(--ion-color-primary);
 }
 
 .title {
   margin: 0;
   font-size: clamp(1.8rem, 4vw, 2.4rem);
   line-height: 1.1;
-  color: #241f14;
+  color: var(--ion-text-color, #241f14);
 }
 
 .description {
   margin: 0;
-  color: #5d5748;
+  color: var(--ion-color-medium-shade, #5d5748);
   line-height: 1.5;
 }
 
@@ -48,14 +48,14 @@
   margin-top: 24px;
   padding: 14px 16px;
   border-radius: 18px;
-  background: rgba(91, 76, 33, 0.07);
-  color: #4c432c;
+  background: var(--ion-color-step-100, rgba(91, 76, 33, 0.07));
+  color: var(--ion-color-medium-shade, #4c432c);
   line-height: 1.45;
 }
 
 .statusError {
-  background: rgba(180, 52, 43, 0.1);
-  color: #7e241d;
+  background: var(--ion-color-danger-tint, rgba(180, 52, 43, 0.1));
+  color: var(--ion-color-danger-shade, #7e241d);
 }
 
 .actions {

--- a/wetty-chat-mobile/src/hooks/useChatDraft.ts
+++ b/wetty-chat-mobile/src/hooks/useChatDraft.ts
@@ -7,6 +7,7 @@ export interface ChatDraft {
   text: string;
   replyToMessageId?: string;
   replyToUsername?: string;
+  savedAt?: number;
 }
 
 const SAVE_DEBOUNCE_MS = 500;
@@ -25,7 +26,12 @@ export async function saveDraft(key: string, draft: ChatDraft): Promise<void> {
     await clearDraft(key);
     return;
   }
-  await kvSet(draftKey(key), draft);
+  const existing = await loadDraft(key);
+  if (existing && existing.text === draft.text && existing.replyToMessageId === draft.replyToMessageId) {
+    return;
+  }
+  const stamped: ChatDraft = { ...draft, savedAt: Date.now() };
+  await kvSet(draftKey(key), stamped);
   notifyDraftChange(key);
 }
 

--- a/wetty-chat-mobile/src/hooks/useEscNavigation.ts
+++ b/wetty-chat-mobile/src/hooks/useEscNavigation.ts
@@ -7,8 +7,9 @@ import { useHistory, useLocation, matchPath } from 'react-router-dom';
  * - In a thread → navigate to parent chat, positioned at the thread root message.
  * - In a chat   → navigate to the chat list (deselect).
  *
- * Defers when focus is inside a textarea/input or ion-modal,
- * so compose-bar reply/edit ESC and modal dismiss take priority.
+ * Defers when focus is inside a textarea/input or an Ionic overlay
+ * (ion-alert, ion-action-sheet, ion-modal, ion-toast),
+ * so compose-bar reply/edit ESC and overlay dismiss take priority.
  */
 export function useEscNavigation(): void {
   const history = useHistory();
@@ -20,7 +21,9 @@ export function useEscNavigation(): void {
 
       const active = document.activeElement;
       if (active instanceof HTMLTextAreaElement || active instanceof HTMLInputElement) return;
-      if (active?.closest('ion-modal')) return;
+      // Defer to Ionic overlays (alerts, action sheets, modals, toasts) — they handle ESC internally.
+      if (active?.closest('ion-alert, ion-action-sheet, ion-modal, ion-toast')) return;
+      if (document.querySelector('ion-alert, ion-action-sheet')) return;
 
       // Thread → parent chat with #msg= scroll target
       const threadMatch = matchPath<{ id: string; threadId: string }>(location.pathname, {

--- a/wetty-chat-mobile/src/hooks/useEscNavigation.ts
+++ b/wetty-chat-mobile/src/hooks/useEscNavigation.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { useHistory, useLocation, matchPath } from 'react-router-dom';
+
+/**
+ * Global ESC key handler for chat-level navigation.
+ *
+ * - In a thread → navigate to parent chat, positioned at the thread root message.
+ * - In a chat   → navigate to the chat list (deselect).
+ *
+ * Defers when focus is inside a textarea/input or ion-modal,
+ * so compose-bar reply/edit ESC and modal dismiss take priority.
+ */
+export function useEscNavigation(): void {
+  const history = useHistory();
+  const location = useLocation();
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+
+      const active = document.activeElement;
+      if (active instanceof HTMLTextAreaElement || active instanceof HTMLInputElement) return;
+      if (active?.closest('ion-modal')) return;
+
+      // Thread → parent chat with #msg= scroll target
+      const threadMatch = matchPath<{ id: string; threadId: string }>(location.pathname, {
+        path: '/chats/chat/:id/thread/:threadId',
+        exact: true,
+      });
+      if (threadMatch) {
+        const { id, threadId } = threadMatch.params;
+        history.replace({ pathname: `/chats/chat/${id}`, hash: `#msg=${threadId}` });
+        return;
+      }
+
+      // Chat → chat list
+      const chatMatch = matchPath(location.pathname, { path: '/chats/chat/:id', exact: true });
+      if (chatMatch) {
+        history.replace('/chats');
+        return;
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [history, location.pathname]);
+}

--- a/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
@@ -25,6 +25,7 @@ import type { ConversationRouteState } from '@/types/conversationNavigation';
 import styles from './DesktopSplitLayout.module.scss';
 import { HeaderActionMenu, type HeaderActionMenuItem } from '@/components/HeaderActionMenu';
 import { useHasGlobalPermission } from '@/hooks/useHasGlobalPermission';
+import { useEscNavigation } from '@/hooks/useEscNavigation';
 import { useFeatureGate } from '@/hooks/useFeatureGate';
 import type { RootState } from '@/store';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -199,6 +200,7 @@ export function DesktopSplitLayout() {
   const canCreateChat = useHasGlobalPermission('chat.create');
   const savedMessagesEnabled = useFeatureGate('savedMessages');
   const currentUser = useSelector((state: RootState) => state.user);
+  useEscNavigation();
   const skipNextGlobalSettingsDismiss = useRef(false);
   const headerActions: HeaderActionMenuItem[] = [
     ...(canCreateChat

--- a/wetty-chat-mobile/src/layouts/MobileLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/MobileLayout.tsx
@@ -31,6 +31,7 @@ import { selectChatsWithUnreadCount } from '@/store/chatsSlice';
 import { selectThreadsWithUnreadCount } from '@/store/threadsSlice';
 import styles from './MobileLayout.module.scss';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { useEscNavigation } from '@/hooks/useEscNavigation';
 
 const TAB_ROOT_PATHS = ['/', '/chats', '/settings', '/demo'];
 
@@ -46,6 +47,7 @@ const MobileLayout: React.FC = () => {
     exact: true,
   });
   useDocumentTitle(chatMatch?.params.id, threadMatch?.params.threadId);
+  useEscNavigation();
 
   const tabBarButtons = useMemo(() => {
     return featureGatedList([

--- a/wetty-chat-mobile/src/pages/conversation/conversation.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/conversation.tsx
@@ -500,7 +500,6 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
                   messageType: replyingTo.messageType,
                   text: replyingTo.message,
                   attachments: replyingTo.attachments,
-                  firstAttachmentKind: replyingTo.attachments?.[0]?.kind,
                   isDeleted: replyingTo.isDeleted,
                   mentions: replyingTo.mentions,
                 }

--- a/wetty-chat-mobile/src/pages/conversation/manage-invites.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/manage-invites.tsx
@@ -21,15 +21,12 @@ import { deleteInvite, getInvites, sendInviteMessage, type InviteInfoResponse, t
 import { usersApi, type MemberSummary } from '@/api/users';
 import { BackButton } from '@/components/BackButton';
 import { ShareInviteGroupSelectorModal } from '@/components/chat/settings/ShareInviteGroupSelectorModal';
-import {
-  canCopyInviteCode,
-  copyInviteCode,
-  createInviteMessageClientGeneratedId,
-} from '@/components/chat/settings/shareInviteHelpers';
+import { canCopyInviteCode, copyInviteCode } from '@/components/chat/settings/shareInviteHelpers';
 import { getChatDisplayName } from '@/utils/chatDisplay';
 import type { GroupSelectorItem } from '@/api/group';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import type { RootState } from '@/store';
+import { createClientGeneratedId } from '@/utils/clientGeneratedId';
 import type { BackAction } from '@/types/back-action';
 import styles from './manage-invites.module.scss';
 
@@ -384,7 +381,7 @@ export default function ChatInvitesCore({ chatId: propChatId, backAction }: Chat
           sourceChatId: chatId,
           destinationChatId: group.id,
           inviteId: selectedInvite.id,
-          clientGeneratedId: createInviteMessageClientGeneratedId(),
+          clientGeneratedId: createClientGeneratedId('invite_'),
         });
 
         presentToast({

--- a/wetty-chat-mobile/src/pages/conversation/utils/conversationUtils.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/conversationUtils.ts
@@ -1,6 +1,7 @@
 import type { Attachment, MessageResponse } from '@/api/messages';
 import type { GroupRole } from '@/api/group';
 import type { ComposeUploadedAttachment } from '@/components/chat/compose/MessageComposeBar';
+import { createClientGeneratedId } from '@/utils/clientGeneratedId';
 
 function isSameDay(d1: Date, d2: Date): boolean {
   return d1.getFullYear() === d2.getFullYear() && d1.getMonth() === d2.getMonth() && d1.getDate() === d2.getDate();
@@ -25,7 +26,7 @@ export function formatDateSeparator(iso: string, locale: string, labels: { today
 }
 
 export function generateClientId(): string {
-  return `cg_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  return createClientGeneratedId('cg_');
 }
 
 export function parseComparableMessageId(messageId: string): bigint | null {

--- a/wetty-chat-mobile/src/store/index.ts
+++ b/wetty-chat-mobile/src/store/index.ts
@@ -42,7 +42,6 @@ function deletedThreadRootPreviewPatch(): Partial<MessagePreview> {
     message: null,
     sticker: null,
     attachments: [],
-    firstAttachmentKind: null,
     mentions: [],
   };
 }

--- a/wetty-chat-mobile/src/store/messages/slice.ts
+++ b/wetty-chat-mobile/src/store/messages/slice.ts
@@ -275,7 +275,6 @@ const messagesSlice = createSlice({
                 current.replyToMessage.sticker = message.sticker;
                 current.replyToMessage.isDeleted = message.isDeleted;
                 current.replyToMessage.attachments = message.attachments;
-                current.replyToMessage.firstAttachmentKind = message.attachments?.[0]?.kind;
                 current.replyToMessage.mentions = message.mentions;
               }
             }

--- a/wetty-chat-mobile/src/store/messages/storeIntegration.test.ts
+++ b/wetty-chat-mobile/src/store/messages/storeIntegration.test.ts
@@ -136,7 +136,6 @@ describe('message listener projections', () => {
       message: null,
       sticker: null,
       attachments: [],
-      firstAttachmentKind: null,
       mentions: [],
     });
   });
@@ -158,7 +157,6 @@ describe('message listener projections', () => {
       message: null,
       sticker: null,
       attachments: [],
-      firstAttachmentKind: null,
       mentions: [],
     });
   });

--- a/wetty-chat-mobile/src/types/attachmentKind.ts
+++ b/wetty-chat-mobile/src/types/attachmentKind.ts
@@ -1,0 +1,22 @@
+import { isHeicLikeMedia } from '@/utils/heicMedia';
+
+export type AttachmentMimeCategory = 'image' | 'video' | 'audio' | 'other';
+
+export function categorizeAttachmentKind(kind: string): AttachmentMimeCategory {
+  if (kind.startsWith('image/')) return 'image';
+  if (kind.startsWith('video/')) return 'video';
+  if (kind.startsWith('audio/')) return 'audio';
+  return 'other';
+}
+
+export function isImageKind(kind: string, meta?: { fileName?: string | null; url?: string | null }): boolean {
+  return kind.startsWith('image/') || isHeicLikeMedia({ mimeType: kind, ...meta });
+}
+
+export function isVideoKind(kind: string): boolean {
+  return kind.startsWith('video/');
+}
+
+export function isAudioKind(kind: string): boolean {
+  return kind.startsWith('audio/');
+}

--- a/wetty-chat-mobile/src/utils/clientGeneratedId.ts
+++ b/wetty-chat-mobile/src/utils/clientGeneratedId.ts
@@ -1,0 +1,7 @@
+/**
+ * Create a short-lived client-side ID (e.g. for optimistic messages).
+ * Format: `{prefix}{timestamp}_{random}`, uniqueness via timestamp + random suffix.
+ */
+export function createClientGeneratedId(prefix: string): string {
+  return `${prefix}${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}

--- a/wetty-chat-mobile/src/utils/draftSync.ts
+++ b/wetty-chat-mobile/src/utils/draftSync.ts
@@ -3,12 +3,12 @@ import type { ChatDraft } from '@/hooks/useChatDraft';
 
 export const DRAFT_KEY_PREFIX = 'draft:';
 
-export async function getAllDrafts(): Promise<Record<string, string>> {
+export async function getAllDrafts(): Promise<Record<string, { text: string; savedAt: number }>> {
   const db = await getDb();
   const keys = await db.getAllKeys('kv');
   const values = await db.getAll('kv');
 
-  const drafts: Record<string, string> = {};
+  const drafts: Record<string, { text: string; savedAt: number }> = {};
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     const value = values[i] as ChatDraft | undefined;
@@ -16,7 +16,7 @@ export async function getAllDrafts(): Promise<Record<string, string>> {
     if (!value || typeof value !== 'object') continue;
 
     const rawKey = key.slice(DRAFT_KEY_PREFIX.length);
-    drafts[rawKey] = value.text;
+    drafts[rawKey] = { text: value.text, savedAt: value.savedAt ?? 0 };
   }
 
   return drafts;

--- a/wetty-chat-mobile/src/utils/messagePreview.ts
+++ b/wetty-chat-mobile/src/utils/messagePreview.ts
@@ -1,3 +1,5 @@
+import type { AttachmentMimeCategory } from '@/types/attachmentKind';
+import { categorizeAttachmentKind } from '@/types/attachmentKind';
 export const MESSAGE_PREVIEW_MAX = 100;
 
 export interface PreviewAttachmentLike {
@@ -128,6 +130,18 @@ export function getNotificationPreviewLabels(locale?: string | null): Notificati
   return PREVIEW_LABELS_BY_LOCALE[resolvePreviewLocale(locale)];
 }
 
+function attachmentKindToLabel(kind: AttachmentMimeCategory, labels: PreviewLabels): string {
+  switch (kind) {
+    case 'image':
+      return labels.image;
+    case 'video':
+      return labels.video;
+    case 'audio':
+      return labels.voiceMessage;
+    case 'other':
+      return labels.attachment;
+  }
+}
 export function formatMessagePreview(preview: PreviewMessage, labels: PreviewLabels): string {
   const { message, messageType, sticker, attachments, firstAttachmentKind, isDeleted, mentions } =
     normalizePreviewMessage(preview);
@@ -148,41 +162,21 @@ export function formatMessagePreview(preview: PreviewMessage, labels: PreviewLab
     return labels.voiceMessage;
   }
 
-  if (message?.trim()) {
-    return renderMentionsAsText(message, mentions);
+  // Build one label per attachment
+  const attachmentLabels: string[] =
+    attachments?.map((a) => attachmentKindToLabel(categorizeAttachmentKind(a.kind), labels)) ?? [];
+
+  // Fallback when attachments array is absent but firstAttachmentKind is set
+  if (attachmentLabels.length === 0 && firstAttachmentKind) {
+    attachmentLabels.push(attachmentKindToLabel(categorizeAttachmentKind(firstAttachmentKind), labels));
   }
 
-  if (attachments?.some((attachment) => attachment.kind.startsWith('audio/'))) {
-    return labels.voiceMessage;
-  }
+  const prefix = attachmentLabels.join('');
+  const text = message?.trim() ? renderMentionsAsText(message, mentions) : '';
 
-  if (firstAttachmentKind?.startsWith('audio/')) {
-    return labels.voiceMessage;
-  }
-
-  if (attachments?.some((attachment) => attachment.kind.startsWith('image/'))) {
-    return labels.image;
-  }
-
-  if (firstAttachmentKind?.startsWith('image/')) {
-    return labels.image;
-  }
-
-  if (attachments?.some((attachment) => attachment.kind.startsWith('video/'))) {
-    return labels.video;
-  }
-
-  if (firstAttachmentKind?.startsWith('video/')) {
-    return labels.video;
-  }
-
-  if (attachments && attachments.length > 0) {
-    return labels.attachment;
-  }
-
-  if (firstAttachmentKind) {
-    return labels.attachment;
-  }
+  if (prefix && text) return `${prefix} ${text}`;
+  if (prefix) return prefix;
+  if (text) return text;
 
   return '';
 }

--- a/wetty-chat-mobile/src/utils/messagePreview.ts
+++ b/wetty-chat-mobile/src/utils/messagePreview.ts
@@ -21,7 +21,6 @@ export interface PreviewMessage {
   messageType?: string | null;
   sticker?: PreviewStickerLike | null;
   attachments?: PreviewAttachmentLike[];
-  firstAttachmentKind?: string | null;
   isDeleted?: boolean;
   mentions?: PreviewMentionLike[] | null;
 }
@@ -93,7 +92,6 @@ function normalizePreviewMessage({
   messageType,
   sticker,
   attachments,
-  firstAttachmentKind,
   isDeleted,
   mentions,
 }: PreviewMessage) {
@@ -102,7 +100,6 @@ function normalizePreviewMessage({
     messageType,
     sticker,
     attachments,
-    firstAttachmentKind,
     isDeleted,
     mentions,
   };
@@ -143,8 +140,7 @@ function attachmentKindToLabel(kind: AttachmentMimeCategory, labels: PreviewLabe
   }
 }
 export function formatMessagePreview(preview: PreviewMessage, labels: PreviewLabels): string {
-  const { message, messageType, sticker, attachments, firstAttachmentKind, isDeleted, mentions } =
-    normalizePreviewMessage(preview);
+  const { message, messageType, sticker, attachments, isDeleted, mentions } = normalizePreviewMessage(preview);
 
   if (isDeleted) {
     return labels.deleted;
@@ -165,11 +161,6 @@ export function formatMessagePreview(preview: PreviewMessage, labels: PreviewLab
   // Build one label per attachment
   const attachmentLabels: string[] =
     attachments?.map((a) => attachmentKindToLabel(categorizeAttachmentKind(a.kind), labels)) ?? [];
-
-  // Fallback when attachments array is absent but firstAttachmentKind is set
-  if (attachmentLabels.length === 0 && firstAttachmentKind) {
-    attachmentLabels.push(attachmentKindToLabel(categorizeAttachmentKind(firstAttachmentKind), labels));
-  }
 
   const prefix = attachmentLabels.join('');
   const text = message?.trim() ? renderMentionsAsText(message, mentions) : '';


### PR DESCRIPTION
- Chats are now sorted by draft saved time when the draft is more recent than the last message.

- Press Esc to quickly exit the current view: in a thread, it navigates up to the parent chat; in a group chat, it returns to the home screen.

- Messages with both text and attachments now correctly display attachment labels in previews. When multiple attachments are present, each one's label is shown individually.

- Scattered inline generated ID definitions have been consolidated into shared utility functions.

- Search results in the PWA now show the "In thread" label, consistent with the Flutter client.

- Previously, resuming a chat would place the last-read message at the top of the screen. This made it hard to recall context and could incorrectly advance the read position if the user entered the chat by accident. The restore position is now the bottom of the screen.

- On chat entry, the last-read message row was briefly highlighted to indicate its position. This highlight is now suppressed when the last-read message is already the latest message in the chat.