### PR TITLE
feat(pwa): Add advanced settings

### DIFF
--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -28,6 +28,9 @@ msgstr "1 day"
 msgid "1 hour"
 msgstr "1 hour"
 
+#~ msgid "100% (Default)"
+#~ msgstr "100% (Default)"
+
 msgid "24 hours"
 msgstr "24 hours"
 
@@ -241,6 +244,9 @@ msgstr "Creating…"
 
 msgid "Custom"
 msgstr "Custom"
+
+msgid "Default (100%)"
+msgstr "Default (100%)"
 
 msgid "Default (350ms)"
 msgstr "Default (350ms)"
@@ -719,6 +725,9 @@ msgstr "Membership"
 msgid "Mention suggestions"
 msgstr "Mention suggestions"
 
+msgid "Menu Background Opacity"
+msgstr "Menu Background Opacity"
+
 msgid "Message"
 msgstr "Message"
 
@@ -856,6 +865,12 @@ msgstr "Only members of a selected group can use this invite link to join."
 
 msgid "Only the selected user can redeem this invite link to join."
 msgstr "Only the selected user can redeem this invite link to join."
+
+msgid "Opacity"
+msgstr "Opacity"
+
+msgid "Opaque"
+msgstr "Opaque"
 
 msgid "Open chat"
 msgstr "Open chat"
@@ -1236,6 +1251,9 @@ msgstr "Thumbnail {0}"
 
 msgid "Today"
 msgstr "Today"
+
+msgid "Transparent"
+msgstr "Transparent"
 
 msgid "Try Again"
 msgstr "Try Again"

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -64,6 +64,15 @@ msgstr "Add Sticker"
 msgid "Add to Favorites"
 msgstr "Add to Favorites"
 
+msgid "Advanced Settings"
+msgstr "Advanced Settings"
+
+msgid "Advanced settings disabled"
+msgstr "Advanced settings disabled"
+
+msgid "Advanced settings enabled"
+msgstr "Advanced settings enabled"
+
 msgid "Alex"
 msgstr "Alex"
 
@@ -196,6 +205,15 @@ msgstr "Copy"
 
 msgid "Copy code"
 msgstr "Copy code"
+
+msgid "Copy JWT Token"
+msgstr "Copy JWT Token"
+
+msgid "Copy Link"
+msgstr "Copy Link"
+
+msgid "Copy text"
+msgstr "Copy text"
 
 msgid "Copy the link below, or choose a group to send it to right now."
 msgstr "Copy the link below, or choose a group to send it to right now."
@@ -371,6 +389,9 @@ msgstr "Failed to add sticker to favorites"
 
 msgid "Failed to copy invite code"
 msgstr "Failed to copy invite code"
+
+msgid "Failed to copy token"
+msgstr "Failed to copy token"
 
 msgid "Failed to create chat"
 msgstr "Failed to create chat"
@@ -607,6 +628,9 @@ msgstr "Join via Code"
 
 msgid "Joining…"
 msgstr "Joining…"
+
+msgid "JWT token copied"
+msgstr "JWT token copied"
 
 msgid "Keep messages"
 msgstr "Keep messages"

--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -209,12 +209,6 @@ msgstr "Copy code"
 msgid "Copy JWT Token"
 msgstr "Copy JWT Token"
 
-msgid "Copy Link"
-msgstr "Copy Link"
-
-msgid "Copy text"
-msgstr "Copy text"
-
 msgid "Copy the link below, or choose a group to send it to right now."
 msgstr "Copy the link below, or choose a group to send it to right now."
 
@@ -244,6 +238,15 @@ msgstr "Create new sticker pack"
 
 msgid "Creating…"
 msgstr "Creating…"
+
+msgid "Custom"
+msgstr "Custom"
+
+msgid "Default (350ms)"
+msgstr "Default (350ms)"
+
+msgid "Delay"
+msgstr "Delay"
 
 msgid "Delete"
 msgstr "Delete"
@@ -291,8 +294,8 @@ msgstr "Description"
 msgid "Destination Group"
 msgstr "Destination Group"
 
-msgid "Reactions"
-msgstr "Reactions"
+msgid "Developer"
+msgstr "Developer"
 
 msgid "Discard"
 msgstr "Discard"
@@ -531,6 +534,12 @@ msgstr "Failed to update role"
 msgid "Failed to upload avatar"
 msgstr "Failed to upload avatar"
 
+msgid "Fast"
+msgstr "Fast"
+
+msgid "Fast (150ms)"
+msgstr "Fast (150ms)"
+
 msgid "Fav"
 msgstr "Fav"
 
@@ -668,6 +677,9 @@ msgstr "Loading..."
 msgid "Loading…"
 msgstr "Loading…"
 
+msgid "Long Press Delay"
+msgstr "Long Press Delay"
+
 msgid "Manage"
 msgstr "Manage"
 
@@ -709,6 +721,9 @@ msgstr "Mention suggestions"
 
 msgid "Message"
 msgstr "Message"
+
+msgid "Message Actions"
+msgstr "Message Actions"
 
 msgid "Message cannot be empty"
 msgstr "Message cannot be empty"
@@ -957,6 +972,9 @@ msgstr "Push notifications enabled"
 msgid "Push notifications turned off"
 msgstr "Push notifications turned off"
 
+msgid "Reactions"
+msgstr "Reactions"
+
 msgid "Read"
 msgstr "Read"
 
@@ -1128,6 +1146,12 @@ msgstr "Show \"All\" Tab in Chats"
 msgid "Show Avatars Next to All Messages"
 msgstr "Show Avatars Next to All Messages"
 
+msgid "Slow"
+msgstr "Slow"
+
+msgid "Slow (600ms)"
+msgstr "Slow (600ms)"
+
 msgid "Small"
 msgstr "Small"
 
@@ -1298,6 +1322,9 @@ msgstr "User {uid}"
 
 msgid "User ID"
 msgstr "User ID"
+
+msgid "Very Slow (1000ms)"
+msgstr "Very Slow (1000ms)"
 
 msgid "Videos"
 msgstr "Videos"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -28,6 +28,9 @@ msgstr "1 天"
 msgid "1 hour"
 msgstr "1 小时"
 
+#~ msgid "100% (Default)"
+#~ msgstr "100%（默认）"
+
 msgid "24 hours"
 msgstr "24 小时"
 
@@ -241,6 +244,9 @@ msgstr "创建中…"
 
 msgid "Custom"
 msgstr "自定义"
+
+msgid "Default (100%)"
+msgstr "默认（100%）"
 
 msgid "Default (350ms)"
 msgstr "默认 (350ms)"
@@ -719,6 +725,9 @@ msgstr "成员资格"
 msgid "Mention suggestions"
 msgstr "提及建议"
 
+msgid "Menu Background Opacity"
+msgstr "菜单背景不透明度"
+
 msgid "Message"
 msgstr "消息"
 
@@ -856,6 +865,12 @@ msgstr "只有所选群组的成员才能使用此邀请链接加入。"
 
 msgid "Only the selected user can redeem this invite link to join."
 msgstr "只有所选用户才能兑换此邀请链接并加入。"
+
+msgid "Opacity"
+msgstr "不透明度"
+
+msgid "Opaque"
+msgstr "不透明"
 
 msgid "Open chat"
 msgstr "打开聊天"
@@ -1236,6 +1251,9 @@ msgstr "缩略图 {0}"
 
 msgid "Today"
 msgstr "今天"
+
+msgid "Transparent"
+msgstr "透明"
 
 msgid "Try Again"
 msgstr "重试"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -64,6 +64,15 @@ msgstr "添加贴纸"
 msgid "Add to Favorites"
 msgstr "添加到收藏"
 
+msgid "Advanced Settings"
+msgstr "高级设置"
+
+msgid "Advanced settings disabled"
+msgstr "已关闭高级设置"
+
+msgid "Advanced settings enabled"
+msgstr "已启用高级设置"
+
 msgid "Alex"
 msgstr "风纪委员"
 
@@ -196,6 +205,15 @@ msgstr "复制"
 
 msgid "Copy code"
 msgstr "复制代码"
+
+msgid "Copy JWT Token"
+msgstr "复制 JWT Token"
+
+msgid "Copy Link"
+msgstr "复制链接"
+
+msgid "Copy text"
+msgstr "复制文本"
 
 msgid "Copy the link below, or choose a group to send it to right now."
 msgstr "复制下方链接，或立即选择一个群组发送。"
