### PR TITLE
feat(pwa): Redesign message overlay action list

### DIFF
--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -85,7 +85,7 @@ msgstr "Archive"
 msgid "Archived"
 msgstr "Archived"
 
-#. placeholder {0}: msg.sender.name ?? 'this user'
+#. placeholder {0}: message.sender.name ?? 'this user'
 msgid "Are you sure you want to delete this message from {0}?"
 msgstr "Are you sure you want to delete this message from {0}?"
 
@@ -197,12 +197,6 @@ msgstr "Copy"
 msgid "Copy code"
 msgstr "Copy code"
 
-msgid "Copy Link"
-msgstr "Copy Link"
-
-msgid "Copy text"
-msgstr "Copy text"
-
 msgid "Copy the link below, or choose a group to send it to right now."
 msgstr "Copy the link below, or choose a group to send it to right now."
 
@@ -278,6 +272,9 @@ msgstr "Description"
 
 msgid "Destination Group"
 msgstr "Destination Group"
+
+msgid "Details"
+msgstr "Details"
 
 msgid "Discard"
 msgstr "Discard"
@@ -513,11 +510,11 @@ msgstr "Failed to update role"
 msgid "Failed to upload avatar"
 msgstr "Failed to upload avatar"
 
+msgid "Fav"
+msgstr "Fav"
+
 msgid "Favorite"
 msgstr "Favorite"
-
-msgid "Favorite Sticker"
-msgstr "Favorite Sticker"
 
 msgid "Favorites"
 msgstr "Favorites"
@@ -560,6 +557,7 @@ msgstr "Images"
 
 msgid "In thread"
 msgstr "In thread"
+
 msgid "indefinitely"
 msgstr "indefinitely"
 
@@ -630,6 +628,9 @@ msgstr "Leaving..."
 
 msgid "Left group"
 msgstr "Left group"
+
+msgid "Link"
+msgstr "Link"
 
 msgid "Load More"
 msgstr "Load More"
@@ -932,9 +933,6 @@ msgstr "Push notifications enabled"
 msgid "Push notifications turned off"
 msgstr "Push notifications turned off"
 
-msgid "Reaction Details"
-msgstr "Reaction Details"
-
 msgid "Read"
 msgstr "Read"
 
@@ -1108,9 +1106,6 @@ msgstr "Show Avatars Next to All Messages"
 
 msgid "Small"
 msgstr "Small"
-
-msgid "Start Thread"
-msgstr "Start Thread"
 
 msgid "Status"
 msgstr "Status"

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -273,8 +273,8 @@ msgstr "Description"
 msgid "Destination Group"
 msgstr "Destination Group"
 
-msgid "Details"
-msgstr "Details"
+msgid "Reactions"
+msgstr "Reactions"
 
 msgid "Discard"
 msgstr "Discard"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -85,7 +85,7 @@ msgstr "归档"
 msgid "Archived"
 msgstr "已归档"
 
-#. placeholder {0}: msg.sender.name ?? 'this user'
+#. placeholder {0}: message.sender.name ?? 'this user'
 msgid "Are you sure you want to delete this message from {0}?"
 msgstr "确定要删除 {0} 的这条消息吗？"
 
@@ -197,12 +197,6 @@ msgstr "复制"
 msgid "Copy code"
 msgstr "复制代码"
 
-msgid "Copy Link"
-msgstr "复制链接"
-
-msgid "Copy text"
-msgstr "复制文本"
-
 msgid "Copy the link below, or choose a group to send it to right now."
 msgstr "复制下方链接，或立即选择一个群组发送。"
 
@@ -278,6 +272,9 @@ msgstr "描述"
 
 msgid "Destination Group"
 msgstr "目标群组"
+
+msgid "Details"
+msgstr "详情"
 
 msgid "Discard"
 msgstr "放弃"
@@ -513,11 +510,11 @@ msgstr "更新角色失败"
 msgid "Failed to upload avatar"
 msgstr "上传头像失败"
 
