### PR TITLE
fix(backend,pwa): Resolve scroll stranding on dangling read pointers

### DIFF
--- a/backend/migrations/2026-06-26-120000-0000_add_thread_user_states_read_pointer_index/down.sql
+++ b/backend/migrations/2026-06-26-120000-0000_add_thread_user_states_read_pointer_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_thread_user_states_root_read_pointer;

--- a/backend/migrations/2026-06-26-120000-0000_add_thread_user_states_read_pointer_index/up.sql
+++ b/backend/migrations/2026-06-26-120000-0000_add_thread_user_states_read_pointer_index/up.sql
@@ -1,0 +1,8 @@
+-- Supports bulk shifting of `thread_user_states.last_read_message_id` anchored
+-- on deleted thread replies. `thread_user_states`' primary key leads with
+-- `chat_id`, so `WHERE thread_root_id = $1 AND last_read_message_id = ANY($2)`
+-- cannot use the PK prefix. Since `thread_root_id` is a globally unique message
+-- id, this index scopes the update without chat_id.
+CREATE INDEX IF NOT EXISTS idx_thread_user_states_root_read_pointer
+ON thread_user_states (thread_root_id, last_read_message_id)
+WHERE last_read_message_id IS NOT NULL;

--- a/backend/src/handlers/chats/messages.rs
+++ b/backend/src/handlers/chats/messages.rs
@@ -984,6 +984,20 @@ async fn delete_message(
             }
         }
 