@@ -371,6 +389,9 @@ msgstr "添加贴纸到收藏失败"
 
 msgid "Failed to copy invite code"
 msgstr "复制邀请码失败"
+
+msgid "Failed to copy token"
+msgstr "复制失败"
 
 msgid "Failed to create chat"
 msgstr "创建聊天失败"
@@ -607,6 +628,9 @@ msgstr "通过邀请码加入"
 
 msgid "Joining…"
 msgstr "正在加入…"
+
+msgid "JWT token copied"
+msgstr "JWT Token 已复制"
 
 msgid "Keep messages"
 msgstr "保留消息"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -209,12 +209,6 @@ msgstr "复制代码"
 msgid "Copy JWT Token"
 msgstr "复制 JWT Token"
 
-msgid "Copy Link"
-msgstr "复制链接"
-
-msgid "Copy text"
-msgstr "复制文本"
-
 msgid "Copy the link below, or choose a group to send it to right now."
 msgstr "复制下方链接，或立即选择一个群组发送。"
 
@@ -244,6 +238,15 @@ msgstr "创建新的贴纸包"
 
 msgid "Creating…"
 msgstr "创建中…"
+
+msgid "Custom"
+msgstr "自定义"
+
+msgid "Default (350ms)"
+msgstr "默认 (350ms)"
+
+msgid "Delay"
+msgstr "延迟"
 
 msgid "Delete"
 msgstr "撤回"
@@ -291,8 +294,8 @@ msgstr "描述"
 msgid "Destination Group"
 msgstr "目标群组"
 
-msgid "Reactions"
-msgstr "回应"
+msgid "Developer"
+msgstr "开发者"
 
 msgid "Discard"
 msgstr "放弃"
@@ -531,6 +534,12 @@ msgstr "更新角色失败"
 msgid "Failed to upload avatar"
 msgstr "上传头像失败"
 
+msgid "Fast"
+msgstr "快速"
+
+msgid "Fast (150ms)"
+msgstr "快速 (150ms)"
+
 msgid "Fav"
 msgstr "收藏"
 
@@ -668,6 +677,9 @@ msgstr "正在加载..."
 msgid "Loading…"
 msgstr "正在加载…"
 
+msgid "Long Press Delay"
+msgstr "长按延迟"
+
 msgid "Manage"
 msgstr "管理"
 
@@ -709,6 +721,9 @@ msgstr "提及建议"
 
 msgid "Message"
 msgstr "消息"
+
+msgid "Message Actions"
+msgstr "消息操作"
 
 msgid "Message cannot be empty"
 msgstr "消息不能为空"
@@ -957,6 +972,9 @@ msgstr "推送通知已开启"
 msgid "Push notifications turned off"
 msgstr "推送通知已关闭"
 
+msgid "Reactions"
+msgstr "回应"
+
 msgid "Read"
 msgstr "标记已读"
 
@@ -1128,6 +1146,12 @@ msgstr "在聊天中显示\"全部\"标签"
 msgid "Show Avatars Next to All Messages"
 msgstr "在所有消息旁显示头像"
 
+msgid "Slow"
+msgstr "慢速"
+
+msgid "Slow (600ms)"
+msgstr "慢速 (600ms)"
+
 msgid "Small"
 msgstr "小"
 
@@ -1298,6 +1322,9 @@ msgstr "用户 {uid}"
 
 msgid "User ID"
 msgstr "用户 ID"
+
+msgid "Very Slow (1000ms)"
+msgstr "很慢 (1000ms)"
 
 msgid "Videos"
 msgstr "视频"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -64,6 +64,15 @@ msgstr "新增表情"
 msgid "Add to Favorites"
 msgstr "加入收藏"
 
+msgid "Advanced Settings"
+msgstr "進階設定"
+
+msgid "Advanced settings disabled"
+msgstr "已關閉進階設定"
+
+msgid "Advanced settings enabled"
+msgstr "已啟用進階設定"
+
 msgid "Alex"
 msgstr "風紀委員"
 
@@ -196,6 +205,15 @@ msgstr "複製"
 
 msgid "Copy code"
 msgstr "複製代碼"
+
+msgid "Copy JWT Token"
+msgstr "複製 JWT Token"
+
+msgid "Copy Link"
+msgstr "複製連結"
+
+msgid "Copy text"
+msgstr "複製文本"
 
 msgid "Copy the link below, or choose a group to send it to right now."
 msgstr "複製下方連結，或立即選擇一個群組傳送。"
@@ -371,6 +389,9 @@ msgstr "添加貼紙到收藏失敗"
 
 msgid "Failed to copy invite code"
 msgstr "複製邀請碼失敗"
+
+msgid "Failed to copy token"
+msgstr "複製失敗"
 
 msgid "Failed to create chat"
 msgstr "建立聊天失敗"
@@ -607,6 +628,9 @@ msgstr "透過邀請碼加入"
 
 msgid "Joining…"
 msgstr "正在加入…"
+
+msgid "JWT token copied"
+msgstr "JWT Token 已複製"
 
 msgid "Keep messages"
 msgstr "保留訊息"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -28,6 +28,9 @@ msgstr "1 天"
 msgid "1 hour"
 msgstr "1 小時"
 
+#~ msgid "100% (Default)"
+#~ msgstr "100%（預設）"
+
 msgid "24 hours"
 msgstr "24 小時"
 
@@ -241,6 +244,9 @@ msgstr "建立中…"
 
 msgid "Custom"
 msgstr "自訂"
+
+msgid "Default (100%)"
+msgstr "預設（100%）"
 
 msgid "Default (350ms)"
 msgstr "預設 (350ms)"
@@ -719,6 +725,9 @@ msgstr "成員資格"
 msgid "Mention suggestions"
 msgstr "提及建議"
 
+msgid "Menu Background Opacity"
+msgstr "選單背景不透明度"
+
 msgid "Message"
 msgstr "訊息"
 
@@ -856,6 +865,12 @@ msgstr "只有所選群組的成員才能使用此邀請連結加入。"
 
 msgid "Only the selected user can redeem this invite link to join."
 msgstr "只有所選使用者才能兌換此邀請連結並加入。"
+
+msgid "Opacity"
+msgstr "不透明度"
+
+msgid "Opaque"
+msgstr "不透明"
 
 msgid "Open chat"
 msgstr "開啟聊天"
@@ -1236,6 +1251,9 @@ msgstr "縮圖 {0}"
 
 msgid "Today"
 msgstr "今天"
+
+msgid "Transparent"
+msgstr "透明"
 
 msgid "Try Again"
 msgstr "再試一次"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -209,12 +209,6 @@ msgstr "複製代碼"
 msgid "Copy JWT Token"
 msgstr "複製 JWT Token"
 
-msgid "Copy Link"
-msgstr "複製連結"
-
-msgid "Copy text"
-msgstr "複製文本"
-
 msgid "Copy the link below, or choose a group to send it to right now."
 msgstr "複製下方連結，或立即選擇一個群組傳送。"
 
@@ -244,6 +238,15 @@ msgstr "建立新的表情包"
 
 msgid "Creating…"
 msgstr "建立中…"
+
+msgid "Custom"
+msgstr "自訂"
+
+msgid "Default (350ms)"
+msgstr "預設 (350ms)"
+
+msgid "Delay"
+msgstr "延遲"
 
 msgid "Delete"
 msgstr "收回"
@@ -291,8 +294,8 @@ msgstr "描述"
 msgid "Destination Group"
 msgstr "目標群組"
 
-msgid "Reactions"
-msgstr "回應"
+msgid "Developer"
+msgstr "開發者"
 
 msgid "Discard"
 msgstr "放棄"
@@ -531,6 +534,12 @@ msgstr "更新角色失敗"
 msgid "Failed to upload avatar"
 msgstr "上傳頭像失敗"
 
+msgid "Fast"
+msgstr "快速"
+
+msgid "Fast (150ms)"
+msgstr "快速 (150ms)"
+
 msgid "Fav"
 msgstr "收藏"
 
@@ -668,6 +677,9 @@ msgstr "正在載入..."
 msgid "Loading…"
 msgstr "正在載入…"
 
