### PR TITLE
style(pwa): Various UI and layout tweaks

### DIFF
--- a/wetty-chat-mobile/src/app.scss
+++ b/wetty-chat-mobile/src/app.scss
@@ -14,6 +14,12 @@
   --scrollbar-width: 2px;
   --scrollbar-thumb: var(--ion-color-medium, rgba(0, 0, 0, 0.3));
   --scrollbar-radius: 1px;
+
+  // Chat-layer avatar geometry. Consumed by ChatBubble (.chatRow avatar column)
+  // and SenderGroup (sticky avatar container) so both align to a single source
+  // of truth. Declared globally so they resolve regardless of mount order.
+  --avatar-size: 36px;
+  --avatar-column-gap: 12px;
 }
 
 *::-webkit-scrollbar {

--- a/wetty-chat-mobile/src/components/UserAvatar.tsx
+++ b/wetty-chat-mobile/src/components/UserAvatar.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import { IonIcon } from '@ionic/react';
 import { personCircle } from 'ionicons/icons';
 import styles from './UserAvatar.module.scss';
@@ -26,15 +27,15 @@ function colorForUser(name: string): string {
   return `hsl(${hue}, 55%, 50%)`;
 }
 
-export function UserAvatar({
-  name,
-  avatarUrl,
-  size = 36,
-  fallback = 'initials',
-  className,
-  style,
-  onClick,
-}: UserAvatarProps) {
+/**
+ * The avatar's root element is the div carrying `styles.avatar`; the forwarded
+ * ref targets that div so callers (e.g. SenderGroup's sticky avatar) can mutate
+ * its style directly (transform during swipe) without triggering React re-renders.
+ */
+export const UserAvatar = forwardRef<HTMLDivElement, UserAvatarProps>(function UserAvatar(
+  { name, avatarUrl, size = 36, fallback = 'initials', className, style, onClick },
+  ref,
+) {
   const base: React.CSSProperties = {
     width: size,
     height: size,
@@ -44,7 +45,7 @@ export function UserAvatar({
 
   if (avatarUrl) {
     return (
-      <div className={classes} style={base} onClick={onClick}>
+      <div ref={ref} className={classes} style={base} onClick={onClick}>
         <img src={avatarUrl} alt="" className={styles.image} />
       </div>
     );
@@ -53,6 +54,7 @@ export function UserAvatar({
   if (fallback === 'icon') {
     return (
       <div
+        ref={ref}
         className={`${classes} ${styles.iconFallback}`}
         style={{
           ...base,
@@ -67,6 +69,7 @@ export function UserAvatar({
 
   return (
     <div
+      ref={ref}
       className={`${classes} ${styles.fallback}`}
       style={{
         ...base,
@@ -78,4 +81,4 @@ export function UserAvatar({
       {getInitials(name)}
     </div>
   );
-}
+});

--- a/wetty-chat-mobile/src/components/chat/compose/AddStickerModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/compose/AddStickerModal.tsx
@@ -15,6 +15,7 @@ import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { EmojiInput } from '@/components/shared/EmojiInput';
 import styles from './AddStickerModal.module.scss';
+import { useIsDesktop } from '@/hooks/platformHooks';
 
 interface AddStickerModalProps {
   file: File | null;
@@ -23,10 +24,15 @@ interface AddStickerModalProps {
 }
 
 export function AddStickerModal({ file, onDismiss, onAdd }: AddStickerModalProps) {
+  const isDesktop = useIsDesktop();
   const fileKey = file ? `${file.name}:${file.size}:${file.lastModified}` : 'empty';
 
   return (
-    <IonModal isOpen={file != null} onDidDismiss={onDismiss} initialBreakpoint={0.8} breakpoints={[0, 0.8]}>
+    <IonModal
+      isOpen={file != null}
+      onDidDismiss={onDismiss}
+      {...(!isDesktop ? { initialBreakpoint: 0.8, breakpoints: [0, 0.8] } : {})}
+    >
       {file ? <AddStickerModalForm key={fileKey} file={file} onDismiss={onDismiss} onAdd={onAdd} /> : null}
     </IonModal>
   );

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -253,12 +253,6 @@
   max-width: 360px;
   min-width: 280px;
   width: 100%;
-
-  // Override InviteMessageCard content width constraint
-  :global(.inviteContent) {
-    width: 100%;
-    max-width: none;
-  }
 }
 
 .stickerContainer {

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -533,6 +533,11 @@
   }
 }
 
+.threadIndicatorMediaOnly {
+  border-top: none;
+  padding-top: 0;
+}
+
 .sent .threadIndicator {
   border-top-color: rgba(var(--ion-color-primary-contrast-rgb, 255, 255, 255), 0.2);
   justify-content: flex-end;

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -1,5 +1,8 @@
-.swipeContainer {
+.swipeRoot {
   position: relative;
+}
+
+.swipeContainer {
   overflow: hidden;
 }
 
@@ -17,9 +20,74 @@
   bottom: 0;
   display: flex;
   align-items: center;
+  justify-content: center;
   font-size: 22px;
   color: var(--ion-color-primary);
   pointer-events: none;
+}
+
+.replyProgressRing {
+  width: 36px;
+  height: 36px;
+  transform: rotate(-90deg);
+  overflow: visible;
+}
+
+.replyProgressBackdrop {
+  fill: none;
+  stroke: none;
+}
+
+.replyProgressTrack {
+  fill: none;
+  stroke: var(--ion-color-primary);
+  stroke-width: 2;
+  opacity: 0.25;
+}
+
+.replyProgressFill {
+  fill: none;
+  stroke: var(--ion-color-primary);
+  stroke-width: 2;
+  stroke-linecap: round;
+  transition: stroke 0.15s ease-out;
+  opacity: 0.5;
+}
+
+.replyProgressRipple {
+  fill: none;
+  stroke: var(--ion-color-primary);
+  stroke-width: 0.5;
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: replyRipple 0.5s ease-out forwards;
+}
+
+@keyframes replyRipple {
+  from {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  to {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+.replyIconBurst {
+  animation: replyIconBurst 0.4s ease-out;
+}
+
+@keyframes replyIconBurst {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(1.25);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 .chatRow {

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.module.scss
@@ -91,13 +91,13 @@
 }
 
 .chatRow {
-  --avatar-size: 36px;
+  /* --avatar-size defined at :root so SenderGroup can share it; --avatar-gap stays local. */
   --avatar-gap: 8px;
 
   display: flex;
   align-items: flex-end;
   gap: var(--avatar-gap);
-  padding: 4px 12px;
+  padding: 4px var(--avatar-column-gap);
 
   &.sent {
     flex-direction: row-reverse;
@@ -481,6 +481,10 @@
 .avatarSpacer {
   width: var(--avatar-size);
   flex-shrink: 0;
+  // The spacer only appears in sticky-avatar mode, where the floating avatar
+  // renders behind the (raised) message column. Let taps pass through so the
+  // avatar behind stays clickable.
+  pointer-events: none;
 }
 
 .messageWrapper {

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
@@ -1,6 +1,4 @@
 import { useRef, useState } from 'react';
-import { IonIcon } from '@ionic/react';
-import { arrowUndo } from 'ionicons/icons';
 import styles from './ChatBubble.module.scss';
 import { ChatBubbleBase, type ChatBubbleBaseProps } from './ChatBubbleBase';
 import { StickerBubble, type StickerBubbleProps } from './StickerBubble';
@@ -9,6 +7,9 @@ import { InviteBubble, type InviteBubbleProps } from './InviteBubble';
 const SWIPE_THRESHOLD = 60;
 const SWIPE_MAX = 80;
 const LONG_PRESS_DELAY_MS = 350;
+
+// Progress ring geometry: circle r=13 within a 36x36 viewBox.
+// const REPLY_RING_CIRCUMFERENCE = 2 * Math.PI * 13; // disabled: progress ring hidden
 
 type ChatBubbleInteractionProps = {
   swipeDirection?: 'left' | 'right';
@@ -94,6 +95,15 @@ export function ChatBubble(props: ChatBubbleProps) {
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const bubbleRef = useRef<HTMLDivElement>(null);
 
+  // Ripple feedback: replays an expanding pulse each time the swipe first
+  // crosses the release threshold. rippleKey forces the element to remount so
+  // the CSS animation restarts on every crossing.
+  // const [rippleKey, setRippleKey] = useState(0); // disabled: ripple pulse hidden
+  const reachedThreshold = useRef(false);
+  // Burst feedback: the reply icon briefly expands then snaps back when the
+  // progress ring fills, as if it launched the ripple outward.
+  const [bursting, setBursting] = useState(false);
+
   function clearLongPress() {
     if (longPressTimer.current) {
       clearTimeout(longPressTimer.current);
@@ -145,6 +155,17 @@ export function ChatBubble(props: ChatBubbleProps) {
       swiping.current = true;
       setOffset(clamped);
     }
+
+    // Fire the ripple once, on the rising edge of crossing the threshold.
+    if (clamped >= SWIPE_THRESHOLD) {
+      if (!reachedThreshold.current) {
+        reachedThreshold.current = true;
+        // setRippleKey((k) => k + 1); // disabled: ripple pulse hidden
+        setBursting(true);
+      }
+    } else {
+      reachedThreshold.current = false;
+    }
   }
 
   function onTouchEnd() {
@@ -168,29 +189,82 @@ export function ChatBubble(props: ChatBubbleProps) {
   }
 
   const progress = Math.min(offset / SWIPE_THRESHOLD, 1);
+  // Fill only starts after 50% of the threshold — maps progress [0.5,1] → [0,1]
+  const fillProgress = Math.max(0, progress * 2 - 1);
 
   return (
-    <div className={styles.swipeContainer}>
+    <div className={styles.swipeRoot}>
       <div
-        className={styles.replyIcon}
+        className={`${styles.replyIcon}${bursting ? ` ${styles.replyIconBurst}` : ''}`}
         style={{
           opacity: progress,
           transform: `scale(${0.5 + progress * 0.5})`,
           [swipeDirection === 'left' ? 'right' : 'left']: 16,
         }}
+        onAnimationEnd={() => setBursting(false)}
       >
-        <IonIcon icon={arrowUndo} />
+        <svg className={styles.replyProgressRing} viewBox="0 0 36 36" aria-hidden="true">
+          {/* Progress ring (backdrop / track / fill) — disabled, keep code for re-enabling
+          {progress < 1 && (
+            <>
+              <circle className={styles.replyProgressBackdrop} cx="18" cy="18" r="13" />
+              <circle className={styles.replyProgressTrack} cx="18" cy="18" r="13" />
+              <circle
+                className={styles.replyProgressFill}
+                cx="18"
+                cy="18"
+                r="13"
+                style={{
+                  strokeDasharray: REPLY_RING_CIRCUMFERENCE,
+                  strokeDashoffset: REPLY_RING_CIRCUMFERENCE * (1 - progress),
+                }}
+              />
+            </>
+          )}
+          */}
+          {/* Ripple pulse — disabled, keep code for re-enabling
+          {rippleKey > 0 && <circle key={rippleKey} className={styles.replyProgressRipple} cx="18" cy="18" r="13" />}
+          */}
+          {/* Reply arrow icon — exact arrowUndoOutline path, scaled to 36×36 viewBox */}
+          <g transform="translate(7, 7) scale(0.044) rotate(90, 256, 256)">
+            {/* Outline layer — always visible */}
+            <path
+              d="M240 424v-96c116.4 0 159.39 33.76 208 96 0-119.23-39.57-240-208-240V88L64 256Z"
+              stroke="currentColor"
+              fill="none"
+              strokeWidth="35"
+              strokeLinejoin="round"
+            />
+            {/* Filled layer — clipped by progress */}
+            <g
+              style={{
+                clipPath:
+                  swipeDirection === 'left'
+                    ? `inset(0 0 0 ${(1 - fillProgress) * 100}%)`
+                    : `inset(0 ${(1 - fillProgress) * 100}% 0 0)`,
+              }}
+            >
+              <path
+                d="M240 424v-96c116.4 0 159.39 33.76 208 96 0-119.23-39.57-240-208-240V88L64 256Z"
+                fill="currentColor"
+                stroke="none"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
-      <div
-        className={`${styles.swipeContent} ${animating ? styles.snapBack : ''}`}
-        style={{ transform: `translateX(${offset * swipeSign}px)` }}
-        onTouchStart={onTouchStart}
-        onTouchMove={onTouchMove}
-        onTouchEnd={onTouchEnd}
-        onContextMenu={handleContextMenu}
-        onTransitionEnd={() => setAnimating(false)}
-      >
-        {renderInnerBubble(props, bubbleRef)}
+      <div className={styles.swipeContainer}>
+        <div
+          className={`${styles.swipeContent} ${animating ? styles.snapBack : ''}`}
+          style={{ transform: `translateX(${offset * swipeSign}px)` }}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          onContextMenu={handleContextMenu}
+          onTransitionEnd={() => setAnimating(false)}
+        >
+          {renderInnerBubble(props, bubbleRef)}
+        </div>
       </div>
     </div>
   );

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubble.tsx
@@ -1,5 +1,6 @@
-import { useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import styles from './ChatBubble.module.scss';
+import { SenderSwipeContext } from './SenderSwipeContext';
 import { ChatBubbleBase, type ChatBubbleBaseProps } from './ChatBubbleBase';
 import { StickerBubble, type StickerBubbleProps } from './StickerBubble';
 import { InviteBubble, type InviteBubbleProps } from './InviteBubble';
@@ -14,6 +15,10 @@ const LONG_PRESS_DELAY_MS = 350;
 type ChatBubbleInteractionProps = {
   swipeDirection?: 'left' | 'right';
   onLongPress?: (rect: DOMRect, interactionPos?: { x: number; y: number }) => void;
+  /** True for the last message in a SenderGroup — only it reports its swipe to the
+   *  group so the floating avatar can follow. Non-last messages never move the
+   *  shared avatar. */
+  isLastInGroup?: boolean;
 };
 
 type StickerChatBubbleProps = StickerBubbleProps &
@@ -84,10 +89,29 @@ function renderInnerBubble(props: ChatBubbleProps, bubbleRef: React.RefObject<HT
 }
 
 export function ChatBubble(props: ChatBubbleProps) {
-  const { swipeDirection = 'left', onLongPress, onReply } = props;
+  const { swipeDirection = 'left', onLongPress, onReply, isLastInGroup } = props;
   const swipeSign = swipeDirection === 'left' ? -1 : 1;
+  const swipeCtx = useContext(SenderSwipeContext);
+
   const [offset, setOffset] = useState(0);
   const [animating, setAnimating] = useState(false);
+
+  // Report this bubble's live swipe offset to the SenderGroup so the floating
+  // avatar can mirror it — but only for the last message in the group. The group
+  // applies the transform directly to the avatar DOM node (no React state), so
+  // this stays 60fps even for large groups. When the context is null (search /
+  // read-only / showAllAvatars inline mode) this is a no-op.
+  useEffect(() => {
+    if (!isLastInGroup || !swipeCtx) return;
+    swipeCtx.reportSwipe(offset * swipeSign, animating);
+  }, [offset, animating, isLastInGroup, swipeCtx, swipeSign]);
+
+  // On unmount, release the avatar so it doesn't keep a stale transform.
+  useEffect(() => {
+    return () => {
+      if (isLastInGroup && swipeCtx) swipeCtx.reportSwipe(0, false);
+    };
+  }, [isLastInGroup, swipeCtx]);
   const startX = useRef(0);
   const startY = useRef(0);
   const swiping = useRef(false);

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState, type CSSProperties, type HTMLAttributes, type Ref } from 'react';
 import { IonIcon } from '@ionic/react';
 import {
-  arrowUndo,
   chatbubbles,
   checkmarkCircle,
   checkmarkCircleOutline,
@@ -12,6 +11,7 @@ import {
 import { t } from '@lingui/core/macro';
 import { useSelector } from 'react-redux';
 import styles from './ChatBubble.module.scss';
+import { HoverReplyButton } from './HoverReplyButton';
 import reactionStyles from './ReactionPill.module.scss';
 import { formatTime } from '@/utils/formatTime';
 import type { Attachment, MentionInfo, ReactionSummary, UserGroupTagInfo } from '@/api/messages';
@@ -528,11 +528,7 @@ export function ChatBubbleBase({
               <div className={styles.avatarSpacer} />
             )}
             {bubble}
-            {interactive && onReply && (
-              <button className={styles.hoverReplyBtn} onClick={onReply} aria-label={t`Reply`}>
-                <IonIcon icon={arrowUndo} />
-              </button>
-            )}
+            <HoverReplyButton interactive={interactive} onReply={onReply} />
           </div>
           {reactionsContent}
         </div>

--- a/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatBubbleBase.tsx
@@ -177,7 +177,9 @@ export function ChatBubbleBase({
     styles.attachmentsContainer,
     (styles as any).edgeToEdgeHorizontal,
     !hasTopContent ? (styles as any).edgeToEdgeTop : (styles as any).hasTopContent,
-    !hasBottomContent ? (styles as any).edgeToEdgeBottom : (styles as any).hasBottomContent,
+    // When a thread indicator follows the media grid, keep normal bottom spacing so the
+    // indicator's divider sits at the grid bottom instead of being pulled into it.
+    !hasBottomContent && !threadInfo ? (styles as any).edgeToEdgeBottom : (styles as any).hasBottomContent,
   ]
     .filter(Boolean)
     .join(' ');
@@ -460,7 +462,10 @@ export function ChatBubbleBase({
         </div>
       )}
       {threadInfo && (
-        <div className={styles.threadIndicator} onClick={interactive ? onThreadClick : undefined}>
+        <div
+          className={`${styles.threadIndicator} ${isMediaOnly ? (styles as any).threadIndicatorMediaOnly : ''}`}
+          onClick={interactive ? onThreadClick : undefined}
+        >
           <IonIcon icon={chatbubbles} />
           <span>
             {threadInfo.replyCount} {threadInfo.replyCount === 1 ? t`reply` : t`replies`}

--- a/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/ChatMessageRow.tsx
@@ -5,13 +5,17 @@ import { InviteMessageModal } from '@/components/invites/InviteMessageModal';
 import { ChatBubble } from './ChatBubble';
 import { type BubblePropsOverride } from './ChatBubbleBase';
 import { MessageDateSeparator } from './MessageDateSeparator';
+import { SenderGroup } from './SenderGroup';
 import { SystemMessage } from './SystemMessage';
+import { isInviteMessage, isStickerMessage } from './messageTypePredicates';
 import type { ChatRow } from '../virtualScroll/types';
 
-interface ChatMessageRowProps {
-  row: ChatRow;
-  currentUserId: number | string | null;
-  threadId?: string;
+/**
+ * Message-interaction callbacks shared by ChatMessageRow and MessageBubble.
+ * Declared once so a callback signature change propagates to both call sites
+ * via the type system instead of two parallel declarations.
+ */
+export interface ChatMessageHandlers {
   onReply: (message: MessageResponse) => void;
   onJumpToReply: (messageId: string) => void;
   onLongPress: (message: MessageResponse, rect: DOMRect, interactionPos?: { x: number; y: number }) => void;
@@ -21,18 +25,11 @@ interface ChatMessageRowProps {
   onStickerTap?: (stickerId: string) => void;
 }
 
-function isSystemMessage(message: MessageResponse): boolean {
-  return message.messageType === 'system';
+interface ChatMessageRowProps extends ChatMessageHandlers {
+  row: ChatRow;
+  currentUserId: number | string | null;
+  threadId?: string;
 }
-
-function isInviteMessage(message: MessageResponse): boolean {
-  return message.messageType === 'invite';
-}
-
-function isStickerMessage(message: MessageResponse): boolean {
-  return message.messageType === 'sticker';
-}
-
 export function ChatMessageRow({
   row,
   currentUserId,
@@ -45,33 +42,107 @@ export function ChatMessageRow({
   onReactionToggle,
   onStickerTap,
 }: ChatMessageRowProps) {
-  const [inviteCode, setInviteCode] = useState<string | null>(null);
-
   if (row.type === 'date') {
     return <MessageDateSeparator label={row.dateLabel} />;
   }
 
-  const msg = row.message;
-  const replyToMessage = msg.replyToMessage;
-  if (isSystemMessage(msg)) {
+  const { messages, useStickyAvatar, showName, isSystem } = row;
+
+  // System message groups render without an avatar container.
+  if (isSystem) {
+    const msg = messages[0];
     return <SystemMessage senderName={msg.sender.name} message={msg.isDeleted ? t`[Deleted]` : (msg.message ?? '')} />;
   }
 
+  const isSent = messages[0].sender.uid === currentUserId;
+
+  return (
+    <SenderGroup
+      useStickyAvatar={useStickyAvatar}
+      isSent={isSent}
+      sender={messages[0].sender}
+      onAvatarClick={onAvatarClick}
+    >
+      {messages.map((msg, index) => (
+        <MessageBubble
+          key={msg.clientGeneratedId || msg.id}
+          msg={msg}
+          index={index}
+          isSent={isSent}
+          useStickyAvatar={useStickyAvatar}
+          showName={showName}
+          threadId={threadId}
+          currentUserId={currentUserId}
+          onReply={onReply}
+          onJumpToReply={onJumpToReply}
+          onLongPress={onLongPress}
+          onAvatarClick={onAvatarClick}
+          onThreadClick={onThreadClick}
+          onReactionToggle={onReactionToggle}
+          onStickerTap={onStickerTap}
+          isLastInGroup={index === messages.length - 1}
+        />
+      ))}
+    </SenderGroup>
+  );
+}
+
+interface MessageBubbleProps extends ChatMessageHandlers {
+  msg: MessageResponse;
+  index: number;
+  isSent: boolean;
+  useStickyAvatar: boolean;
+  isLastInGroup: boolean;
+  showName: boolean;
+  threadId?: string;
+  currentUserId: number | string | null;
+}
+
+function MessageBubble({
+  msg,
+  index,
+  isSent,
+  useStickyAvatar,
+  isLastInGroup,
+  showName,
+  threadId,
+  currentUserId,
+  onReply,
+  onJumpToReply,
+  onLongPress,
+  onAvatarClick,
+  onThreadClick,
+  onReactionToggle,
+  onStickerTap,
+}: MessageBubbleProps) {
+  const [inviteCode, setInviteCode] = useState<string | null>(null);
+
+  const replyToMessage = msg.replyToMessage;
+
+  // Sticky avatar (group-level, handled by SenderGroup) vs inline avatar
+  // (per-message, shown when showAllAvatars is on) are one concept's two
+  // polarities; derive the local render flag from the single upstream value.
+  const showInlineAvatar = !useStickyAvatar;
+
+  // Only the group's first bubble shows the sender name.
+  const showNameOnBubble = showName && index === 0;
+
   const sharedBubbleProps = {
     senderName: msg.sender.name ?? `User ${msg.sender.uid}`,
-    isSent: msg.sender.uid === currentUserId,
+    isSent,
     avatarUrl: msg.sender.avatarUrl ?? undefined,
     onReply: () => onReply(msg),
     onReplyTap: replyToMessage && !replyToMessage.isDeleted ? () => onJumpToReply(replyToMessage.id) : undefined,
     onLongPress: (rect: DOMRect, interactionPos?: { x: number; y: number }) => onLongPress(msg, rect, interactionPos),
-    showAvatar: row.showAvatar,
+    showAvatar: showInlineAvatar,
     timestamp: msg.createdAt,
     edited: msg.isEdited,
     threadInfo: !threadId ? msg.threadInfo : undefined,
     onThreadClick: () => onThreadClick(msg),
     onAvatarClick: () => onAvatarClick(msg.sender),
+    isLastInGroup,
     isConfirmed: !msg.id.startsWith('cg_'),
-    bubbleProps: { 'data-message-id': msg.id } as BubblePropsOverride,
+    bubbleProps: { 'data-message-id': msg.id, 'data-bubble-row': '' } as BubblePropsOverride,
     replyTo: replyToMessage
       ? {
           senderName: replyToMessage.sender.name ?? `User ${replyToMessage.sender.uid}`,
@@ -88,7 +159,7 @@ export function ChatMessageRow({
           {...sharedBubbleProps}
           messageType="invite"
           inviteCode={code}
-          showName={row.showName}
+          showName={showNameOnBubble}
           onOpen={() => setInviteCode(code)}
         />
         <InviteMessageModal inviteCode={inviteCode} onDismiss={() => setInviteCode(null)} />
@@ -115,7 +186,7 @@ export function ChatMessageRow({
       senderGender={msg.sender.gender}
       senderGroup={msg.sender.userGroup}
       message={msg.isDeleted ? t`[Deleted]` : (msg.message ?? '')}
-      showName={row.showName}
+      showName={showNameOnBubble}
       attachments={msg.attachments}
       reactions={msg.reactions}
       onReactionToggle={(emoji, currentlyReacted) => onReactionToggle(msg, emoji, currentlyReacted)}

--- a/wetty-chat-mobile/src/components/chat/messages/HoverReplyButton.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/HoverReplyButton.tsx
@@ -1,0 +1,24 @@
+import { IonIcon } from '@ionic/react';
+import { t } from '@lingui/core/macro';
+import { arrowUndoOutline } from 'ionicons/icons';
+
+import styles from './ChatBubble.module.scss';
+
+interface HoverReplyButtonProps {
+  interactive: boolean;
+  onReply?: () => void;
+}
+
+/**
+ * Desktop-only reply affordance that appears on bubble hover.
+ * Shared by ChatBubbleBase, InviteBubble and StickerBubble — keep in sync
+ * with the `.chatRow:hover .hoverReplyBtn` rule in ChatBubble.module.scss.
+ */
+export function HoverReplyButton({ interactive, onReply }: HoverReplyButtonProps) {
+  if (!interactive || !onReply) return null;
+  return (
+    <button className={styles.hoverReplyBtn} onClick={onReply} aria-label={t`Reply`}>
+      <IonIcon icon={arrowUndoOutline} />
+    </button>
+  );
+}

--- a/wetty-chat-mobile/src/components/chat/messages/InviteBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteBubble.tsx
@@ -1,11 +1,12 @@
 import type { Ref } from 'react';
 import { IonIcon } from '@ionic/react';
-import { arrowUndo, chatbubbles } from 'ionicons/icons';
+import { chatbubbles } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import type { User } from '@/api/messages';
 import { useMouseDetected } from '@/hooks/platformHooks';
 import { InviteMessageCard } from './InviteMessageCard';
 import styles from './ChatBubble.module.scss';
+import { HoverReplyButton } from './HoverReplyButton';
 import type { BubblePropsOverride } from './ChatBubbleBase';
 
 export interface InviteBubbleProps {
@@ -88,11 +89,7 @@ export function InviteBubble({
   return (
     <div className={`${styles.chatRow} ${isSent ? styles.sent : styles.received}`}>
       {bubble}
-      {interactive && onReply && (
-        <button className={styles.hoverReplyBtn} onClick={onReply} aria-label={t`Reply`}>
-          <IonIcon icon={arrowUndo} />
-        </button>
-      )}
+      <HoverReplyButton interactive={interactive} onReply={onReply} />
     </div>
   );
 }

--- a/wetty-chat-mobile/src/components/chat/messages/InviteBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteBubble.tsx
@@ -2,9 +2,9 @@ import type { Ref } from 'react';
 import { IonIcon } from '@ionic/react';
 import { chatbubbles } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
-import type { User } from '@/api/messages';
 import { useMouseDetected } from '@/hooks/platformHooks';
 import { InviteMessageCard } from './InviteMessageCard';
+import { UserAvatar } from '@/components/UserAvatar';
 import styles from './ChatBubble.module.scss';
 import { HoverReplyButton } from './HoverReplyButton';
 import type { BubblePropsOverride } from './ChatBubbleBase';
@@ -33,7 +33,6 @@ export function InviteBubble({
   senderName,
   isSent,
   avatarUrl,
-  showName = true,
   showAvatar = true,
   onOpen,
   onReply,
@@ -50,8 +49,6 @@ export function InviteBubble({
   const interactive = interactionMode === 'interactive';
   const { className: bubbleClassName, style: bubbleStyle, ...bubbleRestProps } = bubblePropOverrides ?? {};
 
-  const sender: User = { uid: 0, name: senderName, avatarUrl, gender: 0 };
-
   const bubble = (
     <div
       ref={bubbleRef}
@@ -63,12 +60,8 @@ export function InviteBubble({
     >
       <InviteMessageCard
         inviteCode={inviteCode}
-        sender={sender}
         isSent={isSent}
-        showName={showName}
-        showAvatar={showAvatar}
         timestamp={timestamp ?? ''}
-        onAvatarClick={interactive ? onAvatarClick : undefined}
         onOpen={interactive && onOpen ? onOpen : () => {}}
       />
       {threadInfo && (
@@ -88,8 +81,23 @@ export function InviteBubble({
 
   return (
     <div className={`${styles.chatRow} ${isSent ? styles.sent : styles.received}`}>
-      {bubble}
-      <HoverReplyButton interactive={interactive} onReply={onReply} />
+      <div className={styles.messageColumn}>
+        <div className={styles.avatarBubbleRow}>
+          {showAvatar ? (
+            <UserAvatar
+              name={senderName}
+              avatarUrl={avatarUrl}
+              size={36}
+              className={styles.avatar}
+              onClick={interactive ? onAvatarClick : undefined}
+            />
+          ) : (
+            <div className={styles.avatarSpacer} />
+          )}
+          {bubble}
+          <HoverReplyButton interactive={interactive} onReply={onReply} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
@@ -28,8 +28,8 @@
 }
 
 .avatarSpacer {
-  width: 36px;
-  flex: 0 0 36px;
+  width: var(--avatar-size);
+  flex: 0 0 var(--avatar-size);
 }
 
 .content {

--- a/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.module.scss
@@ -1,43 +1,9 @@
-.row {
-  display: flex;
-  align-items: flex-end;
-  gap: 8px;
-  padding: 2px 12px;
-}
-
-.rowSent {
-  justify-content: flex-end;
-}
-
-.rowSent .avatarButton,
-.rowSent .avatarSpacer {
-  order: 2;
-}
-
-.rowSent .content {
-  order: 1;
-}
-
-.avatarButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: none;
-  background: transparent;
-}
-
-.avatarSpacer {
-  width: var(--avatar-size);
-  flex: 0 0 var(--avatar-size);
-}
-
 .content {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 4px;
-  width: min(85%, 360px);
+  width: 100%;
   min-width: 0;
 }
 
@@ -51,13 +17,6 @@
 .sentRow {
   flex-direction: row-reverse;
   align-items: flex-end;
-}
-
-.senderName {
-  padding: 0 8px;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--ion-color-medium-shade);
 }
 
 .card {

--- a/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/InviteMessageCard.tsx
@@ -3,20 +3,15 @@ import { IonCard, IonCardHeader, IonCardSubtitle, IonIcon, IonItem, IonLabel, Io
 import { chevronForward, mailOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
-import type { User } from '@/api/messages';
-import { UserAvatar } from '@/components/UserAvatar';
 import { useInvitePreview } from '@/components/invites/useInvitePreview';
+import { UserAvatar } from '@/components/UserAvatar';
 import styles from './InviteMessageCard.module.scss';
 import { formatTime } from '@/utils/formatTime';
 
 interface InviteMessageCardProps {
   inviteCode: string;
-  sender: User;
   isSent: boolean;
-  showName: boolean;
-  showAvatar: boolean;
   timestamp: string;
-  onAvatarClick?: () => void;
   onOpen: () => void;
 }
 
@@ -60,18 +55,8 @@ function InviteCardBody({ viewState }: { viewState: CardBodyViewState }) {
   );
 }
 
-export function InviteMessageCard({
-  inviteCode,
-  sender,
-  isSent,
-  showName,
-  showAvatar,
-  timestamp,
-  onAvatarClick,
-  onOpen,
-}: InviteMessageCardProps) {
+export function InviteMessageCard({ inviteCode, isSent, timestamp, onOpen }: InviteMessageCardProps) {
   const { previewState, preview, displayName } = useInvitePreview(inviteCode);
-  const senderName = sender.name ?? `User ${sender.uid}`;
   let bodyViewState: CardBodyViewState;
   const inviteAvailable = previewState.kind === 'loaded' && !!preview;
 
@@ -97,37 +82,25 @@ export function InviteMessageCard({
   }
 
   return (
-    <div className={`${styles.row} ${isSent ? styles.rowSent : ''}`}>
-      {showAvatar ? (
-        <button type="button" className={styles.avatarButton} onClick={onAvatarClick}>
-          <UserAvatar name={senderName} avatarUrl={sender.avatarUrl} size={36} />
+    <div className={styles.content}>
+      <div className={`${styles.cardRow} ${isSent ? styles.sentRow : ''}`}>
+        <button
+          type="button"
+          className={`${styles.card} ${!inviteAvailable ? styles.cardDisabled : ''}`}
+          onClick={inviteAvailable ? onOpen : undefined}
+          disabled={!inviteAvailable}
+        >
+          <IonCard className={styles.ionCard}>
+            <IonCardHeader className={styles.cardHeader}>
+              <IonCardSubtitle className={styles.cardSubtitle}>
+                <IonIcon icon={mailOutline} />
+                <Trans>Group invite</Trans>
+              </IonCardSubtitle>
+            </IonCardHeader>
+            <InviteCardBody viewState={bodyViewState} />
+          </IonCard>
+          {timestamp && <span className={styles.inviteTimestamp}>{formatTime(timestamp)}</span>}
         </button>
-      ) : (
-        <div className={styles.avatarSpacer} />
-      )}
-
-      <div className={`${styles.content} inviteContent`}>
-        {showName && !isSent && <div className={styles.senderName}>{senderName}</div>}
-
-        <div className={`${styles.cardRow} ${isSent ? styles.sentRow : ''}`}>
-          <button
-            type="button"
-            className={`${styles.card} ${!inviteAvailable ? styles.cardDisabled : ''}`}
-            onClick={inviteAvailable ? onOpen : undefined}
-            disabled={!inviteAvailable}
-          >
-            <IonCard className={styles.ionCard}>
-              <IonCardHeader className={styles.cardHeader}>
-                <IonCardSubtitle className={styles.cardSubtitle}>
-                  <IonIcon icon={mailOutline} />
-                  <Trans>Group invite</Trans>
-                </IonCardSubtitle>
-              </IonCardHeader>
-              <InviteCardBody viewState={bodyViewState} />
-            </IonCard>
-            {timestamp && <span className={styles.inviteTimestamp}>{formatTime(timestamp)}</span>}
-          </button>
-        </div>
       </div>
     </div>
   );

--- a/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/MessageOverlay.module.scss
@@ -59,7 +59,7 @@
 }
 
 .bubbleClone {
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.28);
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.28));
 }
 
 /* Reaction bar */

--- a/wetty-chat-mobile/src/components/chat/messages/ReactionPill.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/ReactionPill.module.scss
@@ -72,5 +72,6 @@
 .reactorOverflow {
   font-size: 11px;
   margin-left: 2px;
+  margin-right: 4px;
   opacity: 0.7;
 }

--- a/wetty-chat-mobile/src/components/chat/messages/SenderGroup.module.scss
+++ b/wetty-chat-mobile/src/components/chat/messages/SenderGroup.module.scss
@@ -1,0 +1,62 @@
+.root {
+  position: relative;
+  width: 100%;
+}
+
+// Absolutely-positioned container spanning the whole group. The avatar inside is
+// position:sticky; bottom, so it tracks the viewport bottom while the group is
+// in view and rests at the group's last message when settled. Modeled on
+// telegram-tt's SenderGroupContainer .avatarContainer.
+.avatarContainer {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  bottom: 0;
+  left: var(--avatar-column-gap); // aligns with .chatRow horizontal padding
+  display: flex;
+  flex-direction: column-reverse; // sticky bottom: avatar rests at the bottom of the group
+  pointer-events: none; // container doesn't block message taps; avatar re-enables
+}
+
+// Own (sent) messages render row-reverse, so the avatar column is on the right.
+.sent {
+  left: auto;
+  right: var(--avatar-column-gap);
+}
+
+.avatar {
+  position: sticky;
+  bottom: 0; // 0 (not a gap): a sticky `bottom` gap only offsets the avatar while it is "stuck"
+  // (long groups mid-scroll), which would misalign short groups that rest in the
+  // clamped state. With bottom:0 the avatar rests flush with the last bubble's
+  // bottom in every state; the container's measured `bottom` offset handles the
+  // reaction-pill exclusion.
+  pointer-events: auto;
+}
+
+// In-flow column holding the message bubbles. The avatar container is
+// absolutely positioned, so this is the sole in-flow child determining the
+// group's height.
+.messageColumn {
+  width: 100%;
+}
+
+// Received groups render the message column above the sticky avatar
+// (.avatarContainer z-index:2) so a left-swiping bubble paints OVER the floating
+// avatar instead of under it. The avatar stays tappable: the per-row avatarSpacer
+// (ChatBubble.module.scss) is pointer-events:none, so taps fall through to the
+// avatar behind. Sent groups omit this class, keeping the avatar on top — sent
+// swipes move the bubble away from the right-side avatar, so no overlap either way.
+.messageColumnAbove {
+  position: relative;
+  z-index: 3;
+}
+
+// Zero-height sentinel placed at the bottom of .messageColumn. An
+// IntersectionObserver watches it: when it intersects the viewport the group's
+// bottom is visible, so the sticky avatar is at rest (aligned with the last
+// message) and the avatar may slide with a swipe on that last message. When the
+// sentinel is out of view the group is still mid-scroll and the avatar stays put.
+.sentinel {
+  height: 0;
+}

--- a/wetty-chat-mobile/src/components/chat/messages/SenderGroup.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/SenderGroup.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { UserAvatar } from '@/components/UserAvatar';
+import type { User } from '@/api/messages';
+import { SenderSwipeContext } from './SenderSwipeContext';
+import styles from './SenderGroup.module.scss';
+
+interface SenderGroupProps {
+  /** Whether the group renders the sticky avatar (true when showAllAvatars is off). */
+  useStickyAvatar: boolean;
+  isSent: boolean;
+  sender: User;
+  onAvatarClick: (sender: User) => void;
+  children: ReactNode;
+}
+
+/**
+ * Wraps a consecutive run of messages from one sender. The avatar lives in an
+ * absolutely-positioned container spanning the whole group; the avatar itself is
+ * `position: sticky; bottom`, so it tracks the viewport bottom while the group is
+ * in view and rests at the group's last message when settled. Pure CSS — no JS
+ * scroll tracking, no handoff logic. Modeled on telegram-tt's SenderGroupContainer.
+ *
+ * Resting offset: reaction pills render below the last bubble *in flow*, which
+ * would otherwise make the avatar rest at pill level. To keep the avatar aligned
+ * with the last bubble's bottom, the avatar container's `bottom` is offset by the
+ * measured height of everything below the last bubble row (reactions + padding).
+ */
+
+// Matches ChatBubble's `.snapBack` transition so the avatar's snap-back stays
+// in sync with the bubble's.
+const SNAP_BACK_TRANSITION = 'transform 0.2s ease-out';
+
+export function SenderGroup({ useStickyAvatar, isSent, sender, onAvatarClick, children }: SenderGroupProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [avatarContainerBottom, setAvatarContainerBottom] = useState(0);
+
+  // The avatar follows the last message's swipe — but only when the group is at
+  // rest (avatar settled at the last message). Mutated directly on the DOM via
+  // `avatarRef` to avoid re-rendering the whole group (and its N ChatBubbles) on
+  // every touchmove frame. `avatarAtRestRef` is the gate; the sentinel's
+  // IntersectionObserver flips it (in-view = group bottom visible = at rest).
+  const avatarRef = useRef<HTMLDivElement>(null);
+  const avatarAtRestRef = useRef(true);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const compute = () => {
+      // The last bubble row in DOM order is the group's last message. Its bottom
+      // is where the avatar should rest (excluding any reaction pills below it).
+      const bubbleRows = root.querySelectorAll<HTMLElement>('[data-bubble-row]');
+      const lastBubbleRow = bubbleRows[bubbleRows.length - 1];
+      if (!lastBubbleRow) {
+        setAvatarContainerBottom(0);
+        return;
+      }
+      const rootRect = root.getBoundingClientRect();
+      const lastBubbleRect = lastBubbleRow.getBoundingClientRect();
+      const tailBelowLastBubble = Math.max(0, rootRect.bottom - lastBubbleRect.bottom);
+      // Offset the avatar container so its bottom edge sits exactly at the last
+      // bubble's bottom. Combined with the sticky avatar's `bottom: 0`, this makes
+      // the avatar rest flush with the last bubble's bottom in every state — short
+      // groups (resting/clamped), long groups (stuck while scrolling), and the
+      // group-end handoff. A sticky `bottom` gap would only apply while the avatar
+      // is "stuck" (long groups mid-scroll), leaving short groups misaligned, so
+      // the gap must be 0 for consistent resting alignment.
+      setAvatarContainerBottom(Math.max(0, tailBelowLastBubble));
+    };
+
+    compute();
+    // Recompute on any size change (reaction added/removed, bubble reflow, new
+    // messages appended to the group).
+    const ro = new ResizeObserver(compute);
+    ro.observe(root);
+    return () => ro.disconnect();
+  }, [useStickyAvatar]);
+
+  // Track whether the group's bottom is in the viewport. When it is, the sticky
+  // avatar has settled at the last message and should slide with that message's
+  // swipe. When it isn't (long group, avatar still stuck higher), keep it static.
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        avatarAtRestRef.current = entry.isIntersecting;
+        // Leaving the rest state: drop any in-flight transform so the avatar
+        // snaps back to its sticky (non-swiped) position immediately.
+        if (!entry.isIntersecting && avatarRef.current) {
+          avatarRef.current.style.transform = '';
+          avatarRef.current.style.transition = '';
+        }
+      },
+      // root: null = viewport. The chat scroll surface is viewport-sized.
+      { threshold: 0 },
+    );
+    io.observe(sentinel);
+    return () => io.disconnect();
+  }, []);
+
+  // Only the last message reports; its updates drive the avatar transform. Mutates
+  // the DOM directly (no state) so swiping stays 60fps regardless of group size.
+  const reportSwipe = useCallback((transformPx: number, animating: boolean) => {
+    const el = avatarRef.current;
+    if (!el || !avatarAtRestRef.current) return;
+    el.style.transform = transformPx !== 0 ? `translateX(${transformPx}px)` : '';
+    el.style.transition = animating ? SNAP_BACK_TRANSITION : '';
+  }, []);
+
+  if (!useStickyAvatar) {
+    // showAllAvatars on: every message renders its own inline avatar (handled
+    // inside each ChatBubble), so this container adds nothing. The swipe context
+    // is null → ChatBubble's reporting noops.
+    return <>{children}</>;
+  }
+
+  const senderName = sender.name ?? `User ${sender.uid}`;
+  const containerClass = `${styles.avatarContainer}${isSent ? ` ${styles.sent}` : ''}`;
+  // Received: raise the message column above the sticky avatar so a left-swiping
+  // bubble slides OVER the floating avatar. Sent keeps the avatar on top (sent
+  // swipes move the bubble away from the right-side avatar, so no overlap).
+
+  return (
+    <div ref={rootRef} className={styles.root}>
+      <div className={containerClass} style={{ bottom: avatarContainerBottom }}>
+        <UserAvatar
+          ref={avatarRef}
+          name={senderName}
+          avatarUrl={sender.avatarUrl ?? undefined}
+          className={styles.avatar}
+          onClick={() => onAvatarClick(sender)}
+        />
+      </div>
+      <div className={`${styles.messageColumn}${!isSent ? ` ${styles.messageColumnAbove}` : ''}`}>
+        <SenderSwipeContext.Provider value={{ reportSwipe }}>{children}</SenderSwipeContext.Provider>
+        <div ref={sentinelRef} className={styles.sentinel} aria-hidden="true" />
+      </div>
+    </div>
+  );
+}

--- a/wetty-chat-mobile/src/components/chat/messages/SenderSwipeContext.ts
+++ b/wetty-chat-mobile/src/components/chat/messages/SenderSwipeContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from 'react';
+
+/**
+ * Reports the live swipe transform of the group's LAST message bubble up to the
+ * SenderGroup, so the floating sticky avatar can slide horizontally together
+ * with that bubble — but only when the group is at rest (avatar aligned with the
+ * last message). SenderGroup applies the transform; non-last messages and groups
+ * whose avatar is still stuck mid-scroll keep the avatar static.
+ *
+ * `transformPx` is the already-signed translateX (offset * swipeSign), so the
+ * avatar mirrors the bubble exactly. `animating` mirrors the `.snapBack` flag so
+ * the snap-back transition stays in sync.
+ */
+export interface SenderSwipeContextValue {
+  reportSwipe: (transformPx: number, animating: boolean) => void;
+}
+
+export const SenderSwipeContext = createContext<SenderSwipeContextValue | null>(null);

--- a/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
@@ -1,10 +1,11 @@
 import type { Ref } from 'react';
 import { IonIcon } from '@ionic/react';
-import { arrowUndo, chatbubbles, checkmarkCircle, checkmarkCircleOutline } from 'ionicons/icons';
+import { chatbubbles, checkmarkCircle, checkmarkCircleOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
 import { StickerImage } from '@/components/shared/StickerImage';
 import { useSelector } from 'react-redux';
 import styles from './ChatBubble.module.scss';
+import { HoverReplyButton } from './HoverReplyButton';
 import { formatMessagePreview, type PreviewMessage, getNotificationPreviewLabels } from '@/utils/messagePreview';
 import { selectEffectiveLocale } from '@/store/settingsSlice';
 import { UserAvatar } from '@/components/UserAvatar';
@@ -131,11 +132,7 @@ export function StickerBubble({
         <div className={styles.avatarSpacer} />
       )}
       {bubble}
-      {interactive && onReply && (
-        <button className={styles.hoverReplyBtn} onClick={onReply} aria-label={t`Reply`}>
-          <IonIcon icon={arrowUndo} />
-        </button>
-      )}
+      <HoverReplyButton interactive={interactive} onReply={onReply} />
     </div>
   );
 }

--- a/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
+++ b/wetty-chat-mobile/src/components/chat/messages/StickerBubble.tsx
@@ -1,4 +1,4 @@
-import type { Ref } from 'react';
+import { useState, type Ref } from 'react';
 import { IonIcon } from '@ionic/react';
 import { chatbubbles, checkmarkCircle, checkmarkCircleOutline } from 'ionicons/icons';
 import { t } from '@lingui/core/macro';
@@ -64,6 +64,7 @@ export function StickerBubble({
   const locale = useSelector(selectEffectiveLocale);
   const interactive = interactionMode === 'interactive';
   const { className: bubbleClassName, style: bubbleStyle, ...bubbleRestProps } = bubblePropOverrides ?? {};
+  const [loaded, setLoaded] = useState(false);
 
   const bubble = (
     <div
@@ -91,9 +92,11 @@ export function StickerBubble({
           alt={t`Sticker`}
           className={styles.stickerImage}
           onClick={interactive && onStickerTap ? onStickerTap : undefined}
+          onLoad={() => setLoaded(true)}
+          onLoadedData={() => setLoaded(true)}
           style={interactive && onStickerTap ? { cursor: 'pointer' } : undefined}
         />
-        {timestamp && (
+        {loaded && timestamp && (
           <span className={styles.stickerTimestamp}>
             {formatTime(timestamp)}
             {edited && ` (${t`Edited`})`}

--- a/wetty-chat-mobile/src/components/chat/messages/messageTypePredicates.ts
+++ b/wetty-chat-mobile/src/components/chat/messages/messageTypePredicates.ts
@@ -1,0 +1,23 @@
+import type { MessageResponse } from '@/api/messages';
+
+/**
+ * Message-type discriminators shared across the chat layer (row grouping in
+ * useChatRows, bubble-kind dispatch in ChatMessageRow, etc.). Centralised so a
+ * new message kind has exactly one place to update before rippling out.
+ *
+ * Note: `messageType` is also compared inline in render-time modules
+ * (ChatBubble, MessageOverlay, messagePreview, …). Those comparisons are
+ * local to a single rendering path and are migrated separately; grouping and
+ * bubble-kind decisions flow through these helpers.
+ */
+export function isSystemMessage(message: MessageResponse): boolean {
+  return message.messageType === 'system';
+}
+
+export function isInviteMessage(message: MessageResponse): boolean {
+  return message.messageType === 'invite';
+}
+
+export function isStickerMessage(message: MessageResponse): boolean {
+  return message.messageType === 'sticker';
+}

--- a/wetty-chat-mobile/src/components/chat/pins/PinListModal.tsx
+++ b/wetty-chat-mobile/src/components/chat/pins/PinListModal.tsx
@@ -11,6 +11,7 @@ import type { PinResponse } from '@/api/pins';
 import { deletePin } from '@/api/pins';
 import { formatMessagePreview, getNotificationPreviewLabels } from '@/utils/messagePreview';
 import styles from './PinListModal.module.scss';
+import { useIsDesktop } from '@/hooks/platformHooks';
 
 interface PinListModalProps {
   chatId: string;
@@ -22,6 +23,7 @@ interface PinListModalProps {
 
 export function PinListModal({ chatId, isOpen, onDismiss, onSelectPin, onSelectThread }: PinListModalProps) {
   const [presentAlert] = useIonAlert();
+  const isDesktop = useIsDesktop();
   const { role } = useChatRole(chatId);
   const isAdmin = role === 'admin';
   const pins = useSelector((state: RootState) => selectPinsForChat(state, chatId));
@@ -67,7 +69,11 @@ export function PinListModal({ chatId, isOpen, onDismiss, onSelectPin, onSelectT
   );
 
   return (
-    <IonModal isOpen={isOpen} onDidDismiss={onDismiss} initialBreakpoint={0.5} breakpoints={[0, 0.5, 0.75]}>
+    <IonModal
+      isOpen={isOpen}
+      onDidDismiss={onDismiss}
+      {...(!isDesktop ? { initialBreakpoint: 0.5, breakpoints: [0, 0.5, 0.75] } : {})}
+    >
       <IonContent>
         <div className={styles.header}>
           <span className={styles.title}>{t`Pinned Messages`}</span>

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.dom.test.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.dom.test.tsx
@@ -93,14 +93,15 @@ function rows(count: number): ChatRow[] {
   return Array.from({ length: count }, (_, index) => {
     const id = String(index + 1);
     return {
-      type: 'message',
-      key: `msg:${id}`,
-      messageId: id,
-      clientGeneratedId: `client-${id}`,
-      message: message(id),
+      type: 'group',
+      key: `grp:${id}`,
+      messages: [message(id)],
+      firstMessageId: id,
+      lastMessageId: id,
+      isSystem: false,
       showName: true,
-      showAvatar: true,
-    };
+      useStickyAvatar: true,
+    } satisfies ChatRow;
   });
 }
 
@@ -113,9 +114,9 @@ function renderVirtualScroll(
     <ChatVirtualScroll
       rows={nextRows}
       renderRow={(row) =>
-        row.type === 'message' ? (
-          <div data-testid={row.key} data-row-index={Number(row.messageId) - 1}>
-            {row.message.message}
+        row.type === 'group' ? (
+          <div data-testid={row.key} data-row-index={Number(row.firstMessageId) - 1}>
+            {row.messages[0].message}
           </div>
         ) : (
           <div data-testid={row.key}>{row.dateLabel}</div>
@@ -244,7 +245,7 @@ describe('ChatVirtualScroll realtime appends', () => {
     await flushLayout();
     currentViewportHeight = VIEWPORT_HEIGHT;
     await flushLayout(8);
-    expect(host.querySelector('[data-testid="msg:40"]')).not.toBeNull();
+    expect(host.querySelector('[data-testid="grp:40"]')).not.toBeNull();
 
     await act(async () => {
       scrollContainer!.scrollTop = 24 * ROW_HEIGHT;

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -210,8 +210,12 @@ export function ChatVirtualScroll({
   const messageIdToTarget = useMemo(() => {
     const map = new Map<string, { key: string; index: number }>();
     rows.forEach((row, index) => {
-      if (row.type !== 'message') return;
-      map.set(row.messageId, { key: row.key, index });
+      if (row.type !== 'group') return;
+      // Map every messageId in the group to the group's row so that
+      // scrollToMessageId / resolveMessageTarget land on the containing group.
+      for (const msg of row.messages) {
+        map.set(msg.id, { key: row.key, index });
+      }
     });
     return map;
   }, [rows]);
@@ -435,12 +439,11 @@ export function ChatVirtualScroll({
 
     const containerRect = container.getBoundingClientRect();
     const mounted = mountedRef.current;
-    let nextMessageId: string | null = null;
+    let lastFullyVisibleId: string | null = null;
     let firstMessageId: string | null = null;
     let firstMessageIndex: number | null = null;
     let nextTopDateColliding = false;
     let nextHiddenDateRowKey: string | null = null;
-
     if (mounted) {
       const overlayHeight = overlayHeightRef.current || TOP_DATE_OVERLAY_FALLBACK_HEIGHT;
       const floatingTop = TOP_DATE_FLOATING_GAP_PX;
@@ -455,25 +458,30 @@ export function ChatVirtualScroll({
 
         const rowRect = rowNode.getBoundingClientRect();
         if (rowRect.height <= 0) continue;
-
-        if (row.type === 'message') {
+        if (row.type === 'group') {
           const fullyVisible = rowRect.bottom <= containerRect.bottom + 0.5;
           const partiallyVisible = rowRect.bottom > containerRect.top && rowRect.top < containerRect.bottom;
 
           if (partiallyVisible) {
-            firstMessageId = row.messageId;
+            // The topmost partially-visible group drives loadOlder / scroll-direction.
+            firstMessageId = row.firstMessageId;
             firstMessageIndex = index;
           }
 
-          if (fullyVisible && nextMessageId === null) {
-            nextMessageId = row.messageId;
+          // A fully-visible group ⇒ its last message is fully visible (the avatar
+          // rests at the group's bottom). lastFullyVisibleMessageId drives read
+          // receipts, so report the group's last message id.
+          if (fullyVisible && lastFullyVisibleId === null) {
+            lastFullyVisibleId = row.lastMessageId;
           }
-        } else if (row.type === 'date' && !nextTopDateColliding) {
-          const distanceFromTop = rowRect.top - containerRect.top;
-          const distanceBottom = distanceFromTop + rowRect.height;
-          const MARGIN = 1;
-          if (distanceBottom + MARGIN >= floatingTop && distanceFromTop - MARGIN <= floatingBottom) {
-            nextTopDateColliding = true;
+        } else if (row.type === 'date') {
+          if (!nextTopDateColliding) {
+            const distanceFromTop = rowRect.top - containerRect.top;
+            const distanceBottom = distanceFromTop + rowRect.height;
+            const MARGIN = 1;
+            if (distanceBottom + MARGIN >= floatingTop && distanceFromTop - MARGIN <= floatingBottom) {
+              nextTopDateColliding = true;
+            }
           }
         }
       }
@@ -501,9 +509,9 @@ export function ChatVirtualScroll({
       onTopDateCollidingChange?.(nextTopDateColliding);
     }
 
-    if (nextMessageId !== lastFullyVisibleMessageIdRef.current) {
-      lastFullyVisibleMessageIdRef.current = nextMessageId;
-      onLastFullyVisibleMessageChange?.(nextMessageId);
+    if (lastFullyVisibleId !== lastFullyVisibleMessageIdRef.current) {
+      lastFullyVisibleMessageIdRef.current = lastFullyVisibleId;
+      onLastFullyVisibleMessageChange?.(lastFullyVisibleId);
     }
 
     if (firstMessageId !== firstVisibleMessageIdRef.current) {
@@ -1116,7 +1124,7 @@ export function ChatVirtualScroll({
       const index = keyToIndex.get(key);
       if (index == null) return;
       const rowModel = rows[index];
-      const attachments = rowModel?.type === 'message' ? (rowModel.message.attachments ?? []) : [];
+      const attachments = rowModel?.type === 'group' ? rowModel.messages.flatMap((m) => m.attachments ?? []) : [];
       const hasAttachments = attachments.length > 0;
       const hasUnknownAttachmentDimensions = attachments.some(
         (attachment) =>
@@ -1198,8 +1206,14 @@ export function ChatVirtualScroll({
           strategy: 'natural-reflow',
         });
       }
+      // Row geometry changed (image loaded, content reflow). Recompute the
+      // last-visible / floating-avatar state so coverage doesn't lag a frame
+      // behind the new layout — the natural-reflow path (preserveContribution
+      // === 0) doesn't touch scrollTop, so without this the stale geometry
+      // would persist until the next user scroll.
+      updateLastFullyVisibleMessage();
     },
-    [keyToIndex, rows, scheduleBottomSettle, scrollToBottomInternal],
+    [keyToIndex, rows, scheduleBottomSettle, scrollToBottomInternal, updateLastFullyVisibleMessage],
   );
 
   const handleScrollIdle = useCallback(() => {

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/ChatVirtualScroll.tsx
@@ -659,7 +659,7 @@ export function ChatVirtualScroll({
       const row = rowRefsMap.current.get(key);
       if (!key || !row) continue;
 
-      if (key.startsWith('msg:') && !firstMountedMessage) {
+      if (key.startsWith('grp:') && !firstMountedMessage) {
         firstMountedMessage = { key, offsetTop: roundScrollValue(row.offsetTop) };
       }
 
@@ -667,7 +667,7 @@ export function ChatVirtualScroll({
       if (rect.bottom <= containerRect.top || rect.top >= containerRect.bottom) continue;
 
       const anchor = { key, offsetTop: roundScrollValue(rect.top - containerRect.top) };
-      if (key.startsWith('msg:')) {
+      if (key.startsWith('grp:')) {
         firstVisibleMessage = anchor;
         break;
       }

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/VirtualScroll.md
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/VirtualScroll.md
@@ -47,8 +47,8 @@ This is a direct replacement behind the existing `ChatVirtualScroll` API.
 Key rules:
 
 - date rows keep stable `date:` / `datefirst:` keys
-- message rows keep stable `msg:${client_generated_id || id}` keys
-- mutation classification uses `msg:` keys only
+- group rows keep stable `grp:${clientGeneratedId || id}` keys
+- mutation classification uses `grp:` keys only
 
 The row model in `useChatRows()` stays as-is.
 

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.test.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.test.ts
@@ -10,10 +10,10 @@ import {
 
 describe('virtual scroll layout math', () => {
   it('classifies message-key mutations while ignoring date rows', () => {
-    expect(classifyKeyMutation(['date:a', 'msg:1', 'msg:2'], ['date:a', 'msg:1', 'msg:2'])).toBe('none');
-    expect(classifyKeyMutation(['msg:3', 'msg:4'], ['msg:1', 'msg:2', 'msg:3', 'msg:4'])).toBe('prepend');
-    expect(classifyKeyMutation(['msg:1', 'msg:2'], ['msg:1', 'msg:2', 'date:b', 'msg:3'])).toBe('append');
-    expect(classifyKeyMutation(['msg:1', 'msg:3'], ['msg:1', 'msg:2', 'msg:3'])).toBe('reset');
+    expect(classifyKeyMutation(['date:a', 'grp:1', 'grp:2'], ['date:a', 'grp:1', 'grp:2'])).toBe('none');
+    expect(classifyKeyMutation(['grp:3', 'grp:4'], ['grp:1', 'grp:2', 'grp:3', 'grp:4'])).toBe('prepend');
+    expect(classifyKeyMutation(['grp:1', 'grp:2'], ['grp:1', 'grp:2', 'date:b', 'grp:3'])).toBe('append');
+    expect(classifyKeyMutation(['grp:1', 'grp:3'], ['grp:1', 'grp:2', 'grp:3'])).toBe('reset');
   });
 
   it('normalizes, unions, and caps mounted ranges', () => {

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/layoutMath.ts
@@ -25,8 +25,8 @@ function isSubsequence(sub: string[], full: string[]): boolean {
 }
 
 export function classifyKeyMutation(prev: string[], next: string[]): MutationType {
-  const prevMsgs = prev.filter((key) => key.startsWith('msg:'));
-  const nextMsgs = next.filter((key) => key.startsWith('msg:'));
+  const prevMsgs = prev.filter((key) => key.startsWith('grp:'));
+  const nextMsgs = next.filter((key) => key.startsWith('grp:'));
 
   if (arraysEqual(prevMsgs, nextMsgs)) return 'none';
   if (prevMsgs.length === 0 || nextMsgs.length === 0) return 'reset';

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/rowHeightEstimator.test.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/rowHeightEstimator.test.ts
@@ -3,7 +3,7 @@ import type { MessageResponse } from '@/api/messages';
 import type { ChatRow } from './types';
 import { estimateRowHeight } from './rowHeightEstimator';
 
-type MessageChatRow = Extract<ChatRow, { type: 'message' }>;
+type GroupChatRow = Extract<ChatRow, { type: 'group' }>;
 
 function baseMessage(): MessageResponse {
   return {
@@ -22,47 +22,59 @@ function baseMessage(): MessageResponse {
   };
 }
 
-function messageRow(overrides: Partial<MessageChatRow> = {}): MessageChatRow {
+function groupRow(messages: MessageResponse[]): GroupChatRow {
   return {
-    type: 'message',
-    key: 'msg:1',
-    messageId: '1',
-    clientGeneratedId: 'client-1',
+    type: 'group',
+    key: `grp:${messages[0].clientGeneratedId || messages[0].id}`,
+    messages,
+    firstMessageId: messages[0].id,
+    lastMessageId: messages[messages.length - 1].id,
+    isSystem: false,
     showName: true,
-    showAvatar: true,
-    message: baseMessage(),
-    ...overrides,
+    useStickyAvatar: true,
   };
 }
 
 describe('estimateRowHeight', () => {
-  it('uses fixed compact estimates for date and deleted rows', () => {
+  it('uses a fixed estimate for date rows', () => {
     expect(estimateRowHeight({ type: 'date', key: 'date:1', dateLabel: 'Today' }, '14px')).toBe(32);
-    expect(estimateRowHeight(messageRow({ message: { ...baseMessage(), isDeleted: true } }), '14px')).toBe(48);
+  });
+
+  it('estimates a single-message group with a deleted message', () => {
+    expect(estimateRowHeight(groupRow([{ ...baseMessage(), isDeleted: true }]), '14px')).toBe(48);
   });
 
   it('adds reply affordance height to media-heavy estimates', () => {
     const base = estimateRowHeight(
-      messageRow({
-        message: {
+      groupRow([
+        {
           ...baseMessage(),
           attachments: [{ id: 'a1', url: 'u', kind: 'image/png', size: 1, fileName: 'a.png' }],
         },
-      }),
+      ]),
       '14px',
     );
     const withReply = estimateRowHeight(
-      messageRow({
-        message: {
+      groupRow([
+        {
           ...baseMessage(),
           attachments: [{ id: 'a1', url: 'u', kind: 'image/png', size: 1, fileName: 'a.png' }],
           replyToMessage: baseMessage(),
         },
-      }),
+      ]),
       '14px',
     );
 
     expect(base).toBe(220);
     expect(withReply).toBe(246);
+  });
+
+  it('sums the heights of all messages in a multi-message group', () => {
+    // Two deleted messages → 48 + 48 = 96.
+    const row = groupRow([
+      { ...baseMessage(), id: '1', isDeleted: true },
+      { ...baseMessage(), id: '2', isDeleted: true },
+    ]);
+    expect(estimateRowHeight(row, '14px')).toBe(96);
   });
 });

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/rowHeightEstimator.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/rowHeightEstimator.ts
@@ -4,12 +4,11 @@ import {
   getMessageLayoutStats,
   parseChatBubbleContentToRichItems,
 } from '@/utils/chatTextMeasure';
+import type { MessageResponse } from '@/api/messages';
 import type { ChatRow } from './types';
 
-export function estimateRowHeight(row: ChatRow, chatFontSizeStyle: string): number {
-  if (row.type === 'date') return 32;
-
-  const { message } = row;
+/** Estimate the rendered height of a single message's bubble row. */
+function estimateMessageHeight(message: MessageResponse, chatFontSizeStyle: string): number {
   if (message.isDeleted) return 48;
 
   let estimate = message.attachments?.length || message.sticker ? 220 : 76;
@@ -33,4 +32,14 @@ export function estimateRowHeight(row: ChatRow, chatFontSizeStyle: string): numb
   }
 
   return Math.min(estimate, 3000);
+}
+
+export function estimateRowHeight(row: ChatRow, chatFontSizeStyle: string): number {
+  if (row.type === 'date') return 32;
+
+  // Group rows: sum the estimated height of each message in the group. Each
+  // message is its own bubble row inside the SenderGroup, so the group's height
+  // is the sum of its members (plus small inter-bubble margins absorbed by the
+  // per-message estimate).
+  return row.messages.reduce((sum, message) => sum + estimateMessageHeight(message, chatFontSizeStyle), 0);
 }

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/types.ts
@@ -6,16 +6,17 @@ import type { MessageResponse } from '@/api/messages';
 export type ChatRow =
   | { type: 'date'; key: string; dateLabel: string }
   | {
-      type: 'message';
+      type: 'group';
       key: string;
-      messageId: string;
-      clientGeneratedId?: string | null;
-      message: MessageResponse;
+      messages: MessageResponse[];
+      firstMessageId: string;
+      lastMessageId: string;
+      isSystem: boolean;
       showName: boolean;
-      showAvatar: boolean;
+      useStickyAvatar: boolean;
     };
 
-// Legacy compatibility for helper modules that still compile in-tree.
+// Range primitive shared by useCoreManager / useMountedWindow for mounted-window math.
 export interface CoreRange {
   start: number;
   end: number;

--- a/wetty-chat-mobile/src/components/chat/virtualScroll/useChatRows.ts
+++ b/wetty-chat-mobile/src/components/chat/virtualScroll/useChatRows.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { MessageResponse } from '@/api/messages';
+import { isSystemMessage } from '../messages/messageTypePredicates';
 import type { ChatRow } from './types';
-
 function formatDateKey(iso: string): string {
   const date = new Date(iso);
 
@@ -19,10 +19,6 @@ function isSameDate(a: string, b: string): boolean {
   return formatDateKey(a) === formatDateKey(b);
 }
 
-function isSystemMessage(message: MessageResponse): boolean {
-  return message.messageType === 'system';
-}
-
 export function useChatRows(
   messages: MessageResponse[],
   formatDateSeparator: (iso: string) => string,
@@ -30,51 +26,81 @@ export function useChatRows(
 ): ChatRow[] {
   return useMemo(() => {
     const rows: ChatRow[] = [];
+    let i = 0;
     let prevSenderUid: number | string | null = null;
+    let hasDateSeparator = true;
 
-    for (let i = 0; i < messages.length; i++) {
+    while (i < messages.length) {
       const msg = messages[i];
-      const prevMsg = messages[i - 1];
-      const nextMsg = messages[i + 1];
+      const prevMsg = i > 0 ? messages[i - 1] : undefined;
 
       // Date separator: always shown on the first message and on date boundaries.
       // The key must stay stable when older messages are prepended, otherwise
       // staging batches can get stranded waiting on a row that changed identity.
-      const isDateBoundary = prevMsg && !isSameDate(msg.createdAt, prevMsg.createdAt);
-      const isFirstMessage = i === 0;
-      if (isFirstMessage || isDateBoundary) {
+      const isDateBoundary = prevMsg ? !isSameDate(msg.createdAt, prevMsg.createdAt) : false;
+      if (i === 0 || isDateBoundary) {
         rows.push({
           type: 'date',
           key: `date:${formatDateKey(msg.createdAt)}`,
           dateLabel: formatDateSeparator(msg.createdAt),
         });
         prevSenderUid = null;
+        hasDateSeparator = true;
+      } else {
+        hasDateSeparator = false;
       }
 
       const isSystem = isSystemMessage(msg);
-      const nextIsSystem = nextMsg ? isSystemMessage(nextMsg) : false;
 
-      // Grouping
-      const hasDateSeparator = isFirstMessage || isDateBoundary;
-      const showName = !isSystem && (msg.sender.uid !== prevSenderUid || hasDateSeparator);
-      const isLastInGroup =
-        isSystem ||
-        !nextMsg ||
-        nextIsSystem ||
-        nextMsg.sender.uid !== msg.sender.uid ||
-        !isSameDate(msg.createdAt, nextMsg.createdAt);
+      if (isSystem) {
+        // System messages form their own single-message group with no avatar.
+        rows.push({
+          type: 'group',
+          key: `grp:${msg.clientGeneratedId || msg.id}`,
+          messages: [msg],
+          firstMessageId: msg.id,
+          lastMessageId: msg.id,
+          isSystem: true,
+          showName: false,
+          useStickyAvatar: false,
+        });
+        prevSenderUid = null;
+        i += 1;
+        continue;
+      }
+
+      // Gather a consecutive run of same-sender non-system messages within the
+      // same date into one group row. The avatar lives in a sticky container
+      // spanning the whole group, so the group is the atomic virtual-scroll unit.
+      const groupMessages: MessageResponse[] = [msg];
+      let j = i + 1;
+      while (j < messages.length) {
+        const next = messages[j];
+        if (isSystemMessage(next)) break;
+        if (next.sender.uid !== msg.sender.uid) break;
+        if (!isSameDate(msg.createdAt, next.createdAt)) break;
+        groupMessages.push(next);
+        j += 1;
+      }
+
+      const showName = msg.sender.uid !== prevSenderUid || hasDateSeparator;
+      // When showAllAvatars is on, every message renders its own inline avatar
+      // (current behavior), so the group-level sticky avatar is not used.
+      const useStickyAvatar = !showAllAvatars;
 
       rows.push({
-        type: 'message',
-        key: `msg:${msg.clientGeneratedId || msg.id}`,
-        messageId: msg.id,
-        clientGeneratedId: msg.clientGeneratedId ?? null,
-        message: msg,
+        type: 'group',
+        key: `grp:${msg.clientGeneratedId || msg.id}`,
+        messages: groupMessages,
+        firstMessageId: msg.id,
+        lastMessageId: groupMessages[groupMessages.length - 1].id,
+        isSystem: false,
         showName,
-        showAvatar: showAllAvatars || isLastInGroup,
+        useStickyAvatar,
       });
 
-      prevSenderUid = isSystem ? null : msg.sender.uid;
+      prevSenderUid = msg.sender.uid;
+      i = j;
     }
 
     return rows;

--- a/wetty-chat-mobile/src/hooks/useDocumentTitle.ts
+++ b/wetty-chat-mobile/src/hooks/useDocumentTitle.ts
@@ -23,7 +23,7 @@ export function useDocumentTitle(activeChatId: string | undefined, activeThreadI
   const threadUnreadCountRef = useRef(threadUnreadCount);
   const chatsWithUnreadRef = useRef(chatsWithUnread);
   const threadsWithUnreadRef = useRef(threadsWithUnread);
-  const baseTitleRef = useRef(document.title || BASE_TITLE);
+  const baseTitleRef = useRef((document.title || '').replace(/^\(\d+\)\s*/, '') || BASE_TITLE);
 
   function updateTitle() {
     if (isPageHidden()) {

--- a/wetty-chat-mobile/src/pages/conversation/conversation.scss
+++ b/wetty-chat-mobile/src/pages/conversation/conversation.scss
@@ -62,11 +62,11 @@
   ion-fab-button {
     width: 48px;
     height: 48px;
-    --background: var(--ion-item-background, var(--ion-background-color));
-    --background-activated: var(--ion-color-light-shade, #d7d8da);
-    --background-hover: var(--ion-color-light, #f4f5f8);
+    --background: var(--ion-background-color-step-100, #f4f5f8);
+    --background-activated: var(--ion-background-color-step-300, #d7d8da);
+    --background-hover: var(--ion-background-color-step-200, #e0e0e0);
     --box-shadow: 0 3px 10px rgba(0, 0, 0, 0.18);
-    --color: var(--ion-color-medium, #92949c);
+    --color: color-mix(in srgb, var(--ion-color-medium, #636469) 60%, var(--ion-text-color, #000) 40%);
 
     &:active::part(native) {
       transform: scale(0.94);

--- a/wetty-chat-mobile/src/pages/conversation/conversation.scss
+++ b/wetty-chat-mobile/src/pages/conversation/conversation.scss
@@ -168,25 +168,6 @@
   margin-bottom: 6px;
 }
 
-/* Avatar */
-.message-avatar {
-  width: 36px;
-  flex-shrink: 0;
-  margin-right: 6px;
-}
-
-.message-avatar-img {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  object-fit: cover;
-}
-
-.message-avatar-spacer {
-  width: 32px;
-  height: 32px;
-}
-
 /* Bubble wrap */
 .message-bubble-wrap {
   display: flex;

--- a/wetty-chat-mobile/src/pages/conversation/manage-invites.tsx
+++ b/wetty-chat-mobile/src/pages/conversation/manage-invites.tsx
@@ -28,6 +28,7 @@ import { selectEffectiveLocale } from '@/store/settingsSlice';
 import type { RootState } from '@/store';
 import { createClientGeneratedId } from '@/utils/clientGeneratedId';
 import type { BackAction } from '@/types/back-action';
+import { useIsDesktop } from '@/hooks/platformHooks';
 import styles from './manage-invites.module.scss';
 
 interface ChatInvitesCoreProps {
@@ -253,6 +254,7 @@ function ChatInvitesContent({
 }
 
 export default function ChatInvitesCore({ chatId: propChatId, backAction }: ChatInvitesCoreProps) {
+  const isDesktop = useIsDesktop();
   const { id } = useParams<{ id: string }>();
   const chatId = propChatId ?? (id ? String(id) : '');
   const locale = useSelector(selectEffectiveLocale);
@@ -470,7 +472,7 @@ export default function ChatInvitesCore({ chatId: propChatId, backAction }: Chat
         />
         <ShareInviteGroupSelectorModal
           isOpen={selectorOpen}
-          isDesktop={false}
+          isDesktop={isDesktop}
           scope="joined"
           onDismiss={closeSelector}
           onSelect={(group) => void handleShareSelect(group)}

--- a/wetty-chat-mobile/src/test/domSetup.ts
+++ b/wetty-chat-mobile/src/test/domSetup.ts
@@ -30,7 +30,7 @@ afterEach(() => {
     }
   });
   cacheStores.clear();
-  localStorage.clear();
-  sessionStorage.clear();
+  if (typeof localStorage !== 'undefined' && localStorage) localStorage.clear();
+  if (typeof sessionStorage !== 'undefined' && sessionStorage) sessionStorage.clear();
   vi.clearAllMocks();
 });


### PR DESCRIPTION
Enhancements:
- Improved the swipe-to-reply animation to indicate the release threshold.
- Pinned user avatars to the bottom of consecutive message groups for better context.

Fixes:
- Fixed thread count divider on media-only bubbles.
- Corrected "Scroll to Bottom" button color and opacity.
- Prevented sticker timestamps from briefly showing in the wrong place during load (Needs verification).
- Ensured desktop modals are centered rather than using mobile popup layouts.
- Aligned group invite cards correctly in the message context menu.
- Added right margin to the emoji reaction "+n" indicator to fix cramped spacing.
- Fixed glitchy duplicate title badges (e.g., (3)(2)茶话) caused by network issues.