+        // Shift any read pointers anchored on the deleted message so they
+        // don't dangle (PWA `around=<last_read_message_id>` would strand
+        // scroll). Only a top-level message with no thread can dangle a
+        // chat-level pointer; a reply dangles its thread-level pointer.
+        if let Some(thread_root_id) = deleted_message.reply_root_id {
+            crate::services::threads::shift_thread_read_pointers_on_delete(
+                conn,
+                thread_root_id,
+                &[message_id],
+            )?;
+        } else if !deleted_message.has_thread {
+            super::shift_chat_read_pointers_on_delete(conn, chat_id, &[message_id])?;
+        }
+
         Ok(deleted_message)
     })?;
 

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -1551,9 +1551,6 @@ async fn get_chat_unread_count(
         .select(gm_dsl::last_read_message_id)
         .first(conn)?;
 
-    let last_read_message_id =
-        clamp_dangling_chat_read_pointer(conn, chat_id, uid, last_read_message_id)?;
-
     let unread_count =
         state
             .unread_service
@@ -1739,69 +1736,52 @@ pub(crate) fn recalculate_group_last_message(
     Ok(())
 }
 
-/// Resolve a `last_read_message_id` that may dangle (point at a message no
-/// longer returned by the `around` window — e.g. a top-level message that was
-/// soft-deleted and has no thread replies). The PWA resume flow fetches
-/// `around=<last_read_message_id>` and strands the scroll position when that id
-/// is absent from the window. To keep the pointer addressable we clamp it to
-/// the newest surviving message that the `around` query would actually return.
+/// After a top-level message with no thread is soft-deleted, any
+/// `group_membership.last_read_message_id` anchored on it dangles — the PWA
+/// resume flow fetches `around=<last_read_message_id>` and strands scroll when
+/// that id is absent from the window (the around filter is `is_published AND
+/// reply_root_id IS NULL AND (deleted_at IS NULL OR has_thread)`). Shift every
+/// anchored pointer to the newest surviving top-level message strictly older
+/// than the deleted one (or NULL when none survives).
 ///
-/// Findability mirrors the `get_messages` around filter:
-///   reply_root_id IS NULL AND (deleted_at IS NULL OR has_thread)
-/// served by `idx_messages_unread_count` (chat_id, id DESC) WHERE
-/// deleted_at IS NULL AND reply_root_id IS NULL for the common case.
+/// Only top-level messages with `has_thread = false` can dangle: a deleted
+/// top-level message that still has a thread remains visible in the around
+/// window, so its pointer stays addressable. Replies never anchor a chat-level
+/// pointer (chat read position tracks top-level messages only), so passing
+/// reply ids here is a harmless no-op.
 ///
-/// When the stored pointer is already findable it is returned unchanged. When
-/// it dangles the clamped value (or NULL when no earlier message survives) is
-/// persisted back to `group_membership` so the lookup is paid only once.
-fn clamp_dangling_chat_read_pointer(
+/// `deleted_message_ids` must already be soft-deleted (deleted_at set) before
+/// this runs, so the clamp subquery's `deleted_at IS NULL` filter excludes them
+/// — letting one batched UPDATE handle multi-message deletes correctly.
+///
+/// Served by `idx_messages_visible_top_level_last` (chat_id, id DESC) WHERE
+/// deleted_at IS NULL AND is_published AND reply_root_id IS NULL.
+pub(crate) fn shift_chat_read_pointers_on_delete(
     conn: &mut PgConnection,
     chat_id: i64,
-    uid: i32,
-    last_read_message_id: Option<i64>,
-) -> Result<Option<i64>, AppError> {
-    use crate::schema::group_membership::dsl as gm_dsl;
-    use crate::schema::messages::dsl;
-
-    let Some(read_id) = last_read_message_id else {
-        return Ok(None);
-    };
-
-    // Is the stored pointer still addressable by the around window?
-    let findable: bool = messages_schema::table
-        .filter(dsl::chat_id.eq(chat_id))
-        .filter(dsl::id.eq(read_id))
-        .filter(dsl::reply_root_id.is_null())
-        .filter(dsl::deleted_at.is_null().or(dsl::has_thread.eq(true)))
-        .select(dsl::id)
-        .first::<i64>(conn)
-        .optional()?
-        .is_some();
-
-    if findable {
-        return Ok(last_read_message_id);
+    deleted_message_ids: &[i64],
+) -> Result<usize, diesel::result::Error> {
+    if deleted_message_ids.is_empty() {
+        return Ok(0);
     }
-
-    // Dangling pointer: clamp to the newest surviving top-level message that is
-    // strictly older than the deleted target.
-    let clamped: Option<i64> = messages_schema::table
-        .filter(dsl::chat_id.eq(chat_id))
-        .filter(dsl::id.lt(read_id))
-        .filter(dsl::reply_root_id.is_null())
-        .filter(dsl::deleted_at.is_null().or(dsl::has_thread.eq(true)))
-        .order(dsl::id.desc())
-        .select(dsl::id)
-        .first::<i64>(conn)
-        .optional()?;
-
-    // Persist the correction so future reads skip the clamp lookup.
-    diesel::update(
-        group_membership::table.filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(uid))),
+    diesel::sql_query(
+        "UPDATE group_membership
+         SET last_read_message_id = (
+             SELECT id FROM messages
+             WHERE chat_id = $1
+               AND id < group_membership.last_read_message_id
+               AND reply_root_id IS NULL
+               AND (deleted_at IS NULL OR has_thread)
+               AND is_published
+             ORDER BY id DESC
+             LIMIT 1
+         )
+         WHERE chat_id = $1
+           AND last_read_message_id = ANY($2)",
     )
-    .set(gm_dsl::last_read_message_id.eq(clamped))
-    .execute(conn)?;
-
-    Ok(clamped)
+    .bind::<diesel::sql_types::BigInt, _>(chat_id)
+    .bind::<diesel::sql_types::Array<diesel::sql_types::BigInt>, _>(deleted_message_ids)
+    .execute(conn)
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/handlers/chats/mod.rs
+++ b/backend/src/handlers/chats/mod.rs
@@ -1551,6 +1551,9 @@ async fn get_chat_unread_count(
         .select(gm_dsl::last_read_message_id)
         .first(conn)?;
 
+    let last_read_message_id =
+        clamp_dangling_chat_read_pointer(conn, chat_id, uid, last_read_message_id)?;
+
     let unread_count =
         state
             .unread_service
@@ -1734,6 +1737,71 @@ pub(crate) fn recalculate_group_last_message(
     }
 
     Ok(())
+}
+
+/// Resolve a `last_read_message_id` that may dangle (point at a message no
+/// longer returned by the `around` window — e.g. a top-level message that was
+/// soft-deleted and has no thread replies). The PWA resume flow fetches
+/// `around=<last_read_message_id>` and strands the scroll position when that id
+/// is absent from the window. To keep the pointer addressable we clamp it to
+/// the newest surviving message that the `around` query would actually return.
+///
+/// Findability mirrors the `get_messages` around filter:
+///   reply_root_id IS NULL AND (deleted_at IS NULL OR has_thread)
+/// served by `idx_messages_unread_count` (chat_id, id DESC) WHERE
+/// deleted_at IS NULL AND reply_root_id IS NULL for the common case.
+///
+/// When the stored pointer is already findable it is returned unchanged. When
+/// it dangles the clamped value (or NULL when no earlier message survives) is
+/// persisted back to `group_membership` so the lookup is paid only once.
+fn clamp_dangling_chat_read_pointer(
+    conn: &mut PgConnection,
+    chat_id: i64,
+    uid: i32,
+    last_read_message_id: Option<i64>,
+) -> Result<Option<i64>, AppError> {
+    use crate::schema::group_membership::dsl as gm_dsl;
+    use crate::schema::messages::dsl;
+
+    let Some(read_id) = last_read_message_id else {
+        return Ok(None);
+    };
+
+    // Is the stored pointer still addressable by the around window?
+    let findable: bool = messages_schema::table
+        .filter(dsl::chat_id.eq(chat_id))
+        .filter(dsl::id.eq(read_id))
+        .filter(dsl::reply_root_id.is_null())
+        .filter(dsl::deleted_at.is_null().or(dsl::has_thread.eq(true)))
+        .select(dsl::id)
+        .first::<i64>(conn)
+        .optional()?
+        .is_some();
+
+    if findable {
+        return Ok(last_read_message_id);
+    }
+
+    // Dangling pointer: clamp to the newest surviving top-level message that is
+    // strictly older than the deleted target.
+    let clamped: Option<i64> = messages_schema::table
+        .filter(dsl::chat_id.eq(chat_id))
+        .filter(dsl::id.lt(read_id))
+        .filter(dsl::reply_root_id.is_null())
+        .filter(dsl::deleted_at.is_null().or(dsl::has_thread.eq(true)))
+        .order(dsl::id.desc())
+        .select(dsl::id)
+        .first::<i64>(conn)
+        .optional()?;
+
+    // Persist the correction so future reads skip the clamp lookup.
+    diesel::update(
+        group_membership::table.filter(gm_dsl::chat_id.eq(chat_id).and(gm_dsl::uid.eq(uid))),
+    )
+    .set(gm_dsl::last_read_message_id.eq(clamped))
+    .execute(conn)?;
+
+    Ok(clamped)
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/handlers/threads.rs
+++ b/backend/src/handlers/threads.rs
@@ -180,13 +180,6 @@ async fn get_thread_read_state(
 
     let last_read_message_id =
         thread_svc::get_thread_last_read_message_id(conn, chat_id, thread_root_id, uid)?;
-    let last_read_message_id = thread_svc::clamp_dangling_thread_read_pointer(
-        conn,
-        chat_id,
-        thread_root_id,
-        uid,
-        last_read_message_id,
-    )?;
 
     Ok(Json(ThreadReadStateResponse {
         last_read_message_id,

--- a/backend/src/handlers/threads.rs
+++ b/backend/src/handlers/threads.rs
@@ -180,6 +180,13 @@ async fn get_thread_read_state(
 
     let last_read_message_id =
         thread_svc::get_thread_last_read_message_id(conn, chat_id, thread_root_id, uid)?;
+    let last_read_message_id = thread_svc::clamp_dangling_thread_read_pointer(
+        conn,
+        chat_id,
+        thread_root_id,
+        uid,
+        last_read_message_id,
+    )?;
 
     Ok(Json(ThreadReadStateResponse {
         last_read_message_id,

--- a/backend/src/services/background.rs
+++ b/backend/src/services/background.rs
@@ -6,7 +6,7 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::PgConnection;
 use futures::future::FutureExt;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
@@ -202,7 +202,8 @@ fn process_bulk_delete(
 
     // 2. Chunked delete loop
     let mut total_deleted: usize = 0;
-    let mut affected_thread_ids = HashSet::new();
+    let mut thread_clamp: HashMap<i64, Vec<i64>> = HashMap::new();
+    let mut chat_clamp_ids: Vec<i64> = Vec::new();
     loop {
         let mut query = messages::table
             .filter(dsl::chat_id.eq(chat_id))
@@ -226,12 +227,25 @@ fn process_bulk_delete(
             break;
         }
 
-        let batch_thread_ids: Vec<Option<i64>> = messages::table
+        // Partition the batch for read-pointer shifting: top-level messages
+        // with no thread dangle chat-level pointers; replies dangle
+        // thread-level pointers (grouped by thread root). Top-level messages
+        // that still have a thread stay visible in the around window, so their
+        // pointers don't dangle and are skipped.
+        let batch_meta: Vec<(Option<i64>, bool)> = messages::table
             .filter(dsl::id.eq_any(&batch_ids))
-            .select(dsl::reply_root_id)
+            .select((dsl::reply_root_id, dsl::has_thread))
             .load(conn)
             .map_err(map_db)?;
-        affected_thread_ids.extend(batch_thread_ids.into_iter().flatten());
+        for (id, (reply_root_id, has_thread)) in batch_ids.iter().zip(batch_meta) {
+            match reply_root_id {
+                None if !has_thread => chat_clamp_ids.push(*id),
+                Some(thread_root_id) => {
+                    thread_clamp.entry(thread_root_id).or_default().push(*id);
+                }
+                None => {}
+            }
+        }
 
         let now = Utc::now();
 
@@ -269,16 +283,17 @@ fn process_bulk_delete(
         }
     }
 
-    // 3. Recalculate last_message_id and thread_meta once after all batches
+    // 3. Recalculate last_message_id and thread_meta once after all batches,
+    //    then shift any read pointers anchored on deleted messages.
     if total_deleted > 0 {
         unread_service.invalidate_chat(chat_id);
 
         crate::handlers::chats::recalculate_group_last_message(conn, chat_id)
             .map_err(|e| format!("recalculate last message: {e:?}"))?;
 
-        for thread_root_id in &affected_thread_ids {
+        for &thread_root_id in thread_clamp.keys() {
             if let Err(e) =
-                crate::services::threads::recalculate_thread_meta(conn, chat_id, *thread_root_id)
+                crate::services::threads::recalculate_thread_meta(conn, chat_id, thread_root_id)
             {
                 warn!(
                     chat_id,
@@ -293,13 +308,39 @@ fn process_bulk_delete(
                 conn,
                 ws_registry,
                 chat_id,
-                *thread_root_id,
+                thread_root_id,
             ) {
                 warn!(
                     chat_id,
                     thread_root_id,
                     ?e,
                     "broadcast thread update after bulk delete"
+                );
+            }
+        }
+
+        // Shift read pointers anchored on deleted messages. Must run after all
+        // batches are soft-deleted so the clamp subqueries' `deleted_at IS NULL`
+        // filter excludes the full deleted set in one pass.
+        if !chat_clamp_ids.is_empty() {
+            crate::handlers::chats::shift_chat_read_pointers_on_delete(
+                conn,
+                chat_id,
+                &chat_clamp_ids,
+            )
+            .map_err(map_db)?;
+        }
+        for (&thread_root_id, ids) in &thread_clamp {
+            if let Err(e) = crate::services::threads::shift_thread_read_pointers_on_delete(
+                conn,
+                thread_root_id,
+                ids,
+            ) {
+                warn!(
+                    chat_id,
+                    thread_root_id,
+                    ?e,
+                    "shift thread read pointers after bulk delete"
                 );
             }
         }

--- a/backend/src/services/threads.rs
+++ b/backend/src/services/threads.rs
@@ -248,76 +248,46 @@ pub fn get_thread_last_read_message_id(
         .map(|row| row.flatten())
 }
 
-/// Resolve a thread `last_read_message_id` that may dangle (point at a reply
-/// that was soft-deleted). Mirrors the chat-level clamp: the PWA thread resume
-/// flow fetches `around=<last_read_message_id>`, and a deleted reply is absent
-/// from that window (the around filter requires `deleted_at IS NULL` for
-/// replies), stranding the scroll position.
+/// After a thread reply is soft-deleted, any `thread_user_states.last_read_message_id`
+/// anchored on it dangles — the PWA thread resume flow fetches
+/// `around=<last_read_message_id>` and strands scroll when that id is absent
+/// from the window (the around filter is `reply_root_id == thread_root_id AND
+/// deleted_at IS NULL AND is_published`). Shift every anchored pointer to the
+/// newest surviving reply strictly older than the deleted one (or NULL when
+/// none survives).
 ///
-/// Thread findability mirrors the `get_messages` thread filter:
-///   (reply_root_id == thread_root_id AND deleted_at IS NULL) OR id == thread_root_id
-/// The clamp lookup is served by
-/// `idx_messages_thread_reply_stats` (reply_root_id, id DESC) WHERE deleted_at IS NULL.
+/// `deleted_message_ids` must already be soft-deleted before this runs, so the
+/// clamp subquery's `deleted_at IS NULL` filter excludes them — letting one
+/// batched UPDATE handle multi-reply deletes correctly. `thread_root_id` is a
+/// globally unique message id, so it alone scopes the update.
 ///
-/// When the pointer is already findable it is returned unchanged. When it
-/// dangles it is clamped to the newest surviving reply older than the deleted
-/// target (or NULL when none survive) and the correction is persisted to
-/// `thread_user_states`.
-pub fn clamp_dangling_thread_read_pointer(
+/// Served by `idx_messages_thread_reply_stats` (reply_root_id, id DESC) WHERE
+/// deleted_at IS NULL AND is_published.
+pub fn shift_thread_read_pointers_on_delete(
     conn: &mut PgConnection,
-    chat_id: i64,
     thread_root_id: i64,
-    uid: i32,
-    last_read_message_id: Option<i64>,
-) -> Result<Option<i64>, diesel::result::Error> {
-    use crate::schema::messages::dsl;
-
-    let Some(read_id) = last_read_message_id else {
-        return Ok(None);
-    };
-
-    // The thread root itself is always addressable; a reply is addressable only
-    // while it is not soft-deleted.
-    if read_id == thread_root_id {
-        return Ok(last_read_message_id);
+    deleted_message_ids: &[i64],
+) -> Result<usize, diesel::result::Error> {
+    if deleted_message_ids.is_empty() {
+        return Ok(0);
     }
-
-    let findable: bool = messages::table
-        .filter(dsl::id.eq(read_id))
-        .filter(dsl::reply_root_id.eq(thread_root_id))
-        .filter(dsl::deleted_at.is_null())
-        .select(dsl::id)
-        .first::<i64>(conn)
-        .optional()?
-        .is_some();
-
-    if findable {
-        return Ok(last_read_message_id);
-    }
-
-    // Dangling pointer: clamp to the newest surviving reply strictly older than
-    // the deleted target.
-    let clamped: Option<i64> = messages::table
-        .filter(dsl::reply_root_id.eq(thread_root_id))
-        .filter(dsl::deleted_at.is_null())
-        .filter(dsl::id.lt(read_id))
-        .order(dsl::id.desc())
-        .select(dsl::id)
-        .first::<i64>(conn)
-        .optional()?;
-
-    diesel::update(
-        thread_user_states::table.filter(
-            thread_user_states::chat_id
-                .eq(chat_id)
-                .and(thread_user_states::thread_root_id.eq(thread_root_id))
-                .and(thread_user_states::uid.eq(uid)),
-        ),
+    diesel::sql_query(
+        "UPDATE thread_user_states
+         SET last_read_message_id = (
+             SELECT id FROM messages
+             WHERE reply_root_id = $1
+               AND id < thread_user_states.last_read_message_id
+               AND deleted_at IS NULL
+               AND is_published
+             ORDER BY id DESC
+             LIMIT 1
+         )
+         WHERE thread_root_id = $1
+           AND last_read_message_id = ANY($2)",
     )
-    .set(thread_user_states::last_read_message_id.eq(clamped))
-    .execute(conn)?;
-
-    Ok(clamped)
+    .bind::<diesel::sql_types::BigInt, _>(thread_root_id)
+    .bind::<diesel::sql_types::Array<diesel::sql_types::BigInt>, _>(deleted_message_ids)
+    .execute(conn)
 }
 /// Get all UIDs subscribed to a given thread.
 pub fn get_thread_subscriber_uids(

--- a/backend/src/services/threads.rs
+++ b/backend/src/services/threads.rs
@@ -247,6 +247,78 @@ pub fn get_thread_last_read_message_id(
         .optional()
         .map(|row| row.flatten())
 }
+
+/// Resolve a thread `last_read_message_id` that may dangle (point at a reply
+/// that was soft-deleted). Mirrors the chat-level clamp: the PWA thread resume
+/// flow fetches `around=<last_read_message_id>`, and a deleted reply is absent
+/// from that window (the around filter requires `deleted_at IS NULL` for
+/// replies), stranding the scroll position.
+///
+/// Thread findability mirrors the `get_messages` thread filter:
+///   (reply_root_id == thread_root_id AND deleted_at IS NULL) OR id == thread_root_id
+/// The clamp lookup is served by
+/// `idx_messages_thread_reply_stats` (reply_root_id, id DESC) WHERE deleted_at IS NULL.
+///
+/// When the pointer is already findable it is returned unchanged. When it
+/// dangles it is clamped to the newest surviving reply older than the deleted
+/// target (or NULL when none survive) and the correction is persisted to
+/// `thread_user_states`.
+pub fn clamp_dangling_thread_read_pointer(
+    conn: &mut PgConnection,
+    chat_id: i64,
+    thread_root_id: i64,
+    uid: i32,
+    last_read_message_id: Option<i64>,
+) -> Result<Option<i64>, diesel::result::Error> {
+    use crate::schema::messages::dsl;
+
+    let Some(read_id) = last_read_message_id else {
+        return Ok(None);
+    };
+
+    // The thread root itself is always addressable; a reply is addressable only
+    // while it is not soft-deleted.
+    if read_id == thread_root_id {
+        return Ok(last_read_message_id);
+    }
+
+    let findable: bool = messages::table
+        .filter(dsl::id.eq(read_id))
+        .filter(dsl::reply_root_id.eq(thread_root_id))
+        .filter(dsl::deleted_at.is_null())
+        .select(dsl::id)
+        .first::<i64>(conn)
+        .optional()?
+        .is_some();
+
+    if findable {
+        return Ok(last_read_message_id);
+    }
+
+    // Dangling pointer: clamp to the newest surviving reply strictly older than
+    // the deleted target.
+    let clamped: Option<i64> = messages::table
+        .filter(dsl::reply_root_id.eq(thread_root_id))
+        .filter(dsl::deleted_at.is_null())
+        .filter(dsl::id.lt(read_id))
+        .order(dsl::id.desc())
+        .select(dsl::id)
+        .first::<i64>(conn)
+        .optional()?;
+
+    diesel::update(
+        thread_user_states::table.filter(
+            thread_user_states::chat_id
+                .eq(chat_id)
+                .and(thread_user_states::thread_root_id.eq(thread_root_id))
+                .and(thread_user_states::uid.eq(uid)),
+        ),
+    )
+    .set(thread_user_states::last_read_message_id.eq(clamped))
+    .execute(conn)?;
+
+    Ok(clamped)
+}
 /// Get all UIDs subscribed to a given thread.
 pub fn get_thread_subscriber_uids(
     conn: &mut PgConnection,

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.dom.test.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.dom.test.tsx
@@ -169,7 +169,11 @@ describe('useConversationTimeline', () => {
     );
   });
 
-  it('loads around the initial resume target before latest load', async () => {
+  it('anchors to the resume target when the around window contains it', async () => {
+    vi.mocked(getMessages).mockResolvedValue(
+      response({ messages: [message('19'), message('20'), message('21')], nextCursor: '19', prevCursor: '21' }),
+    );
+
     await renderHook({ initialResumeMessageId: '20' });
 
     expect(getMessages).toHaveBeenCalledWith('chat-1', { around: '20', max: 50, threadId: undefined });
@@ -179,13 +183,28 @@ describe('useConversationTimeline', () => {
         payload: {
           chatId: 'chat-1',
           targetMessageId: '20',
-          messages: [message('10'), message('11')],
-          nextCursor: '10',
-          prevCursor: null,
+          messages: [message('19'), message('20'), message('21')],
+          nextCursor: '19',
+          prevCursor: '21',
         },
       }),
     );
     expect(state.timeline.initialAnchor).toEqual({ type: 'message', messageId: '20', token: 1, align: 'top' });
+  });
+
+  it('falls back to the latest message when the resume target is missing from the around window', async () => {
+    // The around fetch returns a window that does not contain the requested
+    // target (e.g. the target was soft-deleted and is no longer addressable).
+    // The anchor must degrade to the newest message instead of stranding the
+    // scroll position on a phantom row.
+    vi.mocked(getMessages).mockResolvedValue(
+      response({ messages: [message('10'), message('11')], nextCursor: '10', prevCursor: null }),
+    );
+
+    await renderHook({ initialResumeMessageId: '20' });
+
+    expect(getMessages).toHaveBeenCalledWith('chat-1', { around: '20', max: 50, threadId: undefined });
+    expect(state.timeline.initialAnchor).toEqual({ type: 'bottom', token: 1 });
   });
 
   it('loads older messages from the current older anchor', async () => {

--- a/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.ts
+++ b/wetty-chat-mobile/src/pages/conversation/hooks/useConversationTimeline.ts
@@ -348,12 +348,24 @@ export function useConversationTimeline({
             responseReachedLatest: prevCursor === null,
             snapshot: collectTimelineSnapshot(store.getState(), storeChatId),
           });
-          setInitialAnchor((currentAnchor) => ({
-            type: 'message',
-            messageId: pendingResumeMessageId,
-            token: currentAnchor.token + 1,
-            align: 'top' as const,
-          }));
+          if (containsTarget) {
+            setInitialAnchor((currentAnchor) => ({
+              type: 'message',
+              messageId: pendingResumeMessageId,
+              token: currentAnchor.token + 1,
+              align: 'top' as const,
+            }));
+          } else {
+            // The resume target was not in the fetched window (e.g. the read
+            // pointer is ahead of the newest delivered message, or the target
+            // was deleted). Anchoring to the phantom id leaves VirtualScroll
+            // unable to resolve it, stranding the view at the top of the
+            // loaded window. Fall back to the newest message instead.
+            setInitialAnchor((currentAnchor) => ({
+              type: 'bottom',
+              token: currentAnchor.token + 1,
+            }));
+          }
           setPendingResumeMessageId(null);
         })
         .catch(() => {


### PR DESCRIPTION
When a top-level message that a member's read pointer references is soft-deleted, the pointer is left dangling at an id the `around` query no longer returns. On chat resume the PWA fetches `around=<last_read_id>`, finds the target absent from the window, and anchors the virtual scroll to that phantom row, stranding the view at the top of the loaded window instead of the unread boundary.

Backend (root cause, lazy clamp + persist):
- Add `clamp_dangling_chat_read_pointer` in chats handler: when the stored `group_membership.last_read_message_id` is no longer addressable by the around window, clamp it to the newest surviving top-level message and persist the correction (single-row write). Reuses `idx_messages_unread_count`. Wired into `get_chat_unread_count`.
- Add `clamp_dangling_thread_read_pointer` in threads service for the parallel `thread_user_states` pointer, served by `idx_messages_thread_reply_stats`. Wired into `get_thread_read_state`.
- Findability mirrors the `get_messages` around filters so a clamped pointer is guaranteed to be hittable on the next resume fetch.

Frontend (defense in depth):
- In useConversationTimeline, when the around response does not contain the requested resume target, fall back to a `bottom` anchor (newest) instead of anchoring to the missing id. Covers chat, thread, and deep-link paths.
- Update dom tests: split the resume-target case into target-present (anchors to message) and target-missing (falls back to bottom).