### PR TITLE
fix(pwa): show specific toast for unjoined group on permalink

### DIFF
--- a/wetty-chat-mobile/locales/en/messages.po
+++ b/wetty-chat-mobile/locales/en/messages.po
@@ -1324,6 +1324,9 @@ msgstr "You can only upload up to {maxAttachments} media files at once."
 msgid "You have unsaved group detail changes. Leave without saving?"
 msgstr "You have unsaved group detail changes. Leave without saving?"
 
+msgid "You haven't joined this group"
+msgstr "You haven't joined this group"
+
 msgid "You’ve been invited"
 msgstr "You’ve been invited"
 

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -1325,7 +1325,7 @@ msgid "You have unsaved group detail changes. Leave without saving?"
 msgstr "你有未保存的群组资料更改。要不保存就离开吗？"
 
 msgid "You haven't joined this group"
-msgstr ""
+msgstr "你还没有加入这个群组"
 
 msgid "You’ve been invited"
 msgstr "你已收到邀请"

--- a/wetty-chat-mobile/locales/zh-CN/messages.po
+++ b/wetty-chat-mobile/locales/zh-CN/messages.po
@@ -1324,6 +1324,9 @@ msgstr "你一次最多只能上传 {maxAttachments} 个媒体文件。"
 msgid "You have unsaved group detail changes. Leave without saving?"
 msgstr "你有未保存的群组资料更改。要不保存就离开吗？"
 
+msgid "You haven't joined this group"
+msgstr ""
+
 msgid "You’ve been invited"
 msgstr "你已收到邀请"
 

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -1325,7 +1325,7 @@ msgid "You have unsaved group detail changes. Leave without saving?"
 msgstr "你有尚未儲存的群組資料變更。要不儲存就離開嗎？"
 
 msgid "You haven't joined this group"
-msgstr ""
+msgstr "你還沒有加入這個群組"
 
 msgid "You’ve been invited"
 msgstr "你已收到邀請"

--- a/wetty-chat-mobile/locales/zh-TW/messages.po
+++ b/wetty-chat-mobile/locales/zh-TW/messages.po
@@ -1324,6 +1324,9 @@ msgstr "你一次最多只能上傳 {maxAttachments} 個媒體檔案。"
 msgid "You have unsaved group detail changes. Leave without saving?"
 msgstr "你有尚未儲存的群組資料變更。要不儲存就離開嗎？"
 
+msgid "You haven't joined this group"
+msgstr ""
+
 msgid "You’ve been invited"
 msgstr "你已收到邀請"
 

--- a/wetty-chat-mobile/src/pages/permalink.tsx
+++ b/wetty-chat-mobile/src/pages/permalink.tsx
@@ -45,13 +45,16 @@ export default function PermalinkPage({ encoded }: PermalinkPageProps) {
           status: err?.response?.status,
           err,
         });
+        const status = err?.response?.status;
         // 401 is handled by the axios interceptor (auth redirect)
-        if (err?.response?.status !== 401) {
-          presentToast({
-            message: err?.response?.status === 404 ? t`Message not found` : t`Failed to open link`,
-            duration: 2000,
-            color: 'danger',
-          });
+        if (status !== 401) {
+          const message =
+            status === 404
+              ? t`Message not found`
+              : status === 403
+                ? t`You haven't joined this group`
+                : t`Failed to open link`;
+          presentToast({ message, duration: 2000, color: 'danger' });
           navigateToNotificationTarget('/chats');
         }
       });


### PR DESCRIPTION
When a user opens a message permalink for a group they haven't joined, the backend returns HTTP 403. PermalinkPage previously lumped this into the generic "Failed to open link" error. Show a user-friendly "You haven't joined this group" message for 403 responses instead.

401 (axios interceptor), 404 (Message not found), and other errors keep their existing behavior.

## Summary

Backend returns HTTP 403 when a user opens a message permalink for a group they haven't joined. Previously, `PermalinkPage` showed the generic "Failed to open link" error. This change shows a user-friendly "You haven't joined this group" message instead.

## Changes

- Added a 403 error branch in `src/pages/permalink.tsx`.
- Added the new Lingui translation string.

## Behavior preserved

- 401 → handled by axios interceptor.
- 404 → "Message not found".
- Other errors → "Failed to open link".

## Verification

`npm run verify` passes.