### PR TITLE
style(pwa): Fix message UI alignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 *.sln
 *.sw?
 .cursor
-
+.pi/
+context.md
 .env
 
 # Where I keep my runspace for testing / docker compose
@@ -17,7 +18,6 @@
 /reference
 .geminiignore
 .playwright-mcp
-
 
 # local env files
 *.log

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -1101,6 +1101,9 @@ msgstr "Share Invite"
 msgid "Show \"All\" Tab in Chats"
 msgstr "Show \"All\" Tab in Chats"
 
+msgid "Show Avatars Next to All Messages"
+msgstr "Show Avatars Next to All Messages"
+
 msgid "Small"
 msgstr "Small"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -1101,6 +1101,9 @@ msgstr "分享邀请"
 msgid "Show \"All\" Tab in Chats"
 msgstr "在聊天中显示\"全部\"标签"
 
+msgid "Show Avatars Next to All Messages"
+msgstr "在所有消息旁显示头像"
+
 msgid "Small"
 msgstr "小"
 

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -1101,6 +1101,9 @@ msgstr "分享邀請"
 msgid "Show \"All\" Tab in Chats"
 msgstr "在聊天中顯示「全部」標籤"
 
+msgid "Show Avatars Next to All Messages"
+msgstr "在所有訊息旁顯示頭像"
+
 msgid "Small"
 msgstr "小"
 

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -23,9 +23,12 @@
 }
 
 .chatRow {
+  --avatar-size: 36px;
+  --avatar-gap: 8px;
+
   display: flex;
   align-items: flex-end;
-  gap: 8px;
+  gap: var(--avatar-gap);
   padding: 4px 12px;
 
   &.sent {
@@ -37,7 +40,7 @@
 
     .messageColumn > *:last-child:not(.avatarBubbleRow) {
       margin-left: 0;
-      margin-right: calc(36px + 8px);
+      margin-right: calc(var(--avatar-size) + var(--avatar-gap));
     }
   }
 }
@@ -48,14 +51,14 @@
   width: 100%;
 
   > *:last-child:not(.avatarBubbleRow) {
-    margin-left: calc(36px + 8px);
+    margin-left: calc(var(--avatar-size) + var(--avatar-gap));
   }
 }
 
 .avatarBubbleRow {
   display: flex;
   align-items: flex-end;
-  gap: 8px;
+  gap: var(--avatar-gap);
 }
 
 .bubbleOnly {
@@ -68,8 +71,8 @@
 }
 
 .avatar {
-  width: 36px;
-  height: 36px;
+  width: var(--avatar-size);
+  height: var(--avatar-size);
   border-radius: 50%;
   flex-shrink: 0;
   display: flex;
@@ -360,7 +363,7 @@
 }
 
 .avatarSpacer {
-  width: 36px;
+  width: var(--avatar-size);
   flex-shrink: 0;
 }
 

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -30,7 +30,32 @@
 
   &.sent {
     flex-direction: row-reverse;
+
+    .avatarBubbleRow {
+      flex-direction: row-reverse;
+    }
+
+    .messageColumn > *:last-child:not(.avatarBubbleRow) {
+      margin-left: 0;
+      margin-right: calc(36px + 8px);
+    }
   }
