### PR TITLE
fix(pwa): Fix unread badge inconsistencies

### DIFF
--- a/wetty-chat-mobile/src/layouts/MobileLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/MobileLayout.tsx
@@ -27,8 +27,8 @@ import ComponentDemoPage from '@/pages/component-demo';
 import { safariSafeRouteAnimation } from '@/utils/navigationHistory';
 import { formatUnreadBadge } from '@/utils/unreadBadge';
 import { featureGatedList, whenFeature } from '@/features';
-import { selectTotalUnreadChatCount } from '@/store/chatsSlice';
-import { selectTotalUnreadThreadCount } from '@/store/threadsSlice';
+import { selectChatsWithUnreadCount } from '@/store/chatsSlice';
+import { selectThreadsWithUnreadCount } from '@/store/threadsSlice';
 import styles from './MobileLayout.module.scss';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 
@@ -36,8 +36,8 @@ const TAB_ROOT_PATHS = ['/', '/chats', '/settings', '/demo'];
 
 const MobileLayout: React.FC = () => {
   const location = useLocation();
-  const unreadChatCount = useSelector(selectTotalUnreadChatCount);
-  const unreadThreadCount = useSelector(selectTotalUnreadThreadCount);
+  const unreadChatCount = useSelector(selectChatsWithUnreadCount);
+  const unreadThreadCount = useSelector(selectThreadsWithUnreadCount);
   const totalUnreadCount = unreadChatCount + unreadThreadCount;
   const isTabRoot = TAB_ROOT_PATHS.includes(location.pathname);
   const chatMatch = matchPath<{ id: string }>(location.pathname, { path: '/chats/chat/:id', exact: true });

--- a/wetty-chat-mobile/src/pages/conversation/conversation.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/conversation.tsx
@@ -27,6 +27,7 @@ import { type ChatMessageEditSession, useChatMessageSender } from './hooks/useCh
 import { useChatReadTracking } from './hooks/useChatReadTracking';
 import { useConversationTimeline } from './hooks/useConversationTimeline';
 import { useKeyboardViewport } from './hooks/useKeyboardViewport';
+import { formatUnreadBadge } from '@/utils/unreadBadge';
 import { useMessageOverlayActions } from './hooks/useMessageOverlayActions';
 import { useMessageReactions } from './hooks/useMessageReactions';
 import { useThreadSubscription } from './hooks/useThreadSubscription';
@@ -473,7 +474,7 @@ function ConversationPane({ chatId, threadId, backAction }: ConversationPaneProp
             className={`scroll-to-bottom-fab ${showScrollToBottomButton ? '' : 'scroll-to-bottom-fab--hidden'}`}
           >
             {pendingJumpCount > 0 && (
-              <span className="scroll-to-bottom-fab__badge">{pendingJumpCount > 99 ? '99+' : pendingJumpCount}</span>
+              <span className="scroll-to-bottom-fab__badge">{formatUnreadBadge(pendingJumpCount)}</span>
             )}
             <IonFabButton size="small" onClick={handleScrollToBottomClick}>
               <IonIcon icon={chevronDown} />


### PR DESCRIPTION
Scroll-to-bottom button had a hardcoded 99+ cap while other badges use the shared 999+ utility. 
Bottom tab badge counted total unread messages instead of conversations with unread, mismatching the All tab. 

Both now use the same logic as the rest of the app.