### PR TITLE
feat(pwa): Add invite card context menu interactions

### DIFF
--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -178,6 +178,21 @@
   max-width: 200px;
 }
 
+.bubble.inviteBubble {
+  background: none;
+  padding: 0;
+  border-radius: 12px;
+  max-width: 360px;
+  min-width: 280px;
+  width: 100%;
+
+  // Override InviteMessageCard content width constraint
+  :global(.inviteContent) {
+    width: 100%;
+    max-width: none;
+  }
+}
+
 .stickerContainer {
   position: relative;
   display: inline-block;

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
@@ -4,23 +4,30 @@ import { arrowUndo } from 'ionicons/icons';
 import styles from './ChatBubble.module.scss';
 import { ChatBubbleBase, type ChatBubbleBaseProps } from './ChatBubbleBase';
 import { StickerBubble, type StickerBubbleProps } from './StickerBubble';
+import { InviteBubble, type InviteBubbleProps } from './InviteBubble';
 
 const SWIPE_THRESHOLD = 60;
 const SWIPE_MAX = 80;
 const LONG_PRESS_DELAY_MS = 350;
 
-type StickerChatBubbleProps = StickerBubbleProps & {
-  messageType: 'sticker';
+type ChatBubbleInteractionProps = {
   swipeDirection?: 'left' | 'right';
   onLongPress?: (rect: DOMRect, interactionPos?: { x: number; y: number }) => void;
 };
 
-type RegularChatBubbleProps = ChatBubbleBaseProps & {
-  swipeDirection?: 'left' | 'right';
-  onLongPress?: (rect: DOMRect, interactionPos?: { x: number; y: number }) => void;
-};
+type StickerChatBubbleProps = StickerBubbleProps &
+  ChatBubbleInteractionProps & {
+    messageType: 'sticker';
+  };
 
-export type ChatBubbleProps = StickerChatBubbleProps | RegularChatBubbleProps;
+type RegularChatBubbleProps = ChatBubbleBaseProps & ChatBubbleInteractionProps;
+
+type InviteChatBubbleProps = InviteBubbleProps &
+  ChatBubbleInteractionProps & {
+    messageType: 'invite';
+  };
+
+export type ChatBubbleProps = StickerChatBubbleProps | RegularChatBubbleProps | InviteChatBubbleProps;
 
 function renderInnerBubble(props: ChatBubbleProps, bubbleRef: React.RefObject<HTMLDivElement | null>): React.ReactNode {
   if (props.messageType === 'sticker') {
@@ -39,6 +46,28 @@ function renderInnerBubble(props: ChatBubbleProps, bubbleRef: React.RefObject<HT
         timestamp={props.timestamp}
         edited={props.edited}
         isConfirmed={props.isConfirmed}
+        threadInfo={props.threadInfo}
+        onThreadClick={props.onThreadClick}
+        layout={props.layout}
+        interactionMode={props.interactionMode}
+        bubbleProps={props.bubbleProps}
+        bubbleRef={bubbleRef}
+      />
+    );
+  }
+  if (props.messageType === 'invite') {
+    return (
+      <InviteBubble
+        inviteCode={props.inviteCode}
+        senderName={props.senderName}
+        isSent={props.isSent}
+        avatarUrl={props.avatarUrl}
+        showAvatar={props.showAvatar}
+        showName={props.showName}
+        onOpen={props.onOpen}
+        onReply={props.onReply}
+        onAvatarClick={props.onAvatarClick}
+        timestamp={props.timestamp}
         threadInfo={props.threadInfo}
         onThreadClick={props.onThreadClick}
         layout={props.layout}

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -13,6 +13,7 @@ import { t } from '@lingui/core/macro';
 import { useSelector } from 'react-redux';
 import styles from './ChatBubble.module.scss';
 import reactionStyles from './ReactionPill.module.scss';
+import { formatTime } from '@/utils/formatTime';
 import type { Attachment, MentionInfo, ReactionSummary, UserGroupTagInfo } from '@/api/messages';
 import { ImageViewer } from '@/components/chat/messages/media/ImageViewer';
 import { formatMessagePreview, type PreviewMessage, getNotificationPreviewLabels } from '@/utils/messagePreview';
@@ -33,11 +34,6 @@ import {
   getChatBaseFont,
   getChatBubbleMaxWidth,
 } from '@/utils/chatTextMeasure';
-
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-}
 
 function isImageAttachment(attachment: Attachment) {
   return (

--- a/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
@@ -4,7 +4,6 @@ import { type MessageResponse, mentionToUser, type User } from '@/api/messages';
 import { InviteMessageModal } from '@/components/invites/InviteMessageModal';
 import { ChatBubble } from './ChatBubble';
 import { type BubblePropsOverride } from './ChatBubbleBase';
-import { InviteMessageCard } from './InviteMessageCard';
 import { MessageDateSeparator } from './MessageDateSeparator';
 import { SystemMessage } from './SystemMessage';
 import type { ChatRow } from '../virtualScroll/types';
@@ -58,25 +57,6 @@ export function ChatMessageRow({
     return <SystemMessage senderName={msg.sender.name} message={msg.isDeleted ? t`[Deleted]` : (msg.message ?? '')} />;
   }
 
-  if (isInviteMessage(msg)) {
-    const code = msg.message?.trim() ?? '';
-    return (
-      <>
-        <InviteMessageCard
-          inviteCode={code}
-          sender={msg.sender}
-          isSent={msg.sender.uid === currentUserId}
-          showName={row.showName}
-          showAvatar={row.showAvatar}
-          timestamp={msg.createdAt}
-          onAvatarClick={() => onAvatarClick(msg.sender)}
-          onOpen={() => setInviteCode(code)}
-        />
-        <InviteMessageModal inviteCode={inviteCode} onDismiss={() => setInviteCode(null)} />
-      </>
-    );
-  }
-
   const sharedBubbleProps = {
     senderName: msg.sender.name ?? `User ${msg.sender.uid}`,
     isSent: msg.sender.uid === currentUserId,
@@ -99,6 +79,22 @@ export function ChatMessageRow({
         }
       : undefined,
   } as const;
+
+  if (isInviteMessage(msg)) {
+    const code = msg.message?.trim() ?? '';
+    return (
+      <>
+        <ChatBubble
+          {...sharedBubbleProps}
+          messageType="invite"
+          inviteCode={code}
+          showName={row.showName}
+          onOpen={() => setInviteCode(code)}
+        />
+        <InviteMessageModal inviteCode={inviteCode} onDismiss={() => setInviteCode(null)} />
+      </>
+    );
+  }
 
   if (isStickerMessage(msg)) {
     const stickerUrl = msg.sticker?.media.url ?? '';

--- a/wetty-chat-mobile/src/components/chat/messages/InviteBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteBubble.tsx
@@ -1,0 +1,98 @@
+import type { Ref } from 'react';
+import { IonIcon } from '@ionic/react';
+import { arrowUndo, chatbubbles } from 'ionicons/icons';
+import { t } from '@lingui/core/macro';
+import type { User } from '@/api/messages';
+import { useMouseDetected } from '@/hooks/platformHooks';
+import { InviteMessageCard } from './InviteMessageCard';
+import styles from './ChatBubble.module.scss';
+import type { BubblePropsOverride } from './ChatBubbleBase';
+
+export interface InviteBubbleProps {
+  inviteCode: string;
+  senderName: string;
+  isSent: boolean;
+  avatarUrl?: string;
+  showName?: boolean;
+  showAvatar?: boolean;
+  onOpen?: () => void;
+  onReply?: () => void;
+  onAvatarClick?: () => void;
+  timestamp?: string;
+  threadInfo?: { replyCount: number };
+  onThreadClick?: () => void;
+  layout?: 'thread' | 'bubble-only';
+  interactionMode?: 'interactive' | 'read-only';
+  bubbleProps?: BubblePropsOverride;
+  bubbleRef?: Ref<HTMLDivElement>;
+}
+
+export function InviteBubble({
+  inviteCode,
+  senderName,
+  isSent,
+  avatarUrl,
+  showName = true,
+  showAvatar = true,
+  onOpen,
+  onReply,
+  onAvatarClick,
+  timestamp,
+  threadInfo,
+  onThreadClick,
+  layout = 'thread',
+  interactionMode = 'interactive',
+  bubbleProps: bubblePropOverrides,
+  bubbleRef,
+}: InviteBubbleProps) {
+  const mouseDetected = useMouseDetected();
+  const interactive = interactionMode === 'interactive';
+  const { className: bubbleClassName, style: bubbleStyle, ...bubbleRestProps } = bubblePropOverrides ?? {};
+
+  const sender: User = { uid: 0, name: senderName, avatarUrl, gender: 0 };
+
+  const bubble = (
+    <div
+      ref={bubbleRef}
+      {...bubbleRestProps}
+      className={[styles.bubble, styles.inviteBubble, mouseDetected ? styles.mouseSelectable : '', bubbleClassName]
+        .filter(Boolean)
+        .join(' ')}
+      style={bubbleStyle}
+    >
+      <InviteMessageCard
+        inviteCode={inviteCode}
+        sender={sender}
+        isSent={isSent}
+        showName={showName}
+        showAvatar={showAvatar}
+        timestamp={timestamp ?? ''}
+        onAvatarClick={interactive ? onAvatarClick : undefined}
+        onOpen={interactive && onOpen ? onOpen : () => {}}
+      />
+      {threadInfo && (
+        <div className={styles.threadIndicator} onClick={interactive ? onThreadClick : undefined}>
+          <IonIcon icon={chatbubbles} />
+          <span>
+            {threadInfo.replyCount} {threadInfo.replyCount === 1 ? t`reply` : t`replies`}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+
+  if (layout === 'bubble-only') {
+    return <div className={`${styles.bubbleOnly} ${isSent ? styles.sent : styles.received}`}>{bubble}</div>;
+  }
+
+  return (
+    <div className={`${styles.chatRow} ${isSent ? styles.sent : styles.received}`}>
+      {bubble}
+      {interactive && onReply && (
+        <button className={styles.hoverReplyBtn} onClick={onReply} aria-label={t`Reply`}>
+          <IonIcon icon={arrowUndo} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
@@ -65,6 +65,7 @@
   width: 100%;
   background: transparent;
   padding: 0;
+  position: relative;
 }
 
 .cardDisabled {
@@ -81,6 +82,22 @@
   --background: var(--ion-background-color-step-100, #f0f0f0);
   border: 1px solid var(--ion-color-light-shade);
   box-sizing: border-box;
+}
+
+.inviteTimestamp {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  background: rgba(0, 0, 0, 0.45);
+  border-radius: 10px;
+  padding: 2px 6px;
+  color: #fff;
+  font-size: 11px;
+  opacity: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  z-index: 1;
 }
 
 .cardDisabled .ionCard {

--- a/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.tsx
@@ -7,6 +7,7 @@ import type { User } from '@/api/messages';
 import { UserAvatar } from '@/components/UserAvatar';
 import { useInvitePreview } from '@/components/invites/useInvitePreview';
 import styles from './InviteMessageCard.module.scss';
+import { formatTime } from '@/utils/formatTime';
 
 interface InviteMessageCardProps {
   inviteCode: string;
@@ -17,11 +18,6 @@ interface InviteMessageCardProps {
   timestamp: string;
   onAvatarClick?: () => void;
   onOpen: () => void;
-}
-
-function formatTime(iso: string): string {
-  const date = new Date(iso);
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
 }
 
 type CardBodyViewState =
@@ -110,7 +106,7 @@ export function InviteMessageCard({
         <div className={styles.avatarSpacer} />
       )}
 
-      <div className={styles.content}>
+      <div className={`${styles.content} inviteContent`}>
         {showName && !isSent && <div className={styles.senderName}>{senderName}</div>}
 
         <div className={`${styles.cardRow} ${isSent ? styles.sentRow : ''}`}>
@@ -129,9 +125,8 @@ export function InviteMessageCard({
               </IonCardHeader>
               <InviteCardBody viewState={bodyViewState} />
             </IonCard>
+            {timestamp && <span className={styles.inviteTimestamp}>{formatTime(timestamp)}</span>}
           </button>
-
-          <div className={styles.timestamp}>{formatTime(timestamp)}</div>
         </div>
       </div>
     </div>

--- a/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.tsx
@@ -7,6 +7,7 @@ import type { Attachment, MentionInfo } from '@/api/messages';
 import type { PreviewMessage } from '@/utils/messagePreview';
 import { ChatBubbleBase } from './ChatBubbleBase';
 import { StickerBubble } from './StickerBubble';
+import { InviteBubble } from './InviteBubble';
 import styles from './MessageOverlay.module.scss';
 import { MAX_DISTINCT_REACTIONS_PER_MESSAGE } from '@/constants/emojiAndStickers';
 import { getOverlayPortalTarget } from '@/utils/dom';
@@ -61,7 +62,15 @@ interface RegularOverlayProps extends MessageOverlayBaseProps {
   stickerUrl?: never;
 }
 
-export type MessageOverlayProps = StickerOverlayProps | RegularOverlayProps;
+interface InviteOverlayProps extends MessageOverlayBaseProps {
+  messageType: 'invite';
+  inviteCode: string;
+  message?: never;
+  attachments?: never;
+  stickerUrl?: never;
+}
+
+export type MessageOverlayProps = StickerOverlayProps | RegularOverlayProps | InviteOverlayProps;
 
 export function MessageOverlay(props: MessageOverlayProps) {
   const {
@@ -83,6 +92,7 @@ export function MessageOverlay(props: MessageOverlayProps) {
     onMentionClick,
   } = props;
   const isSticker = props.messageType === 'sticker';
+  const isInvite = props.messageType === 'invite';
   const contentRef = useRef<HTMLDivElement>(null);
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
   const [presentToast] = useIonToast();
@@ -380,40 +390,40 @@ export function MessageOverlay(props: MessageOverlayProps) {
     style: { width: sourceRect.width },
   };
 
+  const commonBubbleProps = {
+    senderName,
+    isSent,
+    showAvatar: false,
+    showName,
+    timestamp,
+    layout: 'bubble-only' as const,
+    interactionMode: 'read-only' as const,
+    bubbleProps: bubbleCloneProps,
+  };
+
   let bubbleClone;
-  if (props.messageType === 'sticker') {
+  if (props.messageType === 'invite') {
+    bubbleClone = <InviteBubble {...commonBubbleProps} inviteCode={props.inviteCode} />;
+  } else if (props.messageType === 'sticker') {
     bubbleClone = (
       <StickerBubble
+        {...commonBubbleProps}
         stickerUrl={props.stickerUrl}
-        senderName={senderName}
-        isSent={isSent}
-        showAvatar={false}
         replyTo={replyTo}
-        timestamp={timestamp}
         edited={edited}
         isConfirmed={isConfirmed}
-        layout="bubble-only"
-        interactionMode="read-only"
-        bubbleProps={bubbleCloneProps}
       />
     );
   } else {
     bubbleClone = (
       <ChatBubbleBase
+        {...commonBubbleProps}
         messageType={props.messageType}
-        senderName={senderName}
         message={props.message}
-        isSent={isSent}
-        showName={showName}
-        showAvatar={false}
         replyTo={replyTo}
-        timestamp={timestamp}
         edited={edited}
         isConfirmed={isConfirmed}
         attachments={props.attachments}
-        layout="bubble-only"
-        interactionMode="read-only"
-        bubbleProps={bubbleCloneProps}
         mentions={mentions}
         currentUserUid={currentUserUid}
         onMentionClick={onMentionClick}
@@ -433,8 +443,9 @@ export function MessageOverlay(props: MessageOverlayProps) {
         className={`${styles.content} ${isSent ? styles.contentSent : ''} ${styles.contentVisible}`}
         style={{ top: sourceRect.top, left: sourceRect.left, visibility: 'hidden' }}
       >
-        {/* Reaction bar — hidden for stickers */}
+        {/* Reaction bar — hidden for stickers and invites */}
         {!isSticker &&
+          !isInvite &&
           reactions &&
           (() => {
             const currentReactionsCount = reactions.currentMessageReactions?.length ?? 0;

--- a/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
@@ -10,11 +10,7 @@ import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { UserAvatar } from '@/components/UserAvatar';
 import { useMouseDetected } from '@/hooks/platformHooks';
 import type { BubblePropsOverride } from './ChatBubbleBase';
-
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-}
+import { formatTime } from '@/utils/formatTime';
 
 export interface StickerBubbleProps {
   messageType?: 'sticker';

--- a/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/ConversationOverlayHost.tsx
@@ -117,6 +117,12 @@ export function ConversationOverlayHost({
               );
             }
 
+            if (msg.messageType === 'invite') {
+              return (
+                <MessageOverlay messageType="invite" inviteCode={msg.message?.trim() ?? ''} {...sharedOverlayProps} />
+              );
+            }
+
             return (
               <MessageOverlay
                 messageType={msg.messageType as 'text' | 'audio'}

--- a/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
+++ b/wetty-chat-mobile/src/pages/conversation/utils/overlayActionPolicy.ts
@@ -88,5 +88,9 @@ export function getOverlayActionPolicy(input: OverlayActionPolicyInput): Overlay
     );
   }
 
+  if (input.messageType === 'invite') {
+    return actions.filter((action) => action.key === 'reply' || action.key === 'pin' || action.key === 'delete');
+  }
+
   return actions;
 }

--- a/wetty-chat-mobile/src/utils/formatTime.ts
+++ b/wetty-chat-mobile/src/utils/formatTime.ts
@@ -1,0 +1,7 @@
+/**
+ * Format an ISO timestamp to a short time string (HH:MM).
+ */
+export function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+}


### PR DESCRIPTION
Wrapped invite cards into the ChatBubble system so they get the same treatment as regular messages — now supports reply, pin, and delete through the standard overlay actions. Also added long-press preview support for invite messages.