+}
+
+.messageColumn {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  > *:last-child:not(.avatarBubbleRow) {
+    margin-left: calc(36px + 8px);
+  }
+}
+
+.avatarBubbleRow {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
 }
 
 .bubbleOnly {
@@ -66,7 +91,6 @@
 .bubbleWrapper {
   display: flex;
   flex-direction: column;
-  max-width: 75%;
 }
 
 .sent .bubbleWrapper {
@@ -78,7 +102,7 @@
 }
 
 .bubble {
-  max-width: 100%;
+  max-width: 75%;
   padding: 8px 12px;
   line-height: 1.4;
   font-size: 14px;
@@ -427,7 +451,7 @@
   font-size: 16px;
   cursor: pointer;
   flex-shrink: 0;
-  align-self: center;
+  align-self: flex-end;
 
   &:hover {
     background: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.12);

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -507,26 +507,28 @@ export function ChatBubbleBase({
   return (
     <>
       <div className={`${styles.chatRow} ${isSent ? styles.sent : styles.received}`}>
-        {showAvatar ? (
-          <UserAvatar
-            name={senderName}
-            avatarUrl={avatarUrl}
-            size={36}
-            className={styles.avatar}
-            onClick={interactive ? onAvatarClick : undefined}
-          />
-        ) : (
-          <div className={styles.avatarSpacer} />
-        )}
-        <div className={styles.bubbleWrapper}>
-          {bubble}
+        <div className={styles.messageColumn}>
+          <div className={styles.avatarBubbleRow}>
+            {showAvatar ? (
+              <UserAvatar
+                name={senderName}
+                avatarUrl={avatarUrl}
+                size={36}
+                className={styles.avatar}
+                onClick={interactive ? onAvatarClick : undefined}
+              />
+            ) : (
+              <div className={styles.avatarSpacer} />
+            )}
+            {bubble}
+            {interactive && onReply && (
+              <button className={styles.hoverReplyBtn} onClick={onReply} aria-label={t`Reply`}>
+                <IonIcon icon={arrowUndo} />
+              </button>
+            )}
+          </div>
           {reactionsContent}
         </div>
-        {interactive && onReply && (
-          <button className={styles.hoverReplyBtn} onClick={onReply} aria-label={t`Reply`}>
-            <IonIcon icon={arrowUndo} />
-          </button>
-        )}
       </div>
       {interactive && viewingAttachmentIndex !== null && imageAttachments.length > 0 && (
         <ImageViewer

--- a/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   align-items: flex-end;
   gap: 8px;
-  padding: 2px 8px;
+  padding: 2px 12px;
 }
 
 .rowSent {
@@ -19,16 +19,24 @@
 }
 
 .avatarSpacer {
-  width: 32px;
-  flex: 0 0 32px;
+  width: 36px;
+  flex: 0 0 36px;
 }
 
 .content {
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
   gap: 4px;
   width: min(85%, 360px);
   min-width: 0;
+}
+
+.cardRow {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  width: 100%;
 }
 
 .senderName {
@@ -41,12 +49,8 @@
 .card {
   display: block;
   width: 100%;
-  padding: 0;
-  border: none;
   background: transparent;
-  text-align: left;
-  color: inherit;
-  width: 100%;
+  padding: 0;
 }
 
 .cardDisabled {
@@ -60,6 +64,7 @@
   border-radius: 14px;
   box-shadow: none;
   --box-shadow: none;
+  --background: var(--ion-background-color);
   border: 1px solid var(--ion-color-light-shade);
   box-sizing: border-box;
 }
@@ -145,7 +150,7 @@
 }
 
 .timestamp {
-  align-self: flex-end;
+  white-space: nowrap;
   padding: 0 8px;
   font-size: 0.75rem;
   color: var(--ion-color-medium);

--- a/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.tsx
@@ -105,7 +105,7 @@ export function InviteMessageCard({
       {!isSent ? (
         showAvatar ? (
           <button type="button" className={styles.avatarButton} onClick={onAvatarClick}>
-            <UserAvatar name={senderName} avatarUrl={sender.avatarUrl} size={32} />
+            <UserAvatar name={senderName} avatarUrl={sender.avatarUrl} size={36} />
           </button>
         ) : (
           <div className={styles.avatarSpacer} />
@@ -115,24 +115,26 @@ export function InviteMessageCard({
       <div className={styles.content}>
         {showName && !isSent && <div className={styles.senderName}>{senderName}</div>}
 
-        <button
-          type="button"
-          className={`${styles.card} ${isSent ? styles.cardSent : ''} ${!inviteAvailable ? styles.cardDisabled : ''}`}
-          onClick={inviteAvailable ? onOpen : undefined}
-          disabled={!inviteAvailable}
-        >
-          <IonCard className={styles.ionCard}>
-            <IonCardHeader className={styles.cardHeader}>
-              <IonCardSubtitle className={styles.cardSubtitle}>
-                <IonIcon icon={mailOutline} />
-                <Trans>Group invite</Trans>
-              </IonCardSubtitle>
-            </IonCardHeader>
-            <InviteCardBody viewState={bodyViewState} />
-          </IonCard>
-        </button>
+        <div className={styles.cardRow}>
+          <button
+            type="button"
+            className={`${styles.card} ${isSent ? styles.cardSent : ''} ${!inviteAvailable ? styles.cardDisabled : ''}`}
+            onClick={inviteAvailable ? onOpen : undefined}
+            disabled={!inviteAvailable}
+          >
+            <IonCard className={styles.ionCard}>
+              <IonCardHeader className={styles.cardHeader}>
+                <IonCardSubtitle className={styles.cardSubtitle}>
+                  <IonIcon icon={mailOutline} />
+                  <Trans>Group invite</Trans>
+                </IonCardSubtitle>
+              </IonCardHeader>
+              <InviteCardBody viewState={bodyViewState} />
+            </IonCard>
+          </button>
 
-        <div className={styles.timestamp}>{formatTime(timestamp)}</div>
+          <div className={styles.timestamp}>{formatTime(timestamp)}</div>
+        </div>
       </div>
     </div>
   );

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/useChatRows.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/useChatRows.ts
@@ -23,7 +23,11 @@ function isSystemMessage(message: MessageResponse): boolean {
   return message.messageType === 'system';
 }
 
-export function useChatRows(messages: MessageResponse[], formatDateSeparator: (iso: string) => string): ChatRow[] {
+export function useChatRows(
+  messages: MessageResponse[],
+  formatDateSeparator: (iso: string) => string,
+  showAllAvatars: boolean,
+): ChatRow[] {
   return useMemo(() => {
     const rows: ChatRow[] = [];
     let prevSenderUid: number | string | null = null;
@@ -67,12 +71,12 @@ export function useChatRows(messages: MessageResponse[], formatDateSeparator: (i
         clientGeneratedId: msg.clientGeneratedId ?? null,
         message: msg,
         showName,
-        showAvatar: isLastInGroup,
+        showAvatar: showAllAvatars || isLastInGroup,
       });
 
       prevSenderUid = isSystem ? null : msg.sender.uid;
     }
 
     return rows;
-  }, [messages, formatDateSeparator]);
+  }, [messages, formatDateSeparator, showAllAvatars]);
 }

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.dom.test.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.dom.test.tsx
@@ -76,6 +76,9 @@ function emptyState(messages: MessageResponse[] = []): RootState {
           : {},
       views: {},
     },
+    settings: {
+      showAllAvatars: false,
+    },
   } as RootState;
 }
 

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import { t } from '@lingui/core/macro';
 import { useDispatch, useSelector } from 'react-redux';
+import { selectShowAllAvatars } from '@/store/settingsSlice';
 import { getMessages } from '@/api/messages';
 import { getThreadReadState } from '@/api/threads';
 import type { VirtualScrollAnchor, VirtualScrollHandle } from '@/components/chat/virtualScroll/types';
@@ -88,7 +89,8 @@ export function useConversationTimeline({
   const pendingLiveCount = useSelector((state: RootState) => selectPendingLiveCount(state, storeChatId));
 
   const messageLookup = useMemo(() => new Map(messages.map((message) => [message.id, message])), [messages]);
-  const chatRows = useChatRows(messages, formatDateSeparator);
+  const showAllAvatars = useSelector(selectShowAllAvatars);
+  const chatRows = useChatRows(messages, formatDateSeparator, showAllAvatars);
 
   useEffect(() => {
     if (messages.length > 0 || pendingLiveCount === 0) {

--- a/wetty-chat-mobile/src/pages/settings/general.tsx
+++ b/wetty-chat-mobile/src/pages/settings/general.tsx
@@ -24,9 +24,11 @@ import {
   chatFontSizeOptions,
   selectLocale,
   selectMessageFontSize,
+  selectShowAllAvatars,
   selectShowAllTab,
   setMessageFontSize,
   setShowAllTab,
+  setShowAllAvatars,
 } from '@/store/settingsSlice';
 import type { BackAction } from '@/types/back-action';
 import styles from './GeneralSettings.module.scss';
@@ -48,6 +50,7 @@ export function GeneralSettingsCore({ backAction, onOpenLanguage }: GeneralSetti
   const locale = useSelector(selectLocale);
   const messageFontSize = useSelector(selectMessageFontSize);
   const showAllTab = useSelector(selectShowAllTab);
+  const showAllAvatars = useSelector(selectShowAllAvatars);
   const sliderValue = chatFontSizeOptions.indexOf(messageFontSize);
 
   const handleOpenLanguage = () => {
@@ -83,6 +86,11 @@ export function GeneralSettingsCore({ backAction, onOpenLanguage }: GeneralSetti
           <IonItem>
             <IonToggle checked={showAllTab} onIonChange={(e) => dispatch(setShowAllTab(e.detail.checked))}>
               <Trans>Show "All" Tab in Chats</Trans>
+            </IonToggle>
+          </IonItem>
+          <IonItem>
+            <IonToggle checked={showAllAvatars} onIonChange={(e) => dispatch(setShowAllAvatars(e.detail.checked))}>
+              <Trans>Show Avatars Next to All Messages</Trans>
             </IonToggle>
           </IonItem>
         </IonList>

--- a/wetty-chat-mobile/src/store/settingsSlice.ts
+++ b/wetty-chat-mobile/src/store/settingsSlice.ts
@@ -32,6 +32,7 @@ export interface SettingsState {
   locale: string | null;
   messageFontSize: ChatFontSizeOption;
   showAllTab: boolean;
+  showAllAvatars: boolean;
   pinnedReactions: string[];
   recentReactions: string[];
 }
@@ -50,6 +51,7 @@ function persistSettings(state: SettingsState) {
     locale: currentState.locale,
     messageFontSize: currentState.messageFontSize,
     showAllTab: currentState.showAllTab,
+    showAllAvatars: currentState.showAllAvatars,
     pinnedReactions: currentState.pinnedReactions,
     recentReactions: currentState.recentReactions,
   });
@@ -68,6 +70,7 @@ const defaultSettings: SettingsState = {
   locale: null,
   messageFontSize: defaultChatFontSize,
   showAllTab: true,
+  showAllAvatars: false,
   pinnedReactions: normalizePinnedReactions(['👍']),
   recentReactions: ['❤️', '😂', '😮', '😢', '🎉'],
 };
@@ -99,6 +102,10 @@ const settingsSlice = createSlice({
       state.showAllTab = action.payload;
       persistSettings(state);
     },
+    setShowAllAvatars(state, action: PayloadAction<boolean>) {
+      state.showAllAvatars = action.payload;
+      persistSettings(state);
+    },
     setPinnedReactions(state, action: PayloadAction<string[]>) {
       state.pinnedReactions = normalizePinnedReactions(action.payload);
       persistSettings(state);
@@ -113,12 +120,19 @@ const settingsSlice = createSlice({
   },
 });
 
-export const { setLocale, setMessageFontSize, setShowAllTab, setPinnedReactions, addRecentReaction } =
-  settingsSlice.actions;
+export const {
+  setLocale,
+  setMessageFontSize,
+  setShowAllTab,
+  setShowAllAvatars,
+  setPinnedReactions,
+  addRecentReaction,
+} = settingsSlice.actions;
 export const selectLocale = (state: RootState) => state.settings.locale;
 export const selectEffectiveLocale = (state: RootState) => state.settings.locale ?? detectLocale();
 export const selectMessageFontSize = (state: RootState) => state.settings.messageFontSize;
 export const selectShowAllTab = (state: RootState) => state.settings.showAllTab;
+export const selectShowAllAvatars = (state: RootState) => state.settings.showAllAvatars;
 export const selectPinnedReactions = (state: RootState) => state.settings.pinnedReactions;
 export const selectRecentReactions = (state: RootState) => state.settings.recentReactions;
 export const selectChatFontSizeStyle = (state: RootState) => getChatFontSizeStyle(state.settings.messageFontSize);


### PR DESCRIPTION
- Align avatars and reply buttons to the bottom of the message bubble, ignoring reaction pills (#324).
- Fix avatar size and horizontal padding on group invite cards.
- Move invite card timestamps to the bottom-right of the card to prevent awkward avatar alignment.
- Add a new preference setting (off by default) to display avatars next to every message.