### PR TITLE
fix(backend): Persist reply quote for deleted messages

### DIFF
--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -210,7 +210,6 @@ fn load_reply_messages(
 
     messages_schema::table
         .filter(messages_schema::id.eq_any(reply_ids))
-        .filter(messages_schema::deleted_at.is_null())
         .filter(messages_schema::is_published.eq(true))
         .select(Message::as_select())
         .load::<Message>(conn)


### PR DESCRIPTION
Removed the `deleted_at.is_null()` filter from `load_reply_messages` so deleted reply targets are still returned — `attach_metadata` already handles them correctly.