-msgid "Favorite"
+msgid "Fav"
 msgstr "收藏"
 
-msgid "Favorite Sticker"
-msgstr "收藏贴纸"
+msgid "Favorite"
+msgstr "收藏"
 
 msgid "Favorites"
 msgstr "收藏"
@@ -560,6 +557,7 @@ msgstr "图片"
 
 msgid "In thread"
 msgstr "在话题中"
+
 msgid "indefinitely"
 msgstr "永久"
 
@@ -630,6 +628,9 @@ msgstr "正在退出..."
 
 msgid "Left group"
 msgstr "已退出群组"
+
+msgid "Link"
+msgstr "链接"
 
 msgid "Load More"
 msgstr "加载更多"
@@ -932,9 +933,6 @@ msgstr "推送通知已开启"
 msgid "Push notifications turned off"
 msgstr "推送通知已关闭"
 
-msgid "Reaction Details"
-msgstr "表情回应详情"
-
 msgid "Read"
 msgstr "标记已读"
 
@@ -1108,9 +1106,6 @@ msgstr "在所有消息旁显示头像"
 
 msgid "Small"
 msgstr "小"
-
-msgid "Start Thread"
-msgstr "创建话题"
 
 msgid "Status"
 msgstr "状态"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -273,8 +273,8 @@ msgstr "描述"
 msgid "Destination Group"
 msgstr "目标群组"
 
-msgid "Details"
-msgstr "详情"
+msgid "Reactions"
+msgstr "回应"
 
 msgid "Discard"
 msgstr "放弃"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -85,7 +85,7 @@ msgstr "封存"
 msgid "Archived"
 msgstr "已封存"
 
-#. placeholder {0}: msg.sender.name ?? 'this user'
+#. placeholder {0}: message.sender.name ?? 'this user'
 msgid "Are you sure you want to delete this message from {0}?"
 msgstr "確定要刪除 {0} 的這則訊息嗎？"
 
@@ -197,12 +197,6 @@ msgstr "複製"
 msgid "Copy code"
 msgstr "複製代碼"
 
-msgid "Copy Link"
-msgstr "複製連結"
-
-msgid "Copy text"
-msgstr "複製文本"
-
 msgid "Copy the link below, or choose a group to send it to right now."
 msgstr "複製下方連結，或立即選擇一個群組傳送。"
 
@@ -278,6 +272,9 @@ msgstr "描述"
 
 msgid "Destination Group"
 msgstr "目標群組"
+
+msgid "Details"
+msgstr "詳情"
 
 msgid "Discard"
 msgstr "放棄"
@@ -513,11 +510,11 @@ msgstr "更新角色失敗"
 msgid "Failed to upload avatar"
 msgstr "上傳頭像失敗"
 
-msgid "Favorite"
+msgid "Fav"
 msgstr "收藏"
 
-msgid "Favorite Sticker"
-msgstr "收藏貼紙"
+msgid "Favorite"
+msgstr "收藏"
 
 msgid "Favorites"
 msgstr "收藏"
@@ -560,6 +557,7 @@ msgstr "圖片"
 
 msgid "In thread"
 msgstr "在話題中"
+
 msgid "indefinitely"
 msgstr "永久"
 
@@ -630,6 +628,9 @@ msgstr "正在退出..."
 
 msgid "Left group"
 msgstr "已退出群組"
+
+msgid "Link"
+msgstr "連結"
 
 msgid "Load More"
 msgstr "載入更多"
@@ -932,9 +933,6 @@ msgstr "推播通知已開啟"
 msgid "Push notifications turned off"
 msgstr "推播通知已關閉"
 
-msgid "Reaction Details"
-msgstr "表情回應詳情"
-
 msgid "Read"
 msgstr "標記已讀"
 
@@ -1108,9 +1106,6 @@ msgstr "在所有訊息旁顯示頭像"
 
 msgid "Small"
 msgstr "小"
