### PR TITLE
fix(pwa): `Enter` key after image upload & tall message read tracking

### DIFF
--- a/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/MessageComposeBar.tsx
@@ -339,6 +339,7 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
       const files = Array.from(e.target.files ?? []);
       queueFiles(files);
       e.target.value = '';
+      textareaRef.current?.focus();
     };
 
     return (
@@ -413,7 +414,7 @@ const MessageComposeBarInner = forwardRef<MessageComposeBarHandle, MessageCompos
                   onMentionTextChange(value);
                 }}
                 onFocusChange={handleInputFocusChange}
-                onSubmit={handleSend}
+                onSubmit={canSend ? handleSend : () => {}}
                 canRequestRecentEdit={canRequestRecentEdit}
                 onRequestEditLastMessage={onRequestEditLastMessage}
                 editing={editing}

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -453,7 +453,7 @@ export function ChatVirtualScroll({
         if (rowRect.height <= 0) continue;
 
         if (row.type === 'message') {
-          const fullyVisible = rowRect.top >= containerRect.top - 0.5 && rowRect.bottom <= containerRect.bottom + 0.5;
+          const fullyVisible = rowRect.bottom <= containerRect.bottom + 0.5;
           const partiallyVisible = rowRect.bottom > containerRect.top && rowRect.top < containerRect.bottom;
 
           if (partiallyVisible) {


### PR DESCRIPTION
Resovle #424 and #427 .