+msgid "Long Press Delay"
+msgstr "長按延遲"
+
 msgid "Manage"
 msgstr "管理"
 
@@ -709,6 +721,9 @@ msgstr "提及建議"
 
 msgid "Message"
 msgstr "訊息"
+
+msgid "Message Actions"
+msgstr "訊息操作"
 
 msgid "Message cannot be empty"
 msgstr "訊息不能為空"
@@ -957,6 +972,9 @@ msgstr "推播通知已開啟"
 msgid "Push notifications turned off"
 msgstr "推播通知已關閉"
 
+msgid "Reactions"
+msgstr "回應"
+
 msgid "Read"
 msgstr "標記已讀"
 
@@ -1128,6 +1146,12 @@ msgstr "在聊天中顯示「全部」標籤"
 msgid "Show Avatars Next to All Messages"
 msgstr "在所有訊息旁顯示頭像"
 
+msgid "Slow"
+msgstr "慢速"
+
+msgid "Slow (600ms)"
+msgstr "慢速 (600ms)"
+
 msgid "Small"
 msgstr "小"
 
@@ -1298,6 +1322,9 @@ msgstr "使用者 {uid}"
 
 msgid "User ID"
 msgstr "使用者 ID"
+
+msgid "Very Slow (1000ms)"
+msgstr "很慢 (1000ms)"
 
 msgid "Videos"
 msgstr "影片"

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
@@ -2,12 +2,12 @@ import { useRef, useState } from 'react';
 import { IonIcon } from '@ionic/react';
 import { arrowUndo } from 'ionicons/icons';
 import styles from './ChatBubble.module.scss';
+import { getLongPressDelayMs } from '@/store/advancedSettingsStore';
 import { ChatBubbleBase, type ChatBubbleBaseProps } from './ChatBubbleBase';
 import { StickerBubble, type StickerBubbleProps } from './StickerBubble';
 
 const SWIPE_THRESHOLD = 60;
 const SWIPE_MAX = 80;
-const LONG_PRESS_DELAY_MS = 350;
 
 type StickerChatBubbleProps = StickerBubbleProps & {
   messageType: 'sticker';
@@ -88,7 +88,7 @@ export function ChatBubble(props: ChatBubbleProps) {
             y: startY.current,
           });
         }
-      }, LONG_PRESS_DELAY_MS);
+      }, getLongPressDelayMs());
     }
   }
 