-
-msgid "Start Thread"
-msgstr "開始話題"
 
 msgid "Status"
 msgstr "狀態"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -273,8 +273,8 @@ msgstr "描述"
 msgid "Destination Group"
 msgstr "目標群組"
 
-msgid "Details"
-msgstr "詳情"
+msgid "Reactions"
+msgstr "回應"
 
 msgid "Discard"
 msgstr "放棄"

--- a/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.module.scss
@@ -29,6 +29,11 @@
 }
 
 .content {
+  --menu-bg: color-mix(in srgb, var(--ion-text-color, #000) 10%, var(--ion-background-color, #fff));
+  --menu-hover-bg: color-mix(in srgb, var(--ion-text-color, #000) 15%, var(--ion-background-color, #fff));
+
+  --action-row-height: 63px;
+
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -59,10 +64,10 @@
   display: flex;
   gap: 4px;
   padding: 6px 8px;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--menu-bg);
   border-radius: 24px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16);
-  width: fit-content;
+  box-shadow: var(--menu-box-shadow);
+  align-self: stretch;
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
@@ -88,7 +93,7 @@
     background-color 0.15s ease;
 
   &:hover {
-    background: rgba(0, 0, 0, 0.06);
+    background: var(--menu-hover-bg);
     transform: scale(1.2);
   }
 
@@ -99,45 +104,67 @@
 
 /* Action list */
 .actionList {
-  background: rgba(255, 255, 255, 0.95);
+  display: flex;
+  flex-direction: column;
+  background: var(--menu-bg);
   border-radius: 14px;
   overflow: hidden;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16);
-  min-width: 200px;
+  align-self: stretch;
+  width: 100%;
+  box-shadow: var(--menu-box-shadow);
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
 }
 
+.actionListPaginated {
+  overflow: hidden;
+  scroll-behavior: smooth;
+}
+
+.actionRow {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-auto-rows: var(--action-row-height);
+  border-bottom: 1px solid var(--ion-background-color-step-200, rgba(0, 0, 0, 0.08));
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
 .actionItem {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 12px;
-  width: 100%;
-  padding: 12px 16px;
+  justify-content: center;
+  gap: 4px;
+  padding: 12px 4px;
+  min-width: 0;
   border: none;
   background: transparent;
-  color: #1a1a1a;
-  font-size: 15px;
+  color: var(--ion-text-color, #1a1a1a);
+  font-size: 11px;
+  white-space: nowrap;
   cursor: pointer;
-  text-align: left;
+  text-align: center;
   appearance: none;
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
 
-  &:not(:last-child) {
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  &:hover {
+    background: var(--menu-hover-bg);
   }
 
   &:active {
-    background: rgba(0, 0, 0, 0.06);
+    background: var(--menu-hover-bg);
   }
 
   ion-icon {
-    font-size: 20px;
+    font-size: 22px;
     flex-shrink: 0;
-    opacity: 0.7;
+    opacity: 0.8;
   }
 }
 
@@ -154,40 +181,8 @@
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .reactionBar {
-    background: rgba(30, 30, 30, 0.95);
-  }
-
-  .reactionBtn:hover {
-    background: rgba(255, 255, 255, 0.1);
-  }
-
-  .actionList {
-    background: rgba(30, 30, 30, 0.95);
-  }
-
-  .actionItem {
-    color: #f0f0f0;
-
-    &:not(:last-child) {
-      border-bottom-color: rgba(255, 255, 255, 0.1);
-    }
-
-    &:active {
-      background: rgba(255, 255, 255, 0.08);
-    }
-  }
-}
-
 .opaqueMenu {
-  background: var(--ion-background-color, #ffffff) !important;
+  background: color-mix(in srgb, var(--ion-text-color, #000) 10%, var(--ion-background-color, #fff)) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
-}
-
-@media (prefers-color-scheme: dark) {
-  .opaqueMenu {
-    background: var(--ion-background-color, #1e1e1e) !important;
-  }
 }

--- a/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { IonIcon, useIonToast } from '@ionic/react';
-import { addOutline } from 'ionicons/icons';
+import { addOutline, chevronDown, chevronUp } from 'ionicons/icons';
 import EmojiPicker, { EmojiStyle, Theme, type EmojiClickData } from 'emoji-picker-react';
 import type { Attachment, MentionInfo } from '@/api/messages';
 import type { PreviewMessage } from '@/utils/messagePreview';
@@ -86,6 +86,75 @@ export function MessageOverlay(props: MessageOverlayProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
   const [presentToast] = useIonToast();
+
+  const [actionListPage, setActionListPage] = useState(0);
+  const actionListScrollRef = useRef<HTMLDivElement>(null);
+  const actionListRowHeightRef = useRef(0);
+
+  const COLS = 5;
+  const VISIBLE_SLOTS = COLS * 2; // 10
+  const needsPagination = actions.length > VISIBLE_SLOTS;
+  const totalRows =
+    actions.length <= COLS ? 1 : actions.length <= 2 * COLS ? 2 : actions.length <= 3 * COLS - 1 ? 3 : 4;
+  const totalPages = needsPagination ? 2 : 1;
+  const scrollRows = totalRows === 4 ? 2 : 1;
+  const firstVisibleIndex = actionListPage === 0 ? 0 : totalRows === 3 ? COLS : 2 * COLS - 1;
+
+  const showDownArrow = needsPagination && actionListPage < totalPages - 1;
+  const showUpArrow = actionListPage > 0;
+
+  const buildPageItems = (): (MessageOverlayAction | { type: 'arrow'; direction: 'up' | 'down' })[] => {
+    if (!needsPagination) return actions;
+
+    const result: (MessageOverlayAction | { type: 'arrow'; direction: 'up' | 'down' })[] = [];
+    const dataStart = firstVisibleIndex;
+    const slotsForData = VISIBLE_SLOTS - (showUpArrow ? 1 : 0) - (showDownArrow ? 1 : 0);
+
+    // Up arrow at end of row 1 (replaces last slot of row 1)
+    const dataItems = actions.slice(dataStart, dataStart + slotsForData);
+    if (showUpArrow) {
+      result.push(...dataItems.slice(0, COLS - 1));
+      result.push({ type: 'arrow', direction: 'up' });
+      result.push(...dataItems.slice(COLS - 1));
+    } else {
+      result.push(...dataItems);
+    }
+    if (showDownArrow) result.push({ type: 'arrow', direction: 'down' });
+
+    return result;
+  };
+
+  const handleArrowClick = (direction: 'up' | 'down') => {
+    const newPage = direction === 'down' ? actionListPage + 1 : actionListPage - 1;
+    setActionListPage(newPage);
+    const scrollContainer = actionListScrollRef.current;
+    if (scrollContainer && actionListRowHeightRef.current > 0) {
+      const gap = 1;
+      const rowStep = actionListRowHeightRef.current + gap;
+      scrollContainer.scrollTo({ top: rowStep * scrollRows * newPage, behavior: 'smooth' });
+    }
+  };
+
+  const visibleActions = buildPageItems();
+
+  // Measure row height and set dynamic max-height after mount/resize
+  useEffect(() => {
+    const el = actionListScrollRef.current;
+    if (!el || !needsPagination) return;
+    const firstRow = el.children[COLS]; // COLS-th child = start of row 2
+    if (firstRow) {
+      const top = (firstRow as HTMLElement).offsetTop;
+      actionListRowHeightRef.current = top; // top of row 2 = row1 height + gap
+      el.style.maxHeight = `${top * 2}px`;
+    }
+  }, [needsPagination, actions.length]);
+
+  // Reset pagination when actions change
+  useEffect(() => {
+    setActionListPage(0);
+    const el = actionListScrollRef.current;
+    if (el) el.scrollTop = 0;
+  }, [messageId]);
 
   const handleEmojiClick = useCallback(
     (emojiData: EmojiClickData) => {
@@ -179,6 +248,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
     // Reset any opaque-menu overrides from a previous layout pass.
     const resetMenuStyles = (el: HTMLElement) => {
       el.style.position = '';
+      el.style.width = '';
       el.style.top = '';
       el.style.left = '';
       el.style.right = '';
@@ -207,6 +277,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
 
       const applyPos = (el: HTMLElement, topY: number, leftX: number, elHeight: number) => {
         el.style.position = 'absolute';
+        // width set externally after positioning to match reactionBar
         let desiredTop = topY;
         if (desiredTop < localViewportTop) desiredTop = localViewportTop;
         if (desiredTop + elHeight > localViewportBottom) desiredTop = localViewportBottom - elHeight;
@@ -249,6 +320,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
 
         applyPos(reactionBarEl, rTop, menuLocalLeft, reactionHeight);
         applyPos(actionListEl, aTop, menuLocalLeft, actionHeight);
+        actionListEl.style.width = `${reactionBarEl.offsetWidth}px`;
       } else if (reactionBarEl) {
         applyPos(
           reactionBarEl,
@@ -348,6 +420,12 @@ export function MessageOverlay(props: MessageOverlayProps) {
       />
     );
   }
+
+  // Group actions into rows of 5 for row containers
+  const actionRows: (typeof visibleActions)[] = [];
+  for (let i = 0; i < visibleActions.length; i += 5) {
+    actionRows.push(visibleActions.slice(i, i + 5));
+  }
   const overlay = (
     <div className={styles.overlay} onClick={handleOverlayClick}>
       <div
@@ -411,22 +489,47 @@ export function MessageOverlay(props: MessageOverlayProps) {
         {bubbleClone}
 
         {/* Action list */}
-        <div className={styles.actionList} data-action-list="true">
-          {actions.map((action) => (
-            <button
-              key={action.key}
-              type="button"
-              disabled={action.disabled}
-              className={`${styles.actionItem} ${action.role === 'destructive' ? styles.actionDestructive : ''} ${action.disabled ? styles.actionDisabled : ''}`}
-              onClick={() => {
-                if (action.disabled) return;
-                action.handler();
-                onClose();
-              }}
-            >
-              {action.icon && <IonIcon icon={action.icon} />}
-              {action.label}
-            </button>
+        <div
+          className={`${styles.actionList} ${totalPages > 1 ? styles.actionListPaginated : ''}`}
+          data-action-list="true"
+          ref={actionListScrollRef}
+        >
+          {actionRows.map((row, rowIdx) => (
+            <div key={rowIdx} className={styles.actionRow}>
+              {row.map((item, index) => {
+                const globalIndex = rowIdx * 5 + index;
+                if ('type' in item && item.type === 'arrow') {
+                  return (
+                    <button
+                      key={`arrow-${item.direction}-${globalIndex}`}
+                      type="button"
+                      className={styles.actionItem}
+                      onClick={() => handleArrowClick(item.direction)}
+                    >
+                      <IonIcon icon={item.direction === 'down' ? chevronDown : chevronUp} />
+                      {'　'}
+                    </button>
+                  );
+                }
+                const action = item as MessageOverlayAction;
+                return (
+                  <button
+                    key={action.key}
+                    type="button"
+                    disabled={action.disabled}
+                    className={`${styles.actionItem} ${action.role === 'destructive' ? styles.actionDestructive : ''} ${action.disabled ? styles.actionDisabled : ''}`}
+                    onClick={() => {
+                      if (action.disabled) return;
+                      action.handler();
+                      onClose();
+                    }}
+                  >
+                    {action.icon && <IonIcon icon={action.icon} />}
+                    {action.label}
+                  </button>
+                );
+              })}
+            </div>
           ))}
         </div>
       </div>

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.dom.test.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.dom.test.tsx
@@ -183,14 +183,14 @@ describe('useMessageOverlayActions', () => {
     renderHook(message());
 
     expect(state.actions.map((action) => action.key)).toEqual([
-      'copy',
-      'copy-link',
-      'save',
       'reply',
       'thread',
-      'edit',
-      'delete',
       'pin',
+      'copy',
+      'edit',
+      'save',
+      'copy-link',
+      'delete',
     ]);
   });
 

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.ts
@@ -95,7 +95,7 @@ export function useMessageOverlayActions({
         case 'copy':
           actions.push({
             key: 'copy',
-            label: policyAction.copyVariant === 'text' ? t`Copy text` : t`Copy`,
+            label: t`Copy`,
             icon: copyOutline,
             handler: () => {
               const textToCopy = message.message ?? '';
@@ -123,7 +123,7 @@ export function useMessageOverlayActions({
         case 'copy-link':
           actions.push({
             key: 'copy-link',
-            label: t`Copy Link`,
+            label: t`Link`,
             icon: linkOutline,
             handler: () => {
               navigator.clipboard.writeText(buildPermalinkUrl(chatId, message.id));
@@ -133,7 +133,7 @@ export function useMessageOverlayActions({
         case 'favorite':
           actions.push({
             key: 'favorite',
-            label: t`Favorite Sticker`,
+            label: t`Fav`,
             icon: heartOutline,
             handler: () => {
               favoriteSticker(message.sticker!.id)
@@ -175,7 +175,7 @@ export function useMessageOverlayActions({
         case 'thread':
           actions.push({
             key: 'thread',
-            label: t`Start Thread`,
+            label: t`Thread`,
             icon: chatbubbles,
             handler: () => {
               onStartThread(message.id);
@@ -256,7 +256,7 @@ export function useMessageOverlayActions({
           actions.push({
             key: 'reaction-details',
             icon: informationCircleOutline,
-            label: t`Reaction Details`,
+            label: t`Details`,
             handler: () => {
               onOpenReactionDetails(message.id);
             },

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useMessageOverlayActions.ts
@@ -1,15 +1,14 @@
 import { useMemo } from 'react';
 import { t } from '@lingui/core/macro';
 import {
-  arrowUndo,
+  arrowUndoOutline,
   bookmarkOutline,
-  chatbubbles,
+  chatbubblesOutline,
   copyOutline,
   createOutline,
+  happyOutline,
   heartOutline,
-  informationCircleOutline,
   linkOutline,
-  pin as pinIcon,
   pinOutline,
   trashOutline,
 } from 'ionicons/icons';
@@ -166,7 +165,7 @@ export function useMessageOverlayActions({
           actions.push({
             key: 'reply',
             label: t`Reply`,
-            icon: arrowUndo,
+            icon: arrowUndoOutline,
             handler: () => {
               onReply(message);
             },
@@ -176,7 +175,7 @@ export function useMessageOverlayActions({
           actions.push({
             key: 'thread',
             label: t`Thread`,
-            icon: chatbubbles,
+            icon: chatbubblesOutline,
             handler: () => {
               onStartThread(message.id);
             },
@@ -225,7 +224,7 @@ export function useMessageOverlayActions({
           actions.push({
             key: 'pin',
             label: existingPin ? t`Unpin` : t`Pin`,
-            icon: existingPin ? pinIcon : pinOutline,
+            icon: pinOutline,
             handler: () => {
               presentAlert({
                 header: existingPin ? t`Unpin Message` : t`Pin Message`,
@@ -255,8 +254,8 @@ export function useMessageOverlayActions({
         case 'reaction-details':
           actions.push({
             key: 'reaction-details',
-            icon: informationCircleOutline,
-            label: t`Details`,
+            icon: happyOutline,
+            label: t`Reactions`,
             handler: () => {
               onOpenReactionDetails(message.id);
             },

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.test.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.test.ts
@@ -22,57 +22,57 @@ function keys(input: Partial<OverlayActionPolicyInput> = {}) {
 
 describe('overlay action policy', () => {
   it('preserves default text message action order', () => {
-    expect(keys()).toEqual(['copy', 'copy-link', 'save', 'reply', 'thread']);
+    expect(keys()).toEqual(['reply', 'thread', 'copy', 'save', 'copy-link']);
   });
 
   it('uses copy text variant when a text message also has attachments', () => {
-    expect(getOverlayActionPolicy({ ...baseInput, hasAttachments: true })[0]).toEqual({
+    expect(getOverlayActionPolicy({ ...baseInput, hasAttachments: true })[2]).toEqual({
       key: 'copy',
       copyVariant: 'text',
     });
   });
 
   it('omits copy when a regular message has no text', () => {
-    expect(keys({ text: '', hasAttachments: true })).toEqual(['copy-link', 'save', 'reply', 'thread']);
+    expect(keys({ text: '', hasAttachments: true })).toEqual(['reply', 'thread', 'save', 'copy-link']);
   });
 
   it('adds edit and delete for own regular messages even when optimistic or deleted', () => {
     expect(keys({ isOwn: true, isOptimistic: true })).toEqual([
-      'copy',
-      'copy-link',
       'reply',
       'thread',
+      'copy',
       'edit',
+      'copy-link',
       'delete',
     ]);
     expect(keys({ isOwn: true, isDeleted: true, text: null })).toEqual([
-      'copy-link',
       'reply',
       'thread',
       'edit',
+      'copy-link',
       'delete',
     ]);
   });
 
   it('adds delete and pin state for admins in main chat', () => {
-    expect(keys({ isAdmin: true })).toEqual(['copy', 'copy-link', 'save', 'reply', 'thread', 'delete', 'pin']);
-    expect(getOverlayActionPolicy({ ...baseInput, isAdmin: true, isPinned: true }).at(-1)).toEqual({
+    expect(keys({ isAdmin: true })).toEqual(['reply', 'thread', 'pin', 'copy', 'save', 'copy-link', 'delete']);
+    expect(getOverlayActionPolicy({ ...baseInput, isAdmin: true, isPinned: true }).at(2)).toEqual({
       key: 'pin',
       pinState: 'pinned',
     });
   });
 
   it('does not offer thread or pin actions inside thread view', () => {
-    expect(keys({ isThreadView: true, isAdmin: true })).toEqual(['copy', 'copy-link', 'save', 'reply', 'delete']);
+    expect(keys({ isThreadView: true, isAdmin: true })).toEqual(['reply', 'copy', 'save', 'copy-link', 'delete']);
   });
 
   it('does not offer start thread when the message already has thread info', () => {
-    expect(keys({ hasThreadInfo: true })).toEqual(['copy', 'copy-link', 'save', 'reply']);
+    expect(keys({ hasThreadInfo: true })).toEqual(['reply', 'copy', 'save', 'copy-link']);
   });
 
   it('preserves current optimistic and deleted save/pin restrictions', () => {
-    expect(keys({ isOptimistic: true })).toEqual(['copy', 'copy-link', 'reply', 'thread']);
-    expect(keys({ isDeleted: true, text: null, isAdmin: true })).toEqual(['copy-link', 'reply', 'thread', 'delete']);
+    expect(keys({ isOptimistic: true })).toEqual(['reply', 'thread', 'copy', 'copy-link']);
+    expect(keys({ isDeleted: true, text: null, isAdmin: true })).toEqual(['reply', 'thread', 'copy-link', 'delete']);
   });
 
   it('keeps sticker actions filtered to reply delete copy link and favorite', () => {
@@ -82,26 +82,26 @@ describe('overlay action policy', () => {
         isAdmin: true,
         hasReactions: true,
       }),
-    ).toEqual(['copy-link', 'favorite', 'reply', 'delete']);
+    ).toEqual(['reply', 'favorite', 'copy-link', 'delete']);
   });
 
   it('uses audio action rules without copy or edit', () => {
     expect(keys({ messageType: 'audio', isOwn: true, isAdmin: true })).toEqual([
-      'copy-link',
-      'save',
       'reply',
       'thread',
-      'delete',
       'pin',
+      'save',
+      'copy-link',
+      'delete',
     ]);
   });
 
   it('adds reaction details only when reactions are present for non-sticker messages', () => {
-    expect(keys({ hasReactions: true })).toEqual(['copy', 'copy-link', 'save', 'reply', 'thread', 'reaction-details']);
+    expect(keys({ hasReactions: true })).toEqual(['reply', 'thread', 'copy', 'save', 'copy-link', 'reaction-details']);
   });
 
   it('disables save when the feature is off or the message is system', () => {
-    expect(keys({ savedMessagesEnabled: false })).toEqual(['copy', 'copy-link', 'reply', 'thread']);
-    expect(keys({ messageType: 'system' })).toEqual(['copy', 'copy-link', 'reply', 'thread']);
+    expect(keys({ savedMessagesEnabled: false })).toEqual(['reply', 'thread', 'copy', 'copy-link']);
+    expect(keys({ messageType: 'system' })).toEqual(['reply', 'thread', 'copy', 'copy-link']);
   });
 });

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
@@ -38,36 +38,45 @@ export function getOverlayActionPolicy(input: OverlayActionPolicyInput): Overlay
   const isDeletableAction = !input.isDeleted && !input.isOptimistic;
   const actions: OverlayActionPolicyItem[] = [];
 
+  // 1. Reply
+  actions.push({ key: 'reply' });
+
+  // 2. Thread
+  if (!input.isThreadView && !input.hasThreadInfo) {
+    actions.push({ key: 'thread' });
+  }
+
+  // 3. Pin
+  if (!input.isThreadView && !input.isDeleted && input.isAdmin) {
+    actions.push({ key: 'pin', pinState: input.isPinned ? 'pinned' : 'unpinned' });
+  }
+
+  // 4. Copy
   if (!audioMessage && !stickerMessage && input.text?.trim()) {
     actions.push({ key: 'copy', copyVariant: input.hasAttachments ? 'text' : 'message' });
   }
 
-  actions.push({ key: 'copy-link' });
+  // 5. Edit
+  if (input.isOwn && !audioMessage && !stickerMessage) {
+    actions.push({ key: 'edit' });
+  }
 
+  // 6. Save / Favorite
   if (stickerMessage && isDeletableAction) {
     actions.push({ key: 'favorite' });
   } else if (input.savedMessagesEnabled && isDeletableAction && input.messageType !== 'system') {
     actions.push({ key: 'save' });
   }
 
-  actions.push({ key: 'reply' });
+  // 7. Copy-link
+  actions.push({ key: 'copy-link' });
 
-  if (!input.isThreadView && !input.hasThreadInfo) {
-    actions.push({ key: 'thread' });
-  }
-
-  if (input.isOwn && !audioMessage && !stickerMessage) {
-    actions.push({ key: 'edit' });
-  }
-
+  // 8. Delete
   if (input.isOwn || input.isAdmin) {
     actions.push({ key: 'delete' });
   }
 
-  if (!input.isThreadView && !input.isDeleted && input.isAdmin) {
-    actions.push({ key: 'pin', pinState: input.isPinned ? 'pinned' : 'unpinned' });
-  }
-
+  // 9. Details
   if (input.hasReactions) {
     actions.push({ key: 'reaction-details' });
   }


### PR DESCRIPTION
Resolve #418.

Switch the long-press message action menu from a vertical list to a 5-column grid layout. When there are more than 10 actions, pagination arrows appear to navigate between pages.

Also replaced all hardcoded colors with CSS variables so the overlay properly supports dark mode, and unified action icons to outline style.