--- a/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.module.scss
@@ -29,15 +29,23 @@
 }
 
 .content {
-  --menu-bg: color-mix(in srgb, var(--ion-text-color, #000) 10%, var(--ion-background-color, #fff));
-  --menu-hover-bg: color-mix(in srgb, var(--ion-text-color, #000) 15%, var(--ion-background-color, #fff));
+  /* Intentionally left empty – overridden below with --menu-bg-opacity */
 
   --action-row-height: 63px;
 
   position: absolute;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  --menu-bg: color-mix(
+    in srgb,
+    color-mix(in srgb, var(--ion-text-color, #000) 10%, var(--ion-background-color, #fff)) var(--menu-bg-opacity, 90%),
+    transparent
+  );
+  --menu-hover-bg: color-mix(
+    in srgb,
+    color-mix(in srgb, var(--ion-text-color, #000) 15%, var(--ion-background-color, #fff)) var(--menu-bg-opacity, 90%),
+    transparent
+  );
   gap: 8px;
   max-width: calc(100vw - 32px);
   pointer-events: none;
@@ -182,7 +190,11 @@
 }
 
 .opaqueMenu {
-  background: color-mix(in srgb, var(--ion-text-color, #000) 10%, var(--ion-background-color, #fff)) !important;
+  background: color-mix(
+    in srgb,
+    color-mix(in srgb, var(--ion-text-color, #000) 10%, var(--ion-background-color, #fff)) var(--menu-bg-opacity, 90%),
+    transparent
+  ) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
 }

--- a/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
@@ -11,6 +11,7 @@ import styles from './MessageOverlay.module.scss';
 import { MAX_DISTINCT_REACTIONS_PER_MESSAGE } from '@/constants/emojiAndStickers';
 import { getOverlayPortalTarget } from '@/utils/dom';
 import { t } from '@lingui/core/macro';
+import { useMenuBgOpacity } from '@/store/advancedSettingsStore';
 
 export interface MessageOverlayAction {
   key: string;
@@ -86,6 +87,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
   const [presentToast] = useIonToast();
+  const menuBgOpacity = useMenuBgOpacity();
 
   const [actionListPage, setActionListPage] = useState(0);
   const actionListScrollRef = useRef<HTMLDivElement>(null);
@@ -431,7 +433,14 @@ export function MessageOverlay(props: MessageOverlayProps) {
       <div
         ref={contentRef}
         className={`${styles.content} ${isSent ? styles.contentSent : ''} ${styles.contentVisible}`}
-        style={{ top: sourceRect.top, left: sourceRect.left, visibility: 'hidden' }}
+        style={
+          {
+            top: sourceRect.top,
+            left: sourceRect.left,
+            visibility: 'hidden',
+            '--menu-bg-opacity': `${menuBgOpacity}%`,
+          } as React.CSSProperties
+        }
       >
         {/* Reaction bar — hidden for stickers */}
         {!isSticker &&

--- a/wetty-chat-mobile/src/components/settings/AppVersionItem.tsx
+++ b/wetty-chat-mobile/src/components/settings/AppVersionItem.tsx
@@ -1,14 +1,13 @@
 import { IonText, useIonToast } from '@ionic/react';
 import { t } from '@lingui/core/macro';
 import { useEffect, useRef } from 'react';
-import { useDeviceToken } from '@/hooks/useDeviceToken';
+import { isAdvancedSettingsUnlocked, toggleAdvancedSettings } from '@/store/advancedSettingsStore';
 import styles from './AppVersionItem.module.scss';
 
 const TAP_RESET_TIMEOUT_MS = 2000;
 const REQUIRED_TAP_COUNT = 5;
 
 export function AppVersionItem() {
-  const jwtToken = useDeviceToken();
   const [presentToast] = useIonToast();
   const tapCountRef = useRef(0);
   const timeoutIdRef = useRef<number | null>(null);
@@ -44,9 +43,11 @@ export function AppVersionItem() {
     tapCountRef.current += 1;
 
     if (tapCountRef.current >= REQUIRED_TAP_COUNT) {
+      const wasUnlocked = isAdvancedSettingsUnlocked();
+      toggleAdvancedSettings();
       presentToast({
-        message: jwtToken || t`No JWT token available`,
-        duration: 4000,
+        message: wasUnlocked ? t`Advanced settings disabled` : t`Advanced settings enabled`,
+        duration: 2000,
         position: 'bottom',
       });
       resetTapSequence();

--- a/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
@@ -14,6 +14,7 @@ import ChatInvitesCore from '@/pages/conversation/manage-invites';
 import CreateChatCore from '@/pages/create-chat';
 import { InvitePreviewCore } from '@/pages/invite-preview';
 import { AdvancedSettingsCore } from '@/pages/settings/advanced';
+import { MenuBgOpacityCore } from '@/pages/settings/menu-bg-opacity';
 import { LongPressDelayCore } from '@/pages/settings/long-press-delay';
 import { useAdvancedSettingsUnlocked } from '@/store/advancedSettingsStore';
 import { JoinChatCore } from '@/pages/join-chat';
@@ -54,6 +55,7 @@ interface DesktopRouteMatches {
   stickerSettings: boolean;
   advancedSettings: boolean;
   longPressDelay: boolean;
+  menuBgOpacity: boolean;
   stickerPackSettings: { packId: string } | null;
 }
 
@@ -122,6 +124,10 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     path: '/settings/advanced/long-press-delay',
     exact: true,
   });
+  const menuBgOpacity = !!matchPath(pathname, {
+    path: '/settings/advanced/menu-bg-opacity',
+    exact: true,
+  });
   const stickerPackRaw = matchPath<{ packId: string }>(pathname, {
     path: '/settings/stickers/:packId',
     exact: true,
@@ -137,6 +143,7 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     languageSettings ||
     advancedSettings ||
     longPressDelay ||
+    menuBgOpacity ||
     stickerSettings;
 
   return {
@@ -163,6 +170,7 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     generalSettings,
     advancedSettings,
     longPressDelay,
+    menuBgOpacity,
     savedMessagesSettings,
     languageSettings,
     stickerSettings,
@@ -362,6 +370,13 @@ export function DesktopSplitLayout() {
   const openLongPressDelay = useCallback(() => {
     history.push({
       pathname: '/settings/advanced/long-press-delay',
+      state: { backgroundPath },
+    });
+  }, [backgroundPath, history]);
+
+  const openMenuBgOpacity = useCallback(() => {
+    history.push({
+      pathname: '/settings/advanced/menu-bg-opacity',
       state: { backgroundPath },
     });
   }, [backgroundPath, history]);
@@ -585,6 +600,17 @@ export function DesktopSplitLayout() {
                   }),
               }}
             />
+          ) : currentRoute.menuBgOpacity ? (
+            <MenuBgOpacityCore
+              backAction={{
+                type: 'callback',
+                onBack: () =>
+                  history.push({
+                    pathname: '/settings/advanced',
+                    state: { backgroundPath },
+                  }),
+              }}
+            />
           ) : currentRoute.advancedSettings ? (
             <AdvancedSettingsCore
               backAction={{
@@ -596,6 +622,7 @@ export function DesktopSplitLayout() {
                   }),
               }}
               onOpenLongPressDelay={openLongPressDelay}
+              onOpenMenuBgOpacity={openMenuBgOpacity}
             />
           ) : (
             <SettingsCore

--- a/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
@@ -13,6 +13,7 @@ import ChatMembersCore from '@/pages/conversation/chat-members';
 import ChatInvitesCore from '@/pages/conversation/manage-invites';
 import CreateChatCore from '@/pages/create-chat';
 import { InvitePreviewCore } from '@/pages/invite-preview';
+import { AdvancedSettingsCore } from '@/pages/settings/advanced';
 import { JoinChatCore } from '@/pages/join-chat';
 import { SettingsCore } from '@/pages/settings';
 import { SavedMessagesCore } from '@/pages/saved-messages';
@@ -49,6 +50,7 @@ interface DesktopRouteMatches {
   savedMessagesSettings: boolean;
   languageSettings: boolean;
   stickerSettings: boolean;
+  advancedSettings: boolean;
   stickerPackSettings: { packId: string } | null;
 }
 
@@ -109,6 +111,10 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     path: '/settings/saved-messages',
     exact: true,
   });
+  const advancedSettings = !!matchPath(pathname, {
+    path: '/settings/advanced',
+    exact: true,
+  });
   const stickerPackRaw = matchPath<{ packId: string }>(pathname, {
     path: '/settings/stickers/:packId',
     exact: true,
@@ -122,6 +128,7 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     generalSettings ||
     savedMessagesSettings ||
     languageSettings ||
+    advancedSettings ||
     stickerSettings;
 
   return {
@@ -146,6 +153,7 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     isJoinChat: !!joinRaw,
     globalSettings,
     generalSettings,
+    advancedSettings,
     savedMessagesSettings,
     languageSettings,
     stickerSettings,
@@ -321,6 +329,13 @@ export function DesktopSplitLayout() {
   const openGeneralSettings = useCallback(() => {
     history.push({
       pathname: '/settings/general',
+      state: { backgroundPath },
+    });
+  }, [backgroundPath, history]);
+
+  const openAdvancedSettings = useCallback(() => {
+    history.push({
+      pathname: '/settings/advanced',
       state: { backgroundPath },
     });
   }, [backgroundPath, history]);
@@ -533,12 +548,24 @@ export function DesktopSplitLayout() {
               }}
               onOpenLanguage={openLanguageSettings}
             />
+          ) : currentRoute.advancedSettings ? (
+            <AdvancedSettingsCore
+              backAction={{
+                type: 'callback',
+                onBack: () =>
+                  history.push({
+                    pathname: '/settings',
+                    state: { backgroundPath },
+                  }),
+              }}
+            />
           ) : (
             <SettingsCore
               backAction={{ type: 'close', onClose: closeGlobalSettings }}
               onOpenGeneral={openGeneralSettings}
               onOpenSavedMessages={savedMessagesEnabled ? openSavedMessages : undefined}
               onOpenStickers={openStickerSettings}
+              onOpenAdvanced={openAdvancedSettings}
             />
           )}
         </IonModal>

--- a/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
@@ -14,6 +14,7 @@ import ChatInvitesCore from '@/pages/conversation/manage-invites';
 import CreateChatCore from '@/pages/create-chat';
 import { InvitePreviewCore } from '@/pages/invite-preview';
 import { AdvancedSettingsCore } from '@/pages/settings/advanced';
+import { LongPressDelayCore } from '@/pages/settings/long-press-delay';
 import { useAdvancedSettingsUnlocked } from '@/store/advancedSettingsStore';
 import { JoinChatCore } from '@/pages/join-chat';
 import { SettingsCore } from '@/pages/settings';
@@ -52,6 +53,7 @@ interface DesktopRouteMatches {
   languageSettings: boolean;
   stickerSettings: boolean;
   advancedSettings: boolean;
+  longPressDelay: boolean;
   stickerPackSettings: { packId: string } | null;
 }
 
@@ -116,6 +118,10 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     path: '/settings/advanced',
     exact: true,
   });
+  const longPressDelay = !!matchPath(pathname, {
+    path: '/settings/advanced/long-press-delay',
+    exact: true,
+  });
   const stickerPackRaw = matchPath<{ packId: string }>(pathname, {
     path: '/settings/stickers/:packId',
     exact: true,
@@ -130,6 +136,7 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     savedMessagesSettings ||
     languageSettings ||
     advancedSettings ||
+    longPressDelay ||
     stickerSettings;
 
   return {
@@ -155,6 +162,7 @@ function getDesktopRouteMatches(pathname: string): DesktopRouteMatches {
     globalSettings,
     generalSettings,
     advancedSettings,
+    longPressDelay,
     savedMessagesSettings,
     languageSettings,
     stickerSettings,
@@ -350,6 +358,13 @@ export function DesktopSplitLayout() {
       });
     }
   }, [advancedUnlocked, currentRoute.advancedSettings, backgroundPath, history]);
+
+  const openLongPressDelay = useCallback(() => {
+    history.push({
+      pathname: '/settings/advanced/long-press-delay',
+      state: { backgroundPath },
+    });
+  }, [backgroundPath, history]);
 
   const openSavedMessages = useCallback(() => {
     if (!savedMessagesEnabled) {
@@ -559,6 +574,17 @@ export function DesktopSplitLayout() {
               }}
               onOpenLanguage={openLanguageSettings}
             />
+          ) : currentRoute.longPressDelay ? (
+            <LongPressDelayCore
+              backAction={{
+                type: 'callback',
+                onBack: () =>
+                  history.push({
+                    pathname: '/settings/advanced',
+                    state: { backgroundPath },
+                  }),
+              }}
+            />
           ) : currentRoute.advancedSettings ? (
             <AdvancedSettingsCore
               backAction={{
@@ -569,6 +595,7 @@ export function DesktopSplitLayout() {
                     state: { backgroundPath },
                   }),
               }}
+              onOpenLongPressDelay={openLongPressDelay}
             />
           ) : (
             <SettingsCore

--- a/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/DesktopSplitLayout.tsx
@@ -14,6 +14,7 @@ import ChatInvitesCore from '@/pages/conversation/manage-invites';
 import CreateChatCore from '@/pages/create-chat';
 import { InvitePreviewCore } from '@/pages/invite-preview';
 import { AdvancedSettingsCore } from '@/pages/settings/advanced';
+import { useAdvancedSettingsUnlocked } from '@/store/advancedSettingsStore';
 import { JoinChatCore } from '@/pages/join-chat';
 import { SettingsCore } from '@/pages/settings';
 import { SavedMessagesCore } from '@/pages/saved-messages';
@@ -339,6 +340,16 @@ export function DesktopSplitLayout() {
       state: { backgroundPath },
     });
   }, [backgroundPath, history]);
+
+  const advancedUnlocked = useAdvancedSettingsUnlocked();
+  useEffect(() => {
+    if (!advancedUnlocked && currentRoute.advancedSettings) {
+      history.replace({
+        pathname: '/settings',
+        state: { backgroundPath },
+      });
+    }
+  }, [advancedUnlocked, currentRoute.advancedSettings, backgroundPath, history]);
 
   const openSavedMessages = useCallback(() => {
     if (!savedMessagesEnabled) {

--- a/wetty-chat-mobile/src/layouts/MobileLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/MobileLayout.tsx
@@ -23,6 +23,7 @@ import StickerSettingsPage from '@/pages/settings/stickers';
 import StickerPackDetailPage from '@/pages/settings/sticker-pack-detail';
 import AdvancedSettingsPage from '@/pages/settings/advanced';
 import LongPressDelayPage from '@/pages/settings/long-press-delay';
+import MenuBgOpacityPage from '@/pages/settings/menu-bg-opacity';
 import NotFoundPage from '@/pages/not-found';
 import ComponentDemoPage from '@/pages/component-demo';
 
@@ -104,6 +105,7 @@ const MobileLayout: React.FC = () => {
         <Route path="/settings/stickers" exact component={StickerSettingsPage} />
         <Route path="/settings/advanced" exact component={AdvancedSettingsPage} />
         <Route path="/settings/advanced/long-press-delay" exact component={LongPressDelayPage} />
+        <Route path="/settings/advanced/menu-bg-opacity" exact component={MenuBgOpacityPage} />
         <Route path="/settings" exact component={SettingsPage} />
         <Redirect exact from="/" to="/chats" />
         <Route component={NotFoundPage} />

--- a/wetty-chat-mobile/src/layouts/MobileLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/MobileLayout.tsx
@@ -21,6 +21,7 @@ import GeneralSettingsPage from '@/pages/settings/general';
 import LanguagePage from '@/pages/settings/language';
 import StickerSettingsPage from '@/pages/settings/stickers';
 import StickerPackDetailPage from '@/pages/settings/sticker-pack-detail';
+import AdvancedSettingsPage from '@/pages/settings/advanced';
 import NotFoundPage from '@/pages/not-found';
 import ComponentDemoPage from '@/pages/component-demo';
 
@@ -100,6 +101,7 @@ const MobileLayout: React.FC = () => {
         {whenFeature('savedMessages', <Route path="/settings/saved-messages" exact component={SavedMessagesPage} />)}
         <Route path="/settings/stickers/:packId" exact component={StickerPackDetailPage} />
         <Route path="/settings/stickers" exact component={StickerSettingsPage} />
+        <Route path="/settings/advanced" exact component={AdvancedSettingsPage} />
         <Route path="/settings" exact component={SettingsPage} />
         <Redirect exact from="/" to="/chats" />
         <Route component={NotFoundPage} />

--- a/wetty-chat-mobile/src/layouts/MobileLayout.tsx
+++ b/wetty-chat-mobile/src/layouts/MobileLayout.tsx
@@ -22,6 +22,7 @@ import LanguagePage from '@/pages/settings/language';
 import StickerSettingsPage from '@/pages/settings/stickers';
 import StickerPackDetailPage from '@/pages/settings/sticker-pack-detail';
 import AdvancedSettingsPage from '@/pages/settings/advanced';
+import LongPressDelayPage from '@/pages/settings/long-press-delay';
 import NotFoundPage from '@/pages/not-found';
 import ComponentDemoPage from '@/pages/component-demo';
 
@@ -102,6 +103,7 @@ const MobileLayout: React.FC = () => {
         <Route path="/settings/stickers/:packId" exact component={StickerPackDetailPage} />
         <Route path="/settings/stickers" exact component={StickerSettingsPage} />
         <Route path="/settings/advanced" exact component={AdvancedSettingsPage} />
+        <Route path="/settings/advanced/long-press-delay" exact component={LongPressDelayPage} />
         <Route path="/settings" exact component={SettingsPage} />
         <Redirect exact from="/" to="/chats" />
         <Route component={NotFoundPage} />

--- a/wetty-chat-mobile/src/main.tsx
+++ b/wetty-chat-mobile/src/main.tsx
@@ -26,6 +26,7 @@ import { kvDelete, kvGet, kvSet } from '@/utils/db';
 import { hydrateSettings, type SettingsState } from '@/store/settingsSlice';
 import { hydrateStickerPreferences } from '@/store/stickerPreferencesSlice';
 import { installBootstrapRecoveryHandlers } from '@/bootstrapRecovery';
+import { initAdvancedSettings } from '@/store/advancedSettingsStore';
 import App from './App';
 import { setupIonicReact } from '@ionic/react';
 
@@ -48,6 +49,7 @@ async function bootstrap() {
       kvGet<unknown>('autoSortFavoriteStickers'),
       initializeClientId(),
       syncJwtTokenToIdb(),
+      initAdvancedSettings(),
     ]);
 
   const settings = hydrateSettings(savedSettings);

--- a/wetty-chat-mobile/src/pages/settings.tsx
+++ b/wetty-chat-mobile/src/pages/settings.tsx
@@ -23,11 +23,21 @@ import { Trans } from '@lingui/react/macro';
 import { FeatureGate } from '@/components/FeatureGate';
 import { CheckForUpdateItem } from '@/components/settings/CheckForUpdateItem';
 import { AppVersionItem } from '@/components/settings/AppVersionItem';
+import { useAdvancedSettingsUnlocked } from '@/store/advancedSettingsStore';
 import { SettingsProfileHero } from '@/components/settings/SettingsProfileHero';
 
 import { type PushNotificationErrorCode, usePushNotifications } from '@/hooks/usePushNotifications';
 import { t } from '@lingui/core/macro';
-import { bookmarkOutline, codeWorking, cog, happyOutline, logIn, logOut, notifications } from 'ionicons/icons';
+import {
+  bookmarkOutline,
+  codeWorking,
+  cog,
+  happyOutline,
+  logIn,
+  logOut,
+  notifications,
+  optionsOutline,
+} from 'ionicons/icons';
 import { BackButton } from '@/components/BackButton';
 import type { BackAction } from '@/types/back-action';
 
@@ -36,6 +46,7 @@ interface SettingsCoreProps {
   onOpenGeneral?: () => void;
   onOpenSavedMessages?: () => void;
   onOpenStickers?: () => void;
+  onOpenAdvanced?: () => void;
 }
 
 function getPermissionLabel(permission: NotificationPermission) {
@@ -67,7 +78,13 @@ function getPushErrorMessage(code: PushNotificationErrorCode) {
   }
 }
 
-export function SettingsCore({ backAction, onOpenGeneral, onOpenSavedMessages, onOpenStickers }: SettingsCoreProps) {
+export function SettingsCore({
+  backAction,
+  onOpenGeneral,
+  onOpenSavedMessages,
+  onOpenStickers,
+  onOpenAdvanced,
+}: SettingsCoreProps) {
   const {
     uid: currentUid,
     username,
@@ -77,6 +94,7 @@ export function SettingsCore({ backAction, onOpenGeneral, onOpenSavedMessages, o
   const [uidInput, setUidInput] = useState(() => String(currentUid || '1'));
   const [presentToast] = useIonToast();
   const history = useHistory();
+  const advancedUnlocked = useAdvancedSettingsUnlocked();
   const { permission, isSubscribed, loading, isCheckingSubscription, subscribeToPush, unsubscribeFromPush } =
     usePushNotifications();
 
@@ -258,6 +276,14 @@ export function SettingsCore({ backAction, onOpenGeneral, onOpenSavedMessages, o
         </IonListHeader>
         <IonList inset={true}>
           <CheckForUpdateItem />
+          {advancedUnlocked && (
+            <IonItem button detail={true} onClick={onOpenAdvanced ?? (() => history.push('/settings/advanced'))}>
+              <IonIcon aria-hidden="true" icon={optionsOutline} slot="start" color="medium" />
+              <IonLabel>
+                <Trans>Advanced Settings</Trans>
+              </IonLabel>
+            </IonItem>
+          )}
         </IonList>
         <AppVersionItem />
       </IonContent>

--- a/wetty-chat-mobile/src/pages/settings/advanced.tsx
+++ b/wetty-chat-mobile/src/pages/settings/advanced.tsx
@@ -1,0 +1,84 @@
+import {
+  IonBackButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+  useIonToast,
+} from '@ionic/react';
+import { t } from '@lingui/core/macro';
+import { Trans } from '@lingui/react/macro';
+import { clipboardOutline } from 'ionicons/icons';
+import { useDeviceToken } from '@/hooks/useDeviceToken';
+import type { BackAction } from '@/types/back-action';
+import { BackButton } from '@/components/BackButton';
+
+interface AdvancedSettingsCoreProps {
+  backAction?: BackAction;
+}
+
+export function AdvancedSettingsCore({ backAction }: AdvancedSettingsCoreProps) {
+  const jwtToken = useDeviceToken();
+  const [presentToast] = useIonToast();
+
+  const handleCopyToken = async () => {
+    if (!jwtToken) {
+      presentToast({ message: t`No JWT token available`, duration: 2000, position: 'bottom' });
+      return;
+    }
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(jwtToken);
+      } else {
+        // Fallback for non-secure contexts (e.g. desktop browser without HTTPS)
+        const textarea = document.createElement('textarea');
+        textarea.value = jwtToken;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+      presentToast({ message: t`JWT token copied`, duration: 2000, position: 'bottom' });
+    } catch {
+      presentToast({ message: t`Failed to copy token`, duration: 2500, position: 'bottom' });
+    }
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            {backAction ? <BackButton action={backAction} /> : <IonBackButton text={t`Back`} defaultHref="/settings" />}
+          </IonButtons>
+          <IonTitle>
+            <Trans>Advanced Settings</Trans>
+          </IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent color="light" className="ion-no-padding">
+        <IonList inset>
+          <IonItem button detail={false} onClick={handleCopyToken}>
+            <IonIcon aria-hidden="true" icon={clipboardOutline} slot="start" color="medium" />
+            <IonLabel>
+              <Trans>Copy JWT Token</Trans>
+            </IonLabel>
+          </IonItem>
+        </IonList>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default function AdvancedSettingsPage() {
+  return <AdvancedSettingsCore />;
+}

--- a/wetty-chat-mobile/src/pages/settings/advanced.tsx
+++ b/wetty-chat-mobile/src/pages/settings/advanced.tsx
@@ -19,22 +19,37 @@ import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { clipboardOutline } from 'ionicons/icons';
 import { useDeviceToken } from '@/hooks/useDeviceToken';
-import { getLongPressPresets, useAdvancedSettingsUnlocked, useLongPressDelayMs } from '@/store/advancedSettingsStore';
+import {
+  getMenuBgOpacityPresets,
+  getLongPressPresets,
+  useAdvancedSettingsUnlocked,
+  useLongPressDelayMs,
+  useMenuBgOpacity,
+} from '@/store/advancedSettingsStore';
 import type { BackAction } from '@/types/back-action';
 import { BackButton } from '@/components/BackButton';
 
 interface AdvancedSettingsCoreProps {
   backAction?: BackAction;
   onOpenLongPressDelay?: () => void;
+  onOpenMenuBgOpacity?: () => void;
 }
 
-export function AdvancedSettingsCore({ backAction, onOpenLongPressDelay }: AdvancedSettingsCoreProps) {
+export function AdvancedSettingsCore({
+  backAction,
+  onOpenLongPressDelay,
+  onOpenMenuBgOpacity,
+}: AdvancedSettingsCoreProps) {
   const jwtToken = useDeviceToken();
   const longPressDelay = useLongPressDelayMs();
+  const menuBgOpacity = useMenuBgOpacity();
   const history = useHistory();
   const currentPresetLabel = useMemo(() => {
     return getLongPressPresets().find((p) => p.value === longPressDelay)?.label ?? `${longPressDelay}ms`;
   }, [longPressDelay]);
+  const currentOpacityLabel = useMemo(() => {
+    return getMenuBgOpacityPresets().find((p) => p.value === menuBgOpacity)?.label ?? `${menuBgOpacity}%`;
+  }, [menuBgOpacity]);
   const [presentToast] = useIonToast();
 
   const handleCopyToken = async () => {
@@ -90,6 +105,16 @@ export function AdvancedSettingsCore({ backAction, onOpenLongPressDelay }: Advan
             <IonLabel>
               <Trans>Long Press Delay</Trans>
               <p>{currentPresetLabel}</p>
+            </IonLabel>
+          </IonItem>
+          <IonItem
+            button
+            detail={true}
+            onClick={onOpenMenuBgOpacity ?? (() => history.push('/settings/advanced/menu-bg-opacity'))}
+          >
+            <IonLabel>
+              <Trans>Menu Background Opacity</Trans>
+              <p>{currentOpacityLabel}</p>
             </IonLabel>
           </IonItem>
         </IonList>

--- a/wetty-chat-mobile/src/pages/settings/advanced.tsx
+++ b/wetty-chat-mobile/src/pages/settings/advanced.tsx
@@ -18,6 +18,8 @@ import { clipboardOutline } from 'ionicons/icons';
 import { useDeviceToken } from '@/hooks/useDeviceToken';
 import type { BackAction } from '@/types/back-action';
 import { BackButton } from '@/components/BackButton';
+import { useAdvancedSettingsUnlocked } from '@/store/advancedSettingsStore';
+import { useHistory } from 'react-router-dom';
 
 interface AdvancedSettingsCoreProps {
   backAction?: BackAction;
@@ -80,5 +82,11 @@ export function AdvancedSettingsCore({ backAction }: AdvancedSettingsCoreProps) 
 }
 
 export default function AdvancedSettingsPage() {
+  const history = useHistory();
+  const unlocked = useAdvancedSettingsUnlocked();
+  if (!unlocked) {
+    history.replace('/settings');
+    return null;
+  }
   return <AdvancedSettingsCore />;
 }

--- a/wetty-chat-mobile/src/pages/settings/advanced.tsx
+++ b/wetty-chat-mobile/src/pages/settings/advanced.tsx
@@ -7,26 +7,34 @@ import {
   IonItem,
   IonLabel,
   IonList,
+  IonListHeader,
   IonPage,
   IonTitle,
   IonToolbar,
   useIonToast,
 } from '@ionic/react';
+import { useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { clipboardOutline } from 'ionicons/icons';
 import { useDeviceToken } from '@/hooks/useDeviceToken';
+import { getLongPressPresets, useAdvancedSettingsUnlocked, useLongPressDelayMs } from '@/store/advancedSettingsStore';
 import type { BackAction } from '@/types/back-action';
 import { BackButton } from '@/components/BackButton';
-import { useAdvancedSettingsUnlocked } from '@/store/advancedSettingsStore';
-import { useHistory } from 'react-router-dom';
 
 interface AdvancedSettingsCoreProps {
   backAction?: BackAction;
+  onOpenLongPressDelay?: () => void;
 }
 
-export function AdvancedSettingsCore({ backAction }: AdvancedSettingsCoreProps) {
+export function AdvancedSettingsCore({ backAction, onOpenLongPressDelay }: AdvancedSettingsCoreProps) {
   const jwtToken = useDeviceToken();
+  const longPressDelay = useLongPressDelayMs();
+  const history = useHistory();
+  const currentPresetLabel = useMemo(() => {
+    return getLongPressPresets().find((p) => p.value === longPressDelay)?.label ?? `${longPressDelay}ms`;
+  }, [longPressDelay]);
   const [presentToast] = useIonToast();
 
   const handleCopyToken = async () => {
@@ -68,6 +76,29 @@ export function AdvancedSettingsCore({ backAction }: AdvancedSettingsCoreProps) 
         </IonToolbar>
       </IonHeader>
       <IonContent color="light" className="ion-no-padding">
+        <IonListHeader>
+          <IonLabel>
+            <Trans>Message Actions</Trans>
+          </IonLabel>
+        </IonListHeader>
+        <IonList inset>
+          <IonItem
+            button
+            detail={true}
+            onClick={onOpenLongPressDelay ?? (() => history.push('/settings/advanced/long-press-delay'))}
+          >
+            <IonLabel>
+              <Trans>Long Press Delay</Trans>
+              <p>{currentPresetLabel}</p>
+            </IonLabel>
+          </IonItem>
+        </IonList>
+
+        <IonListHeader>
+          <IonLabel>
+            <Trans>Developer</Trans>
+          </IonLabel>
+        </IonListHeader>
         <IonList inset>
           <IonItem button detail={false} onClick={handleCopyToken}>
             <IonIcon aria-hidden="true" icon={clipboardOutline} slot="start" color="medium" />

--- a/wetty-chat-mobile/src/pages/settings/long-press-delay.tsx
+++ b/wetty-chat-mobile/src/pages/settings/long-press-delay.tsx
@@ -1,0 +1,113 @@
+import {
+  IonBackButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonPage,
+  IonRange,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/react';
+import { t } from '@lingui/core/macro';
+import { useState } from 'react';
+import { Trans } from '@lingui/react/macro';
+import { checkmark } from 'ionicons/icons';
+import {
+  LONG_PRESS_CUSTOM_MAX,
+  LONG_PRESS_CUSTOM_MIN,
+  getLongPressPresets,
+  isCustomLongPressValue,
+  setLongPressDelayMs,
+  useLongPressDelayMs,
+} from '@/store/advancedSettingsStore';
+import type { BackAction } from '@/types/back-action';
+import { BackButton } from '@/components/BackButton';
+
+interface LongPressDelayCoreProps {
+  backAction?: BackAction;
+}
+
+export function LongPressDelayCore({ backAction }: LongPressDelayCoreProps) {
+  const delayMs = useLongPressDelayMs();
+  const presets = getLongPressPresets();
+  const hasCustomValue = isCustomLongPressValue(delayMs);
+  const [customSelected, setCustomSelected] = useState(hasCustomValue);
+
+  const handlePresetTap = (value: number) => {
+    setCustomSelected(false);
+    setLongPressDelayMs(value);
+  };
+
+  const handleCustomTap = () => {
+    setCustomSelected(true);
+  };
+
+  const handleSliderChange = (value: number) => {
+    setLongPressDelayMs(value);
+  };
+
+  const isCurrentlyCustom = customSelected || hasCustomValue;
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            {backAction ? (
+              <BackButton action={backAction} />
+            ) : (
+              <IonBackButton text={t`Back`} defaultHref="/settings/advanced" />
+            )}
+          </IonButtons>
+          <IonTitle>
+            <Trans>Long Press Delay</Trans>
+          </IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        <IonList>
+          {presets.map((preset) => (
+            <IonItem key={preset.value} button detail={false} onClick={() => handlePresetTap(preset.value)}>
+              <IonLabel>{preset.label}</IonLabel>
+              {!isCurrentlyCustom && delayMs === preset.value && (
+                <IonIcon icon={checkmark} slot="end" color="primary" />
+              )}
+            </IonItem>
+          ))}
+          <IonItem button detail={false} onClick={handleCustomTap}>
+            <IonLabel>{t`Custom`}</IonLabel>
+            {isCurrentlyCustom && <IonIcon icon={checkmark} slot="end" color="primary" />}
+          </IonItem>
+        </IonList>
+
+        {isCurrentlyCustom && (
+          <IonList>
+            <IonItem>
+              <IonLabel position="stacked">
+                {t`Delay`}: {delayMs}ms
+              </IonLabel>
+              <IonRange
+                min={LONG_PRESS_CUSTOM_MIN}
+                max={LONG_PRESS_CUSTOM_MAX}
+                step={5}
+                value={delayMs}
+                onIonInput={(e) => handleSliderChange(e.detail.value as number)}
+              >
+                <IonLabel slot="start">{t`Fast`}</IonLabel>
+                <IonLabel slot="end">{t`Slow`}</IonLabel>
+              </IonRange>
+            </IonItem>
+          </IonList>
+        )}
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default function LongPressDelayPage() {
+  return <LongPressDelayCore />;
+}

--- a/wetty-chat-mobile/src/pages/settings/menu-bg-opacity.tsx
+++ b/wetty-chat-mobile/src/pages/settings/menu-bg-opacity.tsx
@@ -1,0 +1,113 @@
+import {
+  IonBackButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonPage,
+  IonRange,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/react';
+import { t } from '@lingui/core/macro';
+import { useState } from 'react';
+import { Trans } from '@lingui/react/macro';
+import { checkmark } from 'ionicons/icons';
+import {
+  MENU_BG_OPACITY_MIN,
+  MENU_BG_OPACITY_MAX,
+  getMenuBgOpacityPresets,
+  isCustomMenuBgOpacity,
+  setMenuBgOpacity,
+  useMenuBgOpacity,
+} from '@/store/advancedSettingsStore';
+import type { BackAction } from '@/types/back-action';
+import { BackButton } from '@/components/BackButton';
+
+interface MenuBgOpacityCoreProps {
+  backAction?: BackAction;
+}
+
+export function MenuBgOpacityCore({ backAction }: MenuBgOpacityCoreProps) {
+  const currentOpacity = useMenuBgOpacity();
+  const presets = getMenuBgOpacityPresets();
+  const hasCustomValue = isCustomMenuBgOpacity(currentOpacity);
+  const [customSelected, setCustomSelected] = useState(hasCustomValue);
+
+  const handlePresetTap = (value: number) => {
+    setCustomSelected(false);
+    setMenuBgOpacity(value);
+  };
+
+  const handleCustomTap = () => {
+    setCustomSelected(true);
+  };
+
+  const handleSliderChange = (value: number) => {
+    setMenuBgOpacity(value);
+  };
+
+  const isCurrentlyCustom = customSelected || hasCustomValue;
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            {backAction ? (
+              <BackButton action={backAction} />
+            ) : (
+              <IonBackButton text={t`Back`} defaultHref="/settings/advanced" />
+            )}
+          </IonButtons>
+          <IonTitle>
+            <Trans>Menu Background Opacity</Trans>
+          </IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        <IonList>
+          {presets.map((preset) => (
+            <IonItem key={preset.value} button detail={false} onClick={() => handlePresetTap(preset.value)}>
+              <IonLabel>{preset.label}</IonLabel>
+              {!isCurrentlyCustom && currentOpacity === preset.value && (
+                <IonIcon icon={checkmark} slot="end" color="primary" />
+              )}
+            </IonItem>
+          ))}
+          <IonItem button detail={false} onClick={handleCustomTap}>
+            <IonLabel>{t`Custom`}</IonLabel>
+            {isCurrentlyCustom && <IonIcon icon={checkmark} slot="end" color="primary" />}
+          </IonItem>
+        </IonList>
+
+        {isCurrentlyCustom && (
+          <IonList>
+            <IonItem>
+              <IonLabel position="stacked">
+                {t`Opacity`}: {currentOpacity}%
+              </IonLabel>
+              <IonRange
+                min={MENU_BG_OPACITY_MIN}
+                max={MENU_BG_OPACITY_MAX}
+                step={1}
+                value={currentOpacity}
+                onIonInput={(e) => handleSliderChange(e.detail.value as number)}
+              >
+                <IonLabel slot="start">{t`Transparent`}</IonLabel>
+                <IonLabel slot="end">{t`Opaque`}</IonLabel>
+              </IonRange>
+            </IonItem>
+          </IonList>
+        )}
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default function MenuBgOpacityPage() {
+  return <MenuBgOpacityCore />;
+}

--- a/wetty-chat-mobile/src/store/advancedSettingsStore.ts
+++ b/wetty-chat-mobile/src/store/advancedSettingsStore.ts
@@ -13,20 +13,25 @@ import { kvDelete, kvGet, kvSet } from '@/utils/db';
 
 interface AdvancedSettings {
   longPressDelayMs: number;
+  menuBgOpacity: number;
 }
 
 const ADVANCED_DEFAULTS: Readonly<AdvancedSettings> = {
   longPressDelayMs: 350,
+  menuBgOpacity: 100,
 } as const;
 
 // --- Constants (importable by UI) ---
 
-export interface LongPressPreset {
+export const DEFAULT_LONG_PRESS_DELAY_MS = ADVANCED_DEFAULTS.longPressDelayMs;
+export const MENU_BG_OPACITY_MIN = 0;
+export const MENU_BG_OPACITY_MAX = 100;
+export interface Preset {
   value: number;
   label: string;
 }
 
-export function getLongPressPresets(): LongPressPreset[] {
+export function getLongPressPresets(): Preset[] {
   return [
     { value: 150, label: t`Fast (150ms)` },
     { value: 350, label: t`Default (350ms)` },
@@ -40,6 +45,19 @@ export const LONG_PRESS_CUSTOM_MAX = 1500;
 
 export function isCustomLongPressValue(ms: number): boolean {
   return getLongPressPresets().every((p) => p.value !== ms);
+}
+
+export function getMenuBgOpacityPresets() {
+  return [
+    { value: 50, label: `50%` },
+    { value: 70, label: `70%` },
+    { value: 90, label: `90%` },
+    { value: 100, label: t`Default (100%)` },
+  ];
+}
+
+export function isCustomMenuBgOpacity(value: number): boolean {
+  return getMenuBgOpacityPresets().every((p) => p.value !== value);
 }
 
 // --- Pub/Sub ---
@@ -140,4 +158,19 @@ export function setLongPressDelayMs(ms: number): void {
 
 export function useLongPressDelayMs(): number {
   return useSyncExternalStore(subscribe, getLongPressDelaySnapshot, () => ADVANCED_DEFAULTS.longPressDelayMs);
+}
+
+// --- Menu Background Opacity ---
+
+function getMenuBgOpacitySnapshot(): number {
+  return settingsCache.menuBgOpacity;
+}
+
+export function setMenuBgOpacity(opacity: number): void {
+  const clamped = Math.max(MENU_BG_OPACITY_MIN, Math.min(MENU_BG_OPACITY_MAX, opacity));
+  setSetting('menuBgOpacity', clamped);
+}
+
+export function useMenuBgOpacity(): number {
+  return useSyncExternalStore(subscribe, getMenuBgOpacitySnapshot, () => ADVANCED_DEFAULTS.menuBgOpacity);
 }

--- a/wetty-chat-mobile/src/store/advancedSettingsStore.ts
+++ b/wetty-chat-mobile/src/store/advancedSettingsStore.ts
@@ -1,0 +1,78 @@
+import { useSyncExternalStore } from 'react';
+import { kvDelete, kvGet, kvSet } from '@/utils/db';
+
+// ============================================================
+// Adding a new advanced setting:
+//   1. Add a property + default to ADVANCED_DEFAULTS
+//   2. (Optional) Add a typed getter / hook below
+// That's it. Lock resets everything automatically.
+// ============================================================
+
+// --- Advanced settings schema ---
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- populated by future commits
+interface AdvancedSettings {}
+// --- Pub/Sub ---
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+// --- Single IDB key for all advanced settings ---
+
+const SETTINGS_KEY = 'advanced_settings';
+const UNLOCK_KEY = 'advanced_settings_unlocked';
+
+let unlockedCache = false;
+
+// --- Init (call once in bootstrap) ---
+
+export async function initAdvancedSettings(): Promise<void> {
+  const [storedUnlock] = await Promise.all([kvGet<boolean>(UNLOCK_KEY), kvGet<AdvancedSettings>(SETTINGS_KEY)]);
+  unlockedCache = storedUnlock ?? false;
+}
+
+// --- Unlock / Lock ---
+
+function getUnlockedSnapshot(): boolean {
+  return unlockedCache;
+}
+
+export function isAdvancedSettingsUnlocked(): boolean {
+  return unlockedCache;
+}
+
+export function unlockAdvancedSettings(): void {
+  if (unlockedCache) return;
+  unlockedCache = true;
+  kvSet(UNLOCK_KEY, true);
+  notify();
+}
+
+export function lockAdvancedSettings(): void {
+  if (!unlockedCache) return;
+  unlockedCache = false;
+  kvSet(UNLOCK_KEY, false);
+  kvDelete(SETTINGS_KEY);
+  notify();
+}
+
+export function toggleAdvancedSettings(): void {
+  if (unlockedCache) {
+    lockAdvancedSettings();
+  } else {
+    unlockAdvancedSettings();
+  }
+}
+
+export function useAdvancedSettingsUnlocked(): boolean {
+  return useSyncExternalStore(subscribe, getUnlockedSnapshot, () => false);
+}

--- a/wetty-chat-mobile/src/store/advancedSettingsStore.ts
+++ b/wetty-chat-mobile/src/store/advancedSettingsStore.ts
@@ -1,3 +1,4 @@
+import { t } from '@lingui/core/macro';
 import { useSyncExternalStore } from 'react';
 import { kvDelete, kvGet, kvSet } from '@/utils/db';
 
@@ -10,8 +11,37 @@ import { kvDelete, kvGet, kvSet } from '@/utils/db';
 
 // --- Advanced settings schema ---
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- populated by future commits
-interface AdvancedSettings {}
+interface AdvancedSettings {
+  longPressDelayMs: number;
+}
+
+const ADVANCED_DEFAULTS: Readonly<AdvancedSettings> = {
+  longPressDelayMs: 350,
+} as const;
+
+// --- Constants (importable by UI) ---
+
+export interface LongPressPreset {
+  value: number;
+  label: string;
+}
+
+export function getLongPressPresets(): LongPressPreset[] {
+  return [
+    { value: 150, label: t`Fast (150ms)` },
+    { value: 350, label: t`Default (350ms)` },
+    { value: 600, label: t`Slow (600ms)` },
+    { value: 1000, label: t`Very Slow (1000ms)` },
+  ];
+}
+
+export const LONG_PRESS_CUSTOM_MIN = 5;
+export const LONG_PRESS_CUSTOM_MAX = 1500;
+
+export function isCustomLongPressValue(ms: number): boolean {
+  return getLongPressPresets().every((p) => p.value !== ms);
+}
+
 // --- Pub/Sub ---
 
 type Listener = () => void;
@@ -31,13 +61,21 @@ function notify(): void {
 const SETTINGS_KEY = 'advanced_settings';
 const UNLOCK_KEY = 'advanced_settings_unlocked';
 
+// In-memory state
 let unlockedCache = false;
+let settingsCache: AdvancedSettings = { ...ADVANCED_DEFAULTS };
 
 // --- Init (call once in bootstrap) ---
 
 export async function initAdvancedSettings(): Promise<void> {
-  const [storedUnlock] = await Promise.all([kvGet<boolean>(UNLOCK_KEY), kvGet<AdvancedSettings>(SETTINGS_KEY)]);
+  const [storedUnlock, storedSettings] = await Promise.all([
+    kvGet<boolean>(UNLOCK_KEY),
+    kvGet<AdvancedSettings>(SETTINGS_KEY),
+  ]);
   unlockedCache = storedUnlock ?? false;
+  if (storedSettings) {
+    settingsCache = { ...ADVANCED_DEFAULTS, ...storedSettings };
+  }
 }
 
 // --- Unlock / Lock ---
@@ -60,6 +98,7 @@ export function unlockAdvancedSettings(): void {
 export function lockAdvancedSettings(): void {
   if (!unlockedCache) return;
   unlockedCache = false;
+  settingsCache = { ...ADVANCED_DEFAULTS };
   kvSet(UNLOCK_KEY, false);
   kvDelete(SETTINGS_KEY);
   notify();
@@ -75,4 +114,30 @@ export function toggleAdvancedSettings(): void {
 
 export function useAdvancedSettingsUnlocked(): boolean {
   return useSyncExternalStore(subscribe, getUnlockedSnapshot, () => false);
+}
+
+// --- Generic settings accessor ---
+
+function setSetting<K extends keyof AdvancedSettings>(key: K, value: AdvancedSettings[K]): void {
+  settingsCache = { ...settingsCache, [key]: value };
+  kvSet(SETTINGS_KEY, settingsCache);
+  notify();
+}
+
+// --- Long Press Delay ---
+
+function getLongPressDelaySnapshot(): number {
+  return settingsCache.longPressDelayMs;
+}
+
+export function getLongPressDelayMs(): number {
+  return getLongPressDelaySnapshot();
+}
+
+export function setLongPressDelayMs(ms: number): void {
+  setSetting('longPressDelayMs', ms);
+}
+
+export function useLongPressDelayMs(): number {
+  return useSyncExternalStore(subscribe, getLongPressDelaySnapshot, () => ADVANCED_DEFAULTS.longPressDelayMs);
 }


### PR DESCRIPTION
The version item quick-tap action has been changed from showing a JWT token toast to toggling advanced settings. JWT token copy is now available as a dedicated button within the advanced settings page.

The advanced settings section introduces two new options:
- Long Press Delay — allows users to customize how long they need to hold before the long-press menu appears (Resolve #421)
- Menu Background Opacity — allows users to control the transparency of the message action menu overlay

Tapping again disables advanced settings, and all settings are reset